### PR TITLE
Leaking poll fds.

### DIFF
--- a/src/core/options.c
+++ b/src/core/options.c
@@ -1,5 +1,6 @@
 //
-// Copyright 2016 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -191,7 +192,8 @@ nni_getopt_fd(nni_sock *s, nni_notifyfd *fd, int mask, void *val, size_t *szp)
 		return (NNG_ENOMEM);
 	}
 
-	*szp = sizeof(int);
+	fd->sn_init = 1;
+	*szp        = sizeof(int);
 	memcpy(val, &fd->sn_rfd, sizeof(int));
 	return (0);
 }

--- a/tests/pollfd.c
+++ b/tests/pollfd.c
@@ -56,6 +56,14 @@ TestMain("Poll FDs",
 		        So(nng_getopt(s1, NNG_OPT_RCVFD, &fd, &sz) == 0);
 		        So(fd != INVALID_SOCKET);
 
+		        Convey("And it is always the same fd", {
+			        int fd2;
+			        sz = sizeof(fd2);
+			        So(nng_getopt(s1, NNG_OPT_RCVFD, &fd2, &sz) ==
+			            0);
+			        So(fd2 == fd);
+		        });
+
 		        Convey("And they start non pollable", {
 			        struct pollfd pfd;
 			        pfd.fd      = fd;
@@ -88,6 +96,16 @@ TestMain("Poll FDs",
 		        So(nng_send(s1, "oops", 4, 0) == 0);
 	        });
 
+	        Convey("Must have a big enough size", {
+		        int    fd;
+		        size_t sz;
+		        sz = 1;
+		        So(nng_getopt(s1, NNG_OPT_RCVFD, &fd, &sz) ==
+		            NNG_EINVAL);
+		        sz = 128;
+		        So(nng_getopt(s1, NNG_OPT_RCVFD, &fd, &sz) == 0);
+		        So(sz == sizeof(fd));
+	        });
 	        Convey("We cannot get a send FD for PULL", {
 		        nng_socket s3;
 		        int        fd;


### PR DESCRIPTION
We never set the fd->sn_init member, causing new fds to be allocated
on each request for a new pollfd, and causing old ones to leak, and
worse may be even to not get notified.  While here, we arrange for
a bit richer testing against the various options.