### PR TITLE
Thundering herd kills performance.

### DIFF
--- a/perf/perf.c
+++ b/perf/perf.c
@@ -219,13 +219,15 @@ do_inproc_lat(int argc, char **argv)
 	ia.count   = parse_int(argv[1], "count");
 	ia.func    = latency_server;
 
-	// Sleep a bit.
-	nng_usleep(100000);
 
 	if ((rv = nni_thr_init(&thr, do_inproc, &ia)) != 0) {
 		die("Cannot create thread: %s", nng_strerror(rv));
 	}
 	nni_thr_run(&thr);
+
+	// Sleep a bit.
+	nng_usleep(100000);
+
 	latency_client("inproc://latency_test", ia.msgsize, ia.count);
 	nni_thr_fini(&thr);
 }

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -34,7 +34,8 @@ struct nni_aio {
 	unsigned a_pend : 1;     // completion routine pending
 	unsigned a_active : 1;   // aio was started
 	unsigned a_expiring : 1; // expiration callback in progress
-	unsigned a_pad : 27;     // ensure 32-bit alignment
+	unsigned a_waiting : 1;  // a thread is waiting for this to finish
+	unsigned a_pad : 26;     // ensure 32-bit alignment
 	nni_task a_task;
 
 	// Read/write operations.

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -121,6 +122,10 @@ extern void nni_plat_cv_fini(nni_plat_cv *);
 // nni_plat_cv_wake wakes all waiters on the condition.  This should be
 // called with the lock held.
 extern void nni_plat_cv_wake(nni_plat_cv *);
+
+// nni_plat_cv_wake1 wakes only a single waiter.  Use with caution
+// to avoid losing the wakeup when multiple waiters may be present.
+extern void nni_plat_cv_wake1(nni_plat_cv *);
 
 // nni_plat_cv_wait waits for a wake up on the condition variable.  The
 // associated lock is atomically released and reacquired upon wake up.

--- a/src/core/thread.c
+++ b/src/core/thread.c
@@ -73,6 +73,12 @@ nni_cv_wake(nni_cv *cv)
 	nni_plat_cv_wake(cv);
 }
 
+void
+nni_cv_wake1(nni_cv *cv)
+{
+	nni_plat_cv_wake1(cv);
+}
+
 static void
 nni_thr_wrap(void *arg)
 {

--- a/src/core/thread.h
+++ b/src/core/thread.h
@@ -52,6 +52,9 @@ extern void nni_cv_fini(nni_cv *cv);
 // nni_cv_wake wakes all waiters on the condition variable.
 extern void nni_cv_wake(nni_cv *cv);
 
+// nni_cv_wake wakes just one waiter on the condition variable.
+extern void nni_cv_wake1(nni_cv *cv);
+
 // nni_cv_wait waits until nni_cv_wake is called on the condition variable.
 // The wait is indefinite.  Premature wakeups are possible, so the caller
 // must verify any related condition.

--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -116,11 +117,13 @@ nni_plat_cv_init(nni_plat_cv *cv, nni_plat_mtx *mtx)
 void
 nni_plat_cv_wake(nni_plat_cv *cv)
 {
-	int rv;
+	(void) pthread_cond_broadcast(&cv->cv);
+}
 
-	if ((rv = pthread_cond_broadcast(&cv->cv)) != 0) {
-		nni_panic("pthread_cond_broadcast: %s", strerror(rv));
-	}
+void
+nni_plat_cv_wake1(nni_plat_cv *cv)
+{
+	(void) pthread_cond_signal(&cv->cv);
 }
 
 void

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -67,6 +68,12 @@ void
 nni_plat_cv_wake(nni_plat_cv *cv)
 {
 	WakeAllConditionVariable(&cv->cv);
+}
+
+void
+nni_plat_cv_wake1(nni_plat_cv *cv)
+{
+	WakeConditionVariable(&cv->cv);
 }
 
 void


### PR DESCRIPTION
A little benchmarking showed that we were encountering far too many
wakeups, leading to severe performance degradation; we had a bunch
of threads all sleeping on the same condition variable (taskqs)
and this woke them all up, resulting in heavy mutex contention.

Since we only need one of the threads to wake, and we don't care which
one, let's just wake only one.  This reduced RTT latency from about
240 us down to about 30 s.  (1/8 of the former cost.)

There's still a bunch of tuning to do; performance remains worse than
we would like.