### PR TITLE
fixes #48 tcp sometimes fails to get a port

### DIFF
--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -418,11 +418,9 @@ nni_sock_sys_fini(void)
 int
 nni_sock_open(nni_sock **sockp, const nni_proto *proto)
 {
-	nni_sock *          sock;
-	int                 rv;
-	nni_proto_sock_ops *sops;
-	nni_proto_pipe_ops *pops;
-	uint32_t            sockid;
+	nni_sock *sock;
+	int       rv;
+	uint32_t  sockid;
 
 	if (proto->proto_version != NNI_PROTOCOL_VERSION) {
 		// unsupported protocol version
@@ -445,7 +443,6 @@ nni_sock_open(nni_sock **sockp, const nni_proto *proto)
 	sock->s_sock_ops = *proto->proto_sock_ops;
 	sock->s_pipe_ops = *proto->proto_pipe_ops;
 
-	sops = &sock->s_sock_ops;
 	NNI_ASSERT(sock->s_sock_ops.sock_open != NULL);
 	NNI_ASSERT(sock->s_sock_ops.sock_close != NULL);
 
@@ -457,7 +454,7 @@ nni_sock_open(nni_sock **sockp, const nni_proto *proto)
 		return (rv);
 	}
 
-	sops->sock_open(sock->s_data);
+	sock->s_sock_ops.sock_open(sock->s_data);
 
 	nni_mtx_lock(&nni_sock_lk);
 	nni_list_append(&nni_sock_list, sock);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -46,9 +46,9 @@ if (NNG_TESTS)
             target_link_libraries (${NAME} "${CMAKE_THREAD_LIBS_INIT}")
         endif()
 
-        add_test (NAME ${NAME} COMMAND ${NAME} -v ${TEST_PORT})
+        add_test (NAME ${NAME} COMMAND ${NAME} -v -p TEST_PORT=${TEST_PORT})
         set_tests_properties (${NAME} PROPERTIES TIMEOUT ${TIMEOUT})
-        math (EXPR TEST_PORT "${TEST_PORT}+10")
+        math (EXPR TEST_PORT "${TEST_PORT}+20")
     endmacro (add_nng_test)
 
     macro (add_nng_compat_test NAME TIMEOUT)

--- a/tests/convey.c
+++ b/tests/convey.c
@@ -1098,6 +1098,7 @@ conveyMain(int argc, char **argv)
 		break;
 	}
 
+	convey_read_timer(&pc, &secs, &usecs);
 	(void) printf("%-8s%-52s%4d.%03ds\n", status, prog, secs, usecs / 1000);
 	while ((env = convey_environment) != NULL) {
 		convey_environment = env->next;

--- a/tests/convey.h
+++ b/tests/convey.h
@@ -80,6 +80,8 @@ extern int conveyStart(conveyScope *, const char *);
 extern int conveyLoop(conveyScope *, int);
 extern void conveyFinish(conveyScope *, int *);
 extern int conveyMain(int, char **);
+extern char *conveyGetEnv(const char *);
+extern int conveyPutEnv(const char *, char *);
 
 extern void conveyAssertPass(const char *, const char *, int);
 extern void conveyAssertSkip(const char *, const char *, int);
@@ -167,6 +169,17 @@ extern void conveyPrintf(const char *, int, const char *, ...);
 		return (conveyMain(argc, argv));			\
 	}
 
+/*
+ * ConveyGetEnv is used to get environment variables, which can be
+ * overridden with -p <name>=<value> on the command line.
+ */
+#define ConveyGetEnv(name) conveyGetEnv(name)
+
+/*
+ * ConveyPutEnv is used to change environment variables.  This is not
+ * thread safe! 
+ */
+#define ConveyPutEnv(name, value) conveyPutEnv(name, value)
 /*
  * ConveyTest creates a top-level test instance, which can contain multiple
  * Convey blocks.

--- a/tests/inproc.c
+++ b/tests/inproc.c
@@ -1,5 +1,6 @@
 //
-// Copyright 2016 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -14,6 +15,6 @@
 // Inproc tests.
 
 TestMain("Inproc Transport", {
-	trantest_test_all("inproc://TEST");
+	trantest_test_all("inproc://TEST_%u");
 	nni_fini();
 })

--- a/tests/ipc.c
+++ b/tests/ipc.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -10,11 +11,10 @@
 #include "convey.h"
 #include "trantest.h"
 
-
 // Inproc tests.
 
 TestMain("IPC Transport", {
-	trantest_test_all("ipc:///tmp/nng_ipc_test");
+	trantest_test_all("ipc:///tmp/nng_ipc_test_%u");
 
 	nng_fini();
 })

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -14,29 +15,34 @@
 
 TestMain("TCP Transport", {
 
-	trantest_test_all("tcp://127.0.0.1:4450");
+	trantest_test_all("tcp://127.0.0.1:%u");
 
 	Convey("We cannot connect to wild cards", {
 		nng_socket s;
+		char       addr[NNG_MAXADDRLEN];
 
 		So(nng_pair_open(&s) == 0);
 		Reset({ nng_close(s); });
-		So(nng_dial(s, "tcp://*:5555", NULL, NNG_FLAG_SYNCH) ==
-		    NNG_EADDRINVAL);
+		trantest_next_address(addr, "tcp://*:%u");
+		So(nng_dial(s, addr, NULL, NNG_FLAG_SYNCH) == NNG_EADDRINVAL);
 	});
 
 	Convey("We can bind to wild card", {
 		nng_socket s1;
 		nng_socket s2;
+		char       addr[NNG_MAXADDRLEN];
+
 		So(nng_pair_open(&s1) == 0);
 		So(nng_pair_open(&s2) == 0);
 		Reset({
 			nng_close(s2);
 			nng_close(s1);
 		});
-		So(nng_listen(s1, "tcp://*:5771", NULL, NNG_FLAG_SYNCH) == 0);
-		So(nng_dial(
-		       s2, "tcp://127.0.0.1:5771", NULL, NNG_FLAG_SYNCH) == 0);
+		trantest_next_address(addr, "tcp://*:%u");
+		So(nng_listen(s1, addr, NULL, NNG_FLAG_SYNCH) == 0);
+		// reset port back one
+		trantest_prev_address(addr, "tcp://127.0.0.1:%u");
+		So(nng_dial(s2, addr, NULL, NNG_FLAG_SYNCH) == 0);
 	});
 
 	nng_fini();

--- a/tests/trantest.h
+++ b/tests/trantest.h
@@ -11,6 +11,7 @@
 #include "convey.h"
 #include "core/nng_impl.h"
 #include "nng.h"
+#include <stdlib.h>
 #include <string.h>
 
 // Transport common tests.  By making a common test framework for transports,
@@ -25,10 +26,34 @@ typedef struct {
 	nni_tran * tran;
 } trantest;
 
+unsigned trantest_port = 0;
+
+void
+trantest_next_address(char *out, const char *template)
+{
+	if (trantest_port == 0) {
+		char *pstr;
+		trantest_port = 5555;
+		if (((pstr = ConveyGetEnv("TEST_PORT")) != NULL) &&
+		    (atoi(pstr) != 0)) {
+			trantest_port = atoi(pstr);
+		}
+	}
+	(void) snprintf(out, NNG_MAXADDRLEN, template, trantest_port);
+	trantest_port++;
+}
+
+void
+trantest_prev_address(char *out, const char *template)
+{
+	trantest_port--;
+	trantest_next_address(out, template);
+}
+
 void
 trantest_init(trantest *tt, const char *addr)
 {
-	(void) snprintf(tt->addr, sizeof(tt->addr), "%s", addr);
+	trantest_next_address(tt->addr, addr);
 	So(nng_req_open(&tt->reqsock) == 0);
 	So(nng_rep_open(&tt->repsock) == 0);
 


### PR DESCRIPTION
This arranges for port numbers (and also btw IPC paths) to be dynamically incremented both during multi-test executable runs, and across executables.  It should eliminate all the TCP listen failures.