### PR TITLE
Unify the msg API.

### DIFF
--- a/src/core/message.h
+++ b/src/core/message.h
@@ -12,35 +12,38 @@
 #define CORE_MESSAGE_H
 
 // Internally used message API.  Again, this is not part of our public API.
+// "trim" operations work from the front, and "chop" work from the end.
 
 extern int      nni_msg_alloc(nni_msg **, size_t);
 extern void     nni_msg_free(nni_msg *);
 extern int      nni_msg_realloc(nni_msg *, size_t);
 extern int      nni_msg_dup(nni_msg **, const nni_msg *);
 extern void *   nni_msg_header(nni_msg *);
-extern size_t   nni_msg_header_len(nni_msg *);
+extern size_t   nni_msg_header_len(const nni_msg *);
 extern void *   nni_msg_body(nni_msg *);
-extern size_t   nni_msg_len(nni_msg *);
+extern size_t   nni_msg_len(const nni_msg *);
 extern int      nni_msg_append(nni_msg *, const void *, size_t);
-extern int      nni_msg_prepend(nni_msg *, const void *, size_t);
-extern int      nni_msg_append_header(nni_msg *, const void *, size_t);
-extern int      nni_msg_prepend_header(nni_msg *, const void *, size_t);
+extern int      nni_msg_insert(nni_msg *, const void *, size_t);
+extern int      nni_msg_header_append(nni_msg *, const void *, size_t);
+extern int      nni_msg_header_insert(nni_msg *, const void *, size_t);
 extern int      nni_msg_trim(nni_msg *, size_t);
-extern int      nni_msg_trunc(nni_msg *, size_t);
-extern int      nni_msg_trim_header(nni_msg *, size_t);
-extern int      nni_msg_trunc_header(nni_msg *, size_t);
+extern int      nni_msg_chop(nni_msg *, size_t);
+extern void     nni_msg_clear(nni_msg *);
+extern void     nni_msg_header_clear(nni_msg *);
+extern int      nni_msg_header_trim(nni_msg *, size_t);
+extern int      nni_msg_header_chop(nni_msg *, size_t);
 extern int      nni_msg_setopt(nni_msg *, int, const void *, size_t);
 extern int      nni_msg_getopt(nni_msg *, int, void *, size_t *);
 extern void     nni_msg_dump(const char *, const nni_msg *);
 extern int      nni_msg_append_u32(nni_msg *, uint32_t);
-extern int      nni_msg_prepend_u32(nni_msg *, uint32_t);
+extern int      nni_msg_insert_u32(nni_msg *, uint32_t);
 extern int      nni_msg_header_append_u32(nni_msg *, uint32_t);
-extern int      nni_msg_header_prepend_u32(nni_msg *, uint32_t);
+extern int      nni_msg_header_insert_u32(nni_msg *, uint32_t);
 extern uint32_t nni_msg_trim_u32(nni_msg *);
-extern uint32_t nni_msg_trunc_u32(nni_msg *);
+extern uint32_t nni_msg_chop_u32(nni_msg *);
 extern uint32_t nni_msg_header_trim_u32(nni_msg *);
-extern uint32_t nni_msg_header_trunc_u32(nni_msg *);
+extern uint32_t nni_msg_header_chop_u32(nni_msg *);
 extern void     nni_msg_set_pipe(nni_msg *, uint32_t);
-extern uint32_t nni_msg_get_pipe(nni_msg *);
+extern uint32_t nni_msg_get_pipe(const nni_msg *);
 
 #endif // CORE_SOCKET_H

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -411,7 +411,6 @@ nni_sock_open(nni_sock **sockp, const nni_proto *proto)
 {
 	nni_sock *s = NULL;
 	int       rv;
-	uint32_t  sockid;
 
 	if (proto->proto_version != NNI_PROTOCOL_VERSION) {
 		// unsupported protocol version
@@ -603,7 +602,6 @@ void
 nni_sock_closeall(void)
 {
 	nni_sock *s;
-	uint32_t  id;
 
 	for (;;) {
 		nni_mtx_lock(&nni_sock_lk);

--- a/src/nng.c
+++ b/src/nng.c
@@ -486,7 +486,7 @@ nng_msg_body(nng_msg *msg)
 }
 
 size_t
-nng_msg_len(nng_msg *msg)
+nng_msg_len(const nng_msg *msg)
 {
 	return (nni_msg_len(msg));
 }
@@ -498,7 +498,7 @@ nng_msg_header(nng_msg *msg)
 }
 
 size_t
-nng_msg_header_len(nng_msg *msg)
+nng_msg_header_len(const nng_msg *msg)
 {
 	return (nni_msg_header_len(msg));
 }
@@ -510,21 +510,21 @@ nng_msg_append(nng_msg *msg, const void *data, size_t sz)
 }
 
 int
-nng_msg_prepend(nng_msg *msg, const void *data, size_t sz)
+nng_msg_insert(nng_msg *msg, const void *data, size_t sz)
 {
-	return (nni_msg_prepend(msg, data, sz));
+	return (nni_msg_insert(msg, data, sz));
 }
 
 int
-nng_msg_append_header(nng_msg *msg, const void *data, size_t sz)
+nng_msg_header_append(nng_msg *msg, const void *data, size_t sz)
 {
-	return (nni_msg_append_header(msg, data, sz));
+	return (nni_msg_header_append(msg, data, sz));
 }
 
 int
-nng_msg_prepend_header(nng_msg *msg, const void *data, size_t sz)
+nng_msg_header_insert(nng_msg *msg, const void *data, size_t sz)
 {
-	return (nni_msg_prepend_header(msg, data, sz));
+	return (nni_msg_header_insert(msg, data, sz));
 }
 
 int
@@ -534,21 +534,51 @@ nng_msg_trim(nng_msg *msg, size_t sz)
 }
 
 int
-nng_msg_trunc(nng_msg *msg, size_t sz)
+nng_msg_chop(nng_msg *msg, size_t sz)
 {
-	return (nni_msg_trunc(msg, sz));
+	return (nni_msg_chop(msg, sz));
 }
 
 int
-nng_msg_trim_header(nng_msg *msg, size_t sz)
+nng_msg_header_trim(nng_msg *msg, size_t sz)
 {
-	return (nni_msg_trim_header(msg, sz));
+	return (nni_msg_header_trim(msg, sz));
 }
 
 int
-nng_msg_trunc_header(nng_msg *msg, size_t sz)
+nng_msg_header_chop(nng_msg *msg, size_t sz)
 {
-	return (nni_msg_trunc_header(msg, sz));
+	return (nni_msg_header_chop(msg, sz));
+}
+
+void
+nng_msg_clear(nng_msg *msg)
+{
+	nni_msg_clear(msg);
+}
+
+void
+nng_msg_header_clear(nng_msg *msg)
+{
+	nni_msg_header_clear(msg);
+}
+
+int
+nng_msg_dup(nng_msg **dup, const nng_msg *src)
+{
+	return (nni_msg_dup(dup, src));
+}
+
+nng_pipe
+nng_msg_get_pipe(const nng_msg *msg)
+{
+	return (nni_msg_get_pipe(msg));
+}
+
+void
+nng_msg_set_pipe(nng_msg *msg, nng_pipe p)
+{
+	nni_msg_set_pipe(msg, p);
 }
 
 int

--- a/src/nng.h
+++ b/src/nng.h
@@ -252,18 +252,23 @@ NNG_DECL int   nng_msg_alloc(nng_msg **, size_t);
 NNG_DECL void  nng_msg_free(nng_msg *);
 NNG_DECL int   nng_msg_realloc(nng_msg *, size_t);
 NNG_DECL void *nng_msg_header(nng_msg *);
-NNG_DECL size_t nng_msg_header_len(nng_msg *);
+NNG_DECL size_t nng_msg_header_len(const nng_msg *);
 NNG_DECL void * nng_msg_body(nng_msg *);
-NNG_DECL size_t nng_msg_len(nng_msg *);
+NNG_DECL size_t nng_msg_len(const nng_msg *);
 NNG_DECL int    nng_msg_append(nng_msg *, const void *, size_t);
-NNG_DECL int    nng_msg_prepend(nng_msg *, const void *, size_t);
+NNG_DECL int    nng_msg_insert(nng_msg *, const void *, size_t);
 NNG_DECL int    nng_msg_trim(nng_msg *, size_t);
-NNG_DECL int    nng_msg_trunc(nng_msg *, size_t);
-NNG_DECL int    nng_msg_append_header(nng_msg *, const void *, size_t);
-NNG_DECL int    nng_msg_prepend_header(nng_msg *, const void *, size_t);
-NNG_DECL int    nng_msg_trim_header(nng_msg *, size_t);
-NNG_DECL int    nng_msg_trunc_header(nng_msg *, size_t);
-NNG_DECL int    nng_msg_getopt(nng_msg *, int, void *, size_t *);
+NNG_DECL int    nng_msg_chop(nng_msg *, size_t);
+NNG_DECL int    nng_msg_header_append(nng_msg *, const void *, size_t);
+NNG_DECL int    nng_msg_header_insert(nng_msg *, const void *, size_t);
+NNG_DECL int    nng_msg_header_trim(nng_msg *, size_t);
+NNG_DECL int    nng_msg_header_chop(nng_msg *, size_t);
+NNG_DECL int    nng_msg_dup(nng_msg **, const nng_msg *);
+NNG_DECL void   nng_msg_clear(nng_msg *);
+NNG_DECL void   nng_msg_header_clear(nng_msg *);
+NNG_DECL void   nng_msg_set_pipe(nng_msg *, nng_pipe);
+NNG_DECL nng_pipe nng_msg_get_pipe(const nng_msg *);
+NNG_DECL int      nng_msg_getopt(nng_msg *, int, void *, size_t *);
 
 // Pipe API. Generally pipes are only "observable" to applications, but
 // we do permit an application to close a pipe. This can be useful, for

--- a/src/nng_compat.c
+++ b/src/nng_compat.c
@@ -345,7 +345,7 @@ nn_recvmsg(int s, struct nn_msghdr *mh, int flags)
 	if ((mh->msg_iovlen == 1) && (mh->msg_iov[0].iov_len == NN_MSG)) {
 		// Receiver wants to have a dynamically allocated message.
 		// There can only be one of these.
-		if ((rv = nng_msg_prepend(msg, &msg, sizeof(msg))) != 0) {
+		if ((rv = nng_msg_insert(msg, &msg, sizeof(msg))) != 0) {
 			nng_msg_free(msg);
 			nn_seterror(rv);
 			return (-1);
@@ -534,7 +534,7 @@ nn_sendmsg(int s, const struct nn_msghdr *mh, int flags)
 				continue;
 			}
 			data += sizeof(spsz);
-			rv = nng_msg_append_header(msg, data, spsz);
+			rv = nng_msg_header_append(msg, data, spsz);
 			if (rv != 0) {
 				if (!keep) {
 					nng_msg_free(msg);

--- a/src/protocol/pair/pair_v1.c
+++ b/src/protocol/pair/pair_v1.c
@@ -224,7 +224,7 @@ pair1_pipe_recv_cb(void *arg)
 
 	// If we bounced too many times, discard the message, but
 	// keep getting more.
-	if (hdr >= s->ttl) {
+	if (hdr >= (unsigned) s->ttl) {
 		nni_msg_free(msg);
 		nni_pipe_recv(npipe, &p->aio_recv);
 		return;
@@ -309,7 +309,6 @@ pair1_pipe_getq_cb(void *arg)
 	pair1_sock *s = p->psock;
 	nni_msg *   msg;
 	uint32_t    hops;
-	uint8_t *   data;
 
 	if (nni_aio_result(&p->aio_getq) != 0) {
 		nni_pipe_stop(p->npipe);

--- a/src/protocol/reqrep/req.c
+++ b/src/protocol/reqrep/req.c
@@ -437,17 +437,14 @@ nni_req_recv_cb(void *arg)
 		// Malformed message.
 		goto malformed;
 	}
-	if (nni_msg_append_header(msg, nni_msg_body(msg), 4) != 0) {
+	if (nni_msg_header_append(msg, nni_msg_body(msg), 4) != 0) {
 		// Arguably we could just discard and carry on.  But
 		// dropping the connection is probably more helpful since
 		// it lets the other side see that a problem occurred.
 		// Plus it gives us a chance to reclaim some memory.
 		goto malformed;
 	}
-	if (nni_msg_trim(msg, 4) != 0) {
-		// This should never happen - could be an assert.
-		nni_panic("Failed to trim REQ header from body");
-	}
+	(void) nni_msg_trim(msg, 4); // Cannot fail
 
 	rp->aio_putq.a_msg = msg;
 	nni_msgq_aio_put(rp->req->urq, &rp->aio_putq);
@@ -548,7 +545,7 @@ nni_req_sock_sfilter(void *arg, nni_msg *msg)
 	// Request ID is in big endian format.
 	NNI_PUT32(req->reqid, id);
 
-	if (nni_msg_append_header(msg, req->reqid, 4) != 0) {
+	if (nni_msg_header_append(msg, req->reqid, 4) != 0) {
 		// Should be ENOMEM.
 		nni_msg_free(msg);
 		return (NULL);

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -159,11 +159,11 @@ nni_inproc_pipe_send(void *arg, nni_aio *aio)
 	// side won't know what to do otherwise.
 	h = nni_msg_header(msg);
 	l = nni_msg_header_len(msg);
-	if ((rv = nni_msg_prepend(msg, h, l)) != 0) {
+	if ((rv = nni_msg_insert(msg, h, l)) != 0) {
 		nni_aio_finish(aio, rv, aio->a_count);
 		return;
 	}
-	nni_msg_trunc_header(msg, l);
+	nni_msg_header_chop(msg, l);
 	nni_msgq_aio_put(pipe->wq, aio);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,7 +87,7 @@ add_nng_test(sock 5)
 add_nng_test(survey 5)
 add_nng_test(tcp 5)
 add_nng_test(scalability 20)
-add_nng_test(device 5)
+add_nng_test(message 5)
 
 # compatbility tests
 add_nng_compat_test(compat_block 5)

--- a/tests/message.c
+++ b/tests/message.c
@@ -1,0 +1,186 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "convey.h"
+#include "nng.h"
+
+#include <string.h>
+
+TestMain("Message Tests", {
+	int      rv;
+	nng_msg *msg;
+
+	Convey("Given an empty message", {
+
+		So(nng_msg_alloc(&msg, 0) == 0);
+
+		Reset({ nng_msg_free(msg); });
+
+		Convey("Lengths are empty", {
+			So(nng_msg_len(msg) == 0);
+			So(nng_msg_header_len(msg) == 0);
+		});
+
+		Convey("We can append to the header", {
+			So(nng_msg_header_append(msg, "pad", 4) == 0);
+			So(nng_msg_header_len(msg) == 4);
+			So(strcmp(nng_msg_header(msg), "pad") == 0);
+		});
+
+		Convey("We can append to the body", {
+			So(nng_msg_append(msg, "123", 4) == 0);
+			So(nng_msg_len(msg) == 4);
+			So(strcmp(nng_msg_body(msg), "123") == 0);
+		});
+
+		Convey("We can insert to the header", {
+			So(nng_msg_header_append(msg, "def", 4) == 0);
+			So(nng_msg_header_insert(msg, "abc", 3) == 0);
+			So(nng_msg_header_len(msg) == 7);
+			So(strcmp(nng_msg_header(msg), "abcdef") == 0);
+
+			Convey("We can delete from the front", {
+				So(nng_msg_header_trim(msg, 2) == 0);
+				So(nng_msg_header_len(msg) == 5);
+				So(strcmp(nng_msg_header(msg), "cdef") == 0);
+			});
+
+			Convey("We can delete from the back", {
+				So(nng_msg_header_chop(msg, 5) == 0);
+				So(nng_msg_header_len(msg) == 2);
+				So(memcmp(nng_msg_header(msg), "ab", 2) == 0);
+			});
+		});
+
+		Convey("We can insert to the body", {
+			So(nng_msg_append(msg, "xyz", 4) == 0);
+			So(nng_msg_insert(msg, "uvw", 3) == 0);
+			So(nng_msg_len(msg) == 7);
+			So(strcmp(nng_msg_body(msg), "uvwxyz") == 0);
+
+			Convey("We can delete from the front", {
+				So(nng_msg_trim(msg, 2) == 0);
+				So(nng_msg_len(msg) == 5);
+				So(strcmp(nng_msg_body(msg), "wxyz") == 0);
+			});
+
+			Convey("We can delete from the back", {
+				So(nng_msg_chop(msg, 5) == 0);
+				So(nng_msg_len(msg) == 2);
+				So(memcmp(nng_msg_body(msg), "uv", 2) == 0);
+			});
+		});
+
+		Convey("Clearing the header works", {
+			So(nng_msg_header_append(msg, "bogus", 6) == 0);
+			So(nng_msg_header_len(msg) == 6);
+			nng_msg_header_clear(msg);
+			So(nng_msg_header_len(msg) == 0);
+		});
+
+		Convey("Clearing the body works", {
+			So(nng_msg_append(msg, "bogus", 6) == 0);
+			So(nng_msg_len(msg) == 6);
+			nng_msg_clear(msg);
+			So(nng_msg_len(msg) == 0);
+		});
+
+		Convey("We cannot delete more header than exists", {
+			So(nng_msg_header_append(
+			       msg, "short", strlen("short") + 1) == 0);
+			So(nng_msg_header_trim(msg, 16) == NNG_EINVAL);
+			So(nng_msg_header_len(msg) == strlen("short") + 1);
+			So(nng_msg_header_chop(msg, 16) == NNG_EINVAL);
+			So(nng_msg_header_len(msg) == strlen("short") + 1);
+			So(strcmp(nng_msg_header(msg), "short") == 0);
+		});
+
+		Convey("We cannot delete more body than exists", {
+			So(nng_msg_append(msg, "short", strlen("short") + 1) ==
+			    0);
+			So(nng_msg_trim(msg, 16) == NNG_EINVAL);
+			So(nng_msg_len(msg) == strlen("short") + 1);
+			So(nng_msg_chop(msg, 16) == NNG_EINVAL);
+			So(nng_msg_len(msg) == strlen("short") + 1);
+			So(strcmp(nng_msg_body(msg), "short") == 0);
+		});
+
+		Convey("Pipe retrievals work", {
+			So(nng_msg_get_pipe(msg) == 0);
+			nng_msg_set_pipe(msg, (nng_pipe) 45);
+			So(nng_msg_get_pipe(msg) == (nng_pipe) 45);
+		});
+
+		Convey("Message realloc works", {
+			So(nng_msg_append(msg, "abc", 4) == 0);
+			So(nng_msg_realloc(msg, 1500) == 0);
+			So(nng_msg_len(msg) == 1500);
+			So(strcmp(nng_msg_body(msg), "abc") == 0);
+			So(nng_msg_realloc(msg, 2) == 0);
+			So(nng_msg_len(msg) == 2);
+			So(memcmp(nng_msg_body(msg), "abc", 2) == 0);
+			So(nng_msg_append(msg, "CDEF", strlen("CDEF") + 1) ==
+			    0);
+			So(nng_msg_len(msg) == strlen("abCDEF") + 1);
+			So(strcmp(nng_msg_body(msg), "abCDEF") == 0);
+		});
+
+		Convey("Inserting a lot of data works", {
+			char chunk[1024];
+			memset(chunk, '+', sizeof(chunk));
+			So(nng_msg_append(msg, "abc", strlen("abc") + 1) == 0);
+			So(nng_msg_len(msg) == strlen("abc") + 1);
+			So(nng_msg_insert(msg, chunk, sizeof(chunk)) == 0);
+			So(nng_msg_len(msg) ==
+			    strlen("abc") + 1 + sizeof(chunk));
+			So(memcmp(chunk, nng_msg_body(msg), sizeof(chunk)) ==
+			    0);
+			So(strcmp((char *) nng_msg_body(msg) + sizeof(chunk),
+			       "abc") == 0);
+			So(nng_msg_trim(msg, sizeof(chunk) - 2) == 0);
+			So(strcmp(nng_msg_body(msg), "++abc") == 0);
+		});
+
+		Convey("Message dup works", {
+			nng_msg *m2;
+
+			So(nng_msg_header_append(
+			       msg, "front", strlen("front") + 1) == 0);
+			So(nng_msg_append(msg, "back", strlen("back") + 1) ==
+			    0);
+
+			So(nng_msg_dup(&m2, msg) == 0);
+			Reset({ nng_msg_free(m2); });
+
+			So(nng_msg_len(msg) == strlen("front"));
+			So(nng_msg_len(m2) == strlen("front"));
+			So(nng_msg_header_len(msg) == nng_msg_header_len(m2));
+
+			So(nng_msg_insert(msg, "way", 3) == 0);
+			So(nng_msg_len(msg) == strlen("wayback") + 1);
+			So(nng_msg_len(m2) == strlen("back") + 1);
+			So(strcmp(nng_msg_body(msg), "wayback") == 0);
+			So(strcmp(nng_msg_body(m2), "back") == 0);
+			So(nng_msg_chop(m2, 1) == 0);
+			So(nng_msg_append(
+			       m2, "2basics", strlen("2basics") + 1) == 0);
+			So(nng_msg_len(msg) == strlen("wayback") + 1);
+			So(strcmp(nng_msg_body(msg), "wayback") == 0);
+			So(nng_msg_len(m2) == strlen("back2basics") + 1);
+			So(strcmp(nng_msg_body(m2), "back2basics") == 0);
+		});
+
+		Convey("Missing option fails properly", {
+			char   buf[128];
+			size_t sz = sizeof(buf);
+			So(nng_msg_getopt(msg, 4545, buf, &sz) == NNG_ENOENT);
+		});
+	});
+});

--- a/tests/survey.c
+++ b/tests/survey.c
@@ -123,7 +123,7 @@ Main({
 				        msg = NULL;
 				        So(nng_recvmsg(resp, &msg, 0) == 0);
 				        CHECKSTR(msg, "abc");
-				        nng_msg_trunc(msg, 3);
+				        nng_msg_chop(msg, 3);
 				        APPENDSTR(msg, "def");
 				        So(nng_sendmsg(resp, msg, 0) == 0);
 				        msg = NULL;


### PR DESCRIPTION
This makes the operations that work on headers start with
nni_msg_header or nng_msg_header.  It also renames _trunc to
_chop (same strlen as _trim), and renames prepend to insert.

We add a shorthand for clearing message content, and make
better use of the endian safe 32-bit accessors too.