### PR TITLE
Eliminate legacy option settings, provide easier option IDs.

### DIFF
--- a/perf/perf.c
+++ b/perf/perf.c
@@ -354,17 +354,15 @@ throughput_server(const char *addr, int msgsize, int count)
 	nng_msg *  msg;
 	int        rv;
 	int        i;
-	size_t     len;
 	uint64_t   start, end;
 	double     msgpersec, mbps, total;
 
 	if ((rv = nng_pair_open(&s)) != 0) {
 		die("nng_socket: %s", nng_strerror(rv));
 	}
-	len = 128;
-	rv  = nng_setopt(s, NNG_OPT_RCVBUF, &len, sizeof(len));
+	rv = nng_setopt_int(s, nng_optid_recvbuf, 128);
 	if (rv != 0) {
-		die("nng_setopt(NNG_OPT_RCVBUF): %s", nng_strerror(rv));
+		die("nng_setopt(nng_optid_recvbuf): %s", nng_strerror(rv));
 	}
 
 	// XXX: set no delay
@@ -411,7 +409,6 @@ throughput_client(const char *addr, int msgsize, int count)
 	nng_msg *  msg;
 	int        rv;
 	int        i;
-	int        len;
 
 	// We send one extra zero length message to start the timer.
 	count++;
@@ -423,10 +420,9 @@ throughput_client(const char *addr, int msgsize, int count)
 	// XXX: set no delay
 	// XXX: other options (TLS in the future?, Linger?)
 
-	len = 128;
-	rv  = nng_setopt(s, NNG_OPT_SNDBUF, &len, sizeof(len));
+	rv = nng_setopt_int(s, nng_optid_sendbuf, 128);
 	if (rv != 0) {
-		die("nng_setopt(NNG_OPT_SNDBUF): %s", nng_strerror(rv));
+		die("nng_setopt(nng_optid_sendbuf): %s", nng_strerror(rv));
 	}
 
 	if ((rv = nng_dial(s, addr, NULL, 0)) != 0) {

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -171,7 +171,8 @@ nni_aio_finish_impl(
 {
 	nni_mtx_lock(&nni_aio_lk);
 
-	NNI_ASSERT(aio->a_pend == 0); // provider only calls us *once*
+	// provider only calls us *once*, but expiration may be in flight
+	NNI_ASSERT(aio->a_expiring || aio->a_pend == 0);
 
 	nni_list_node_remove(&aio->a_expire_node);
 	aio->a_pend        = 1;

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -171,8 +171,7 @@ nni_aio_finish_impl(
 {
 	nni_mtx_lock(&nni_aio_lk);
 
-	// provider only calls us *once*, but expiration may be in flight
-	NNI_ASSERT(aio->a_expiring || aio->a_pend == 0);
+	NNI_ASSERT(aio->a_pend == 0); // provider only calls us *once*
 
 	nni_list_node_remove(&aio->a_expire_node);
 	aio->a_pend        = 1;

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -90,10 +91,10 @@ nni_device(nni_sock *sock1, nni_sock *sock2)
 
 	// No timeouts.
 	sz = sizeof(never);
-	if ((nni_sock_setopt(sock1, NNG_OPT_RCVTIMEO, &never, sz) != 0) ||
-	    (nni_sock_setopt(sock2, NNG_OPT_RCVTIMEO, &never, sz) != 0) ||
-	    (nni_sock_setopt(sock1, NNG_OPT_SNDTIMEO, &never, sz) != 0) ||
-	    (nni_sock_setopt(sock2, NNG_OPT_SNDTIMEO, &never, sz) != 0)) {
+	if ((nni_sock_setopt(sock1, nng_optid_recvtimeo, &never, sz) != 0) ||
+	    (nni_sock_setopt(sock2, nng_optid_recvtimeo, &never, sz) != 0) ||
+	    (nni_sock_setopt(sock1, nng_optid_sendtimeo, &never, sz) != 0) ||
+	    (nni_sock_setopt(sock2, nng_optid_sendtimeo, &never, sz) != 0)) {
 		// This should never happen.
 		rv = NNG_EINVAL;
 		goto out;

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -320,7 +320,8 @@ nni_ep_tmo_start(nni_ep *ep)
 	// have a statistically perfect distribution with the modulo of
 	// the random number, but this really doesn't matter.
 
-	ep->ep_tmo_aio.a_expire = nni_clock() + (nni_random() % backoff);
+	ep->ep_tmo_aio.a_expire =
+	    nni_clock() + (backoff ? nni_random() % backoff : 0);
 	nni_aio_start(&ep->ep_tmo_aio, nni_ep_tmo_cancel, ep);
 }
 

--- a/src/core/idhash.c
+++ b/src/core/idhash.c
@@ -174,7 +174,7 @@ nni_hash_resize(nni_idhash *h)
 		h->ih_maxload = 5;
 	}
 	for (i = 0; i < oldsize; i++) {
-		uint32_t index;
+		size_t index;
 		if (oldents[i].ihe_val == NULL) {
 			continue;
 		}

--- a/src/core/options.c
+++ b/src/core/options.c
@@ -263,7 +263,7 @@ static int
 nni_option_set_id(const char *name, int id)
 {
 	nni_option *opt;
-	int         len;
+	size_t      len;
 	nni_mtx_lock(&nni_option_lk);
 	NNI_LIST_FOREACH (&nni_options, opt) {
 		if (strcmp(name, opt->o_name) == 0) {

--- a/src/core/options.c
+++ b/src/core/options.c
@@ -340,50 +340,6 @@ nni_option_register(const char *name, int *idp)
 	return (0);
 }
 
-int
-nni_option_sys_init(void)
-{
-	nni_mtx_init(&nni_option_lk);
-	NNI_LIST_INIT(&nni_options, nni_option, o_link);
-	nni_option_nextid = 0x10000;
-	int rv;
-
-	// Register our well-known options.
-	if (((rv = nni_option_set_id("raw", NNG_OPT_RAW)) != 0) ||
-	    ((rv = nni_option_set_id("linger", NNG_OPT_LINGER)) != 0) ||
-	    ((rv = nni_option_set_id("recv-buf", NNG_OPT_RCVBUF)) != 0) ||
-	    ((rv = nni_option_set_id("send-buf", NNG_OPT_SNDBUF)) != 0) ||
-	    ((rv = nni_option_set_id("recv-timeout", NNG_OPT_RCVTIMEO)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("send-timeout", NNG_OPT_SNDTIMEO)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("reconnect-time", NNG_OPT_RECONN_TIME)) !=
-	        0) ||
-	    ((rv = nni_option_set_id(
-	          "reconnect-max-time", NNG_OPT_RECONN_MAXTIME)) != 0) ||
-	    ((rv = nni_option_set_id("recv-max-size", NNG_OPT_RCVMAXSZ)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("max-ttl", NNG_OPT_MAXTTL)) != 0) ||
-	    ((rv = nni_option_set_id("protocol", NNG_OPT_PROTOCOL)) != 0) ||
-	    ((rv = nni_option_set_id("subscribe", NNG_OPT_SUBSCRIBE)) != 0) ||
-	    ((rv = nni_option_set_id("unsubscribe", NNG_OPT_UNSUBSCRIBE)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("survey-time", NNG_OPT_SURVEYTIME)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("resend-time", NNG_OPT_RESENDTIME)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("transport", NNG_OPT_TRANSPORT)) != 0) ||
-	    ((rv = nni_option_set_id("local-addr", NNG_OPT_LOCALADDR)) != 0) ||
-	    ((rv = nni_option_set_id("remote-addr", NNG_OPT_REMOTEADDR)) !=
-	        0) ||
-	    ((rv = nni_option_set_id("recv-fd", NNG_OPT_RCVFD)) != 0) ||
-	    ((rv = nni_option_set_id("send-fd", NNG_OPT_SNDFD)) != 0)) {
-		nni_option_sys_fini();
-		return (rv);
-	}
-	return (0);
-}
-
 void
 nni_option_sys_fini(void)
 {
@@ -396,4 +352,42 @@ nni_option_sys_fini(void)
 		}
 	}
 	nni_option_nextid = 0;
+}
+
+int
+nni_option_sys_init(void)
+{
+	nni_mtx_init(&nni_option_lk);
+	NNI_LIST_INIT(&nni_options, nni_option, o_link);
+	nni_option_nextid = 0x10000;
+	int rv;
+
+#define OPT_REGISTER(o) nni_option_register(nng_opt_##o, &nng_optid_##o)
+	// Register our well-known options.
+	if (((rv = OPT_REGISTER(raw)) != 0) ||
+	    ((rv = OPT_REGISTER(linger)) != 0) ||
+	    ((rv = OPT_REGISTER(recvbuf)) != 0) ||
+	    ((rv = OPT_REGISTER(sendbuf)) != 0) ||
+	    ((rv = OPT_REGISTER(recvtimeo)) != 0) ||
+	    ((rv = OPT_REGISTER(sendtimeo)) != 0) ||
+	    ((rv = OPT_REGISTER(reconnmint)) != 0) ||
+	    ((rv = OPT_REGISTER(reconnmaxt)) != 0) ||
+	    ((rv = OPT_REGISTER(recvmaxsz)) != 0) ||
+	    ((rv = OPT_REGISTER(maxttl)) != 0) ||
+	    ((rv = OPT_REGISTER(protocol)) != 0) ||
+	    ((rv = OPT_REGISTER(transport)) != 0) ||
+	    ((rv = OPT_REGISTER(locaddr)) != 0) ||
+	    ((rv = OPT_REGISTER(remaddr)) != 0) ||
+	    ((rv = OPT_REGISTER(recvfd)) != 0) ||
+	    ((rv = OPT_REGISTER(sendfd)) != 0) ||
+	    ((rv = OPT_REGISTER(req_resendtime)) != 0) ||
+	    ((rv = OPT_REGISTER(sub_subscribe)) != 0) ||
+	    ((rv = OPT_REGISTER(sub_unsubscribe)) != 0) ||
+	    ((rv = OPT_REGISTER(surveyor_surveytime)) != 0)) {
+		nni_option_sys_fini();
+		return (rv);
+	}
+#undef OPT_REGISTER
+
+	return (0);
 }

--- a/src/nng.c
+++ b/src/nng.c
@@ -881,12 +881,14 @@ nng_msg_getopt(nng_msg *msg, int opt, void *ptr, size_t *szp)
 int
 nng_option_lookup(const char *name)
 {
+	(void) nni_init();
 	return (nni_option_lookup(name));
 }
 
 const char *
 nng_option_name(int id)
 {
+	(void) nni_init();
 	return (nni_option_name(id));
 }
 
@@ -990,3 +992,49 @@ nng_thread_destroy(void *arg)
 
 	NNI_FREE_STRUCT(thr);
 }
+
+// Constant option definitions.  These are for well-known options,
+// so that the vast majority of consumers don't have to look these up.
+
+const char *nng_opt_raw        = "raw";
+const char *nng_opt_linger     = "linger";
+const char *nng_opt_recvbuf    = "recv-buffer";
+const char *nng_opt_sendbuf    = "send-buffer";
+const char *nng_opt_recvtimeo  = "recv-timeout";
+const char *nng_opt_sendtimeo  = "send-timeout";
+const char *nng_opt_recvmaxsz  = "recv-size-max";
+const char *nng_opt_reconnmint = "reconnect-time-min";
+const char *nng_opt_reconnmaxt = "reconnect-time-min";
+const char *nng_opt_maxttl     = "ttl-max";
+const char *nng_opt_protocol   = "protocol";
+const char *nng_opt_transport  = "transport";
+const char *nng_opt_recvfd     = "recv-fd";
+const char *nng_opt_sendfd     = "send-fd";
+const char *nng_opt_locaddr    = "local-address";
+const char *nng_opt_remaddr    = "remote-address";
+// Well known protocol options.
+const char *nng_opt_req_resendtime      = "req:resend-time";
+const char *nng_opt_sub_subscribe       = "sub:subscribe";
+const char *nng_opt_sub_unsubscribe     = "sub:unsubscribe";
+const char *nng_opt_surveyor_surveytime = "surveyor:survey-time";
+
+int nng_optid_raw;
+int nng_optid_linger;
+int nng_optid_recvbuf;
+int nng_optid_sendbuf;
+int nng_optid_recvtimeo;
+int nng_optid_sendtimeo;
+int nng_optid_recvmaxsz;
+int nng_optid_reconnmint;
+int nng_optid_reconnmaxt;
+int nng_optid_maxttl;
+int nng_optid_protocol;
+int nng_optid_transport;
+int nng_optid_recvfd;
+int nng_optid_sendfd;
+int nng_optid_locaddr;
+int nng_optid_remaddr;
+int nng_optid_req_resendtime;
+int nng_optid_sub_subscribe;
+int nng_optid_sub_unsubscribe;
+int nng_optid_surveyor_surveytime;

--- a/src/nng.h
+++ b/src/nng.h
@@ -403,29 +403,50 @@ NNG_DECL int nng_respondent0_open(nng_socket *);
 #define NNG_OPT_SOCKET(c) (c)
 #define NNG_OPT_TRANSPORT_OPT(t, c) (0x10000 | ((t) << 16) | (c))
 
-enum nng_opt_enum {
-	NNG_OPT_RAW            = NNG_OPT_SOCKET(0),
-	NNG_OPT_LINGER         = NNG_OPT_SOCKET(1),
-	NNG_OPT_RCVBUF         = NNG_OPT_SOCKET(2),
-	NNG_OPT_SNDBUF         = NNG_OPT_SOCKET(3),
-	NNG_OPT_RCVTIMEO       = NNG_OPT_SOCKET(4),
-	NNG_OPT_SNDTIMEO       = NNG_OPT_SOCKET(5),
-	NNG_OPT_RECONN_TIME    = NNG_OPT_SOCKET(6),
-	NNG_OPT_RECONN_MAXTIME = NNG_OPT_SOCKET(7),
-	NNG_OPT_RCVMAXSZ       = NNG_OPT_SOCKET(8),
-	NNG_OPT_MAXTTL         = NNG_OPT_SOCKET(9),
-	NNG_OPT_PROTOCOL       = NNG_OPT_SOCKET(10),
-	NNG_OPT_SUBSCRIBE      = NNG_OPT_SOCKET(11),
-	NNG_OPT_UNSUBSCRIBE    = NNG_OPT_SOCKET(12),
-	NNG_OPT_SURVEYTIME     = NNG_OPT_SOCKET(13),
-	NNG_OPT_RESENDTIME     = NNG_OPT_SOCKET(14),
-	NNG_OPT_TRANSPORT      = NNG_OPT_SOCKET(15),
-	NNG_OPT_LOCALADDR      = NNG_OPT_SOCKET(16),
-	NNG_OPT_REMOTEADDR     = NNG_OPT_SOCKET(17),
-	NNG_OPT_RCVFD          = NNG_OPT_SOCKET(18),
-	NNG_OPT_SNDFD          = NNG_OPT_SOCKET(19),
-};
+extern const char *nng_opt_raw;
+extern const char *nng_opt_linger;
+extern const char *nng_opt_recvbuf;
+extern const char *nng_opt_sendbuf;
+extern const char *nng_opt_recvtimeo;
+extern const char *nng_opt_sendtimeo;
+extern const char *nng_opt_recvmaxsz;
+extern const char *nng_opt_reconnmint;
+extern const char *nng_opt_reconnmaxt;
+extern const char *nng_opt_maxttl;
+extern const char *nng_opt_protocol;
+extern const char *nng_opt_transport;
+extern const char *nng_opt_recvfd;
+extern const char *nng_opt_sendfd;
+extern const char *nng_opt_locaddr;
+extern const char *nng_opt_remaddr;
+extern const char *nng_opt_req_resendtime;
+extern const char *nng_opt_sub_subscribe;
+extern const char *nng_opt_sub_unsubscribe;
+extern const char *nng_opt_surveyor_surveytime;
 
+extern int nng_optid_raw;
+extern int nng_optid_linger;
+extern int nng_optid_recvbuf;
+extern int nng_optid_sendbuf;
+extern int nng_optid_recvtimeo;
+extern int nng_optid_sendtimeo;
+extern int nng_optid_recvmaxsz;
+extern int nng_optid_reconnmint;
+extern int nng_optid_reconnmaxt;
+extern int nng_optid_maxttl;
+extern int nng_optid_protocol;
+extern int nng_optid_transport;
+extern int nng_optid_recvfd;
+extern int nng_optid_sendfd;
+extern int nng_optid_locaddr;
+extern int nng_optid_remaddr;
+
+// These protocol specific options may not be valid until a socket of
+// the given protocol is opened!
+extern int nng_optid_req_resendtime;
+extern int nng_optid_sub_subscribe;
+extern int nng_optid_sub_unsubscribe;
+extern int nng_optid_surveyor_surveytime;
 // XXX: TBD: priorities, socket names, ipv4only
 
 // Statistics.  These are for informational purposes only, and subject

--- a/src/protocol/bus/bus.c
+++ b/src/protocol/bus/bus.c
@@ -322,14 +322,10 @@ static int
 nni_bus_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_bus_sock *psock = arg;
-	int           rv;
+	int           rv    = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&psock->raw, buf, sz, 0, 1);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }
@@ -338,14 +334,10 @@ static int
 nni_bus_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_bus_sock *psock = arg;
-	int           rv;
+	int           rv    = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&psock->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/pair/pair_v0.c
+++ b/src/protocol/pair/pair_v0.c
@@ -231,11 +231,9 @@ pair0_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 	pair0_sock *s = arg;
 	int         rv;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&s->raw, buf, sz, 0, 1);
-		break;
-	default:
+	} else {
 		rv = NNG_ENOTSUP;
 	}
 	return (rv);
@@ -247,11 +245,9 @@ pair0_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 	pair0_sock *s = arg;
 	int         rv;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&s->raw, buf, szp);
-		break;
-	default:
+	} else {
 		rv = NNG_ENOTSUP;
 	}
 	return (rv);

--- a/src/protocol/pipeline/pull.c
+++ b/src/protocol/pipeline/pull.c
@@ -170,14 +170,10 @@ static int
 nni_pull_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_pull_sock *pull = arg;
-	int            rv;
+	int            rv   = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&pull->raw, buf, sz, 0, 1);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }
@@ -186,14 +182,10 @@ static int
 nni_pull_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_pull_sock *pull = arg;
-	int            rv;
+	int            rv   = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&pull->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/pipeline/push.c
+++ b/src/protocol/pipeline/push.c
@@ -192,14 +192,10 @@ static int
 nni_push_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_push_sock *push = arg;
-	int            rv;
+	int            rv   = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&push->raw, buf, sz, 0, 1);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }
@@ -208,14 +204,10 @@ static int
 nni_push_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_push_sock *push = arg;
-	int            rv;
+	int            rv   = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&push->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/pubsub/pub.c
+++ b/src/protocol/pubsub/pub.c
@@ -266,14 +266,10 @@ static int
 nni_pub_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_pub_sock *pub = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&pub->raw, buf, sz, 0, 1);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }
@@ -282,14 +278,10 @@ static int
 nni_pub_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_pub_sock *pub = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&pub->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/pubsub/sub.c
+++ b/src/protocol/pubsub/sub.c
@@ -251,20 +251,14 @@ static int
 nni_sub_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_sub_sock *sub = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&sub->raw, buf, sz, 0, 1);
-		break;
-	case NNG_OPT_SUBSCRIBE:
+	} else if (opt == nng_optid_sub_subscribe) {
 		rv = nni_sub_subscribe(sub, buf, sz);
-		break;
-	case NNG_OPT_UNSUBSCRIBE:
+	} else if (opt == nng_optid_sub_unsubscribe) {
 		rv = nni_sub_unsubscribe(sub, buf, sz);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }
@@ -273,14 +267,10 @@ static int
 nni_sub_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_sub_sock *sub = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RAW:
+	if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&sub->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/reqrep/rep.c
+++ b/src/protocol/reqrep/rep.c
@@ -348,18 +348,13 @@ static int
 nni_rep_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_rep_sock *rep = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_MAXTTL:
+	if (opt == nng_optid_maxttl) {
 		rv = nni_setopt_int(&rep->ttl, buf, sz, 1, 255);
-		break;
-	case NNG_OPT_RAW:
+	} else if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&rep->raw, buf, sz, 0, 1);
 		nni_sock_senderr(rep->sock, rep->raw ? 0 : NNG_ESTATE);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }
@@ -368,17 +363,12 @@ static int
 nni_rep_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_rep_sock *rep = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_MAXTTL:
+	if (opt == nng_optid_maxttl) {
 		rv = nni_getopt_int(&rep->ttl, buf, szp);
-		break;
-	case NNG_OPT_RAW:
+	} else if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&rep->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/reqrep/req.c
+++ b/src/protocol/reqrep/req.c
@@ -243,24 +243,21 @@ static int
 nni_req_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_req_sock *req = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RESENDTIME:
+	if (opt == nng_optid_req_resendtime) {
 		rv = nni_setopt_usec(&req->retry, buf, sz);
-		break;
-	case NNG_OPT_RAW:
+
+	} else if (opt == nng_optid_raw) {
 		rv = nni_setopt_int(&req->raw, buf, sz, 0, 1);
 		if (rv == 0) {
 			nni_sock_recverr(req->sock, req->raw ? 0 : NNG_ESTATE);
 		}
-		break;
-	case NNG_OPT_MAXTTL:
+
+	} else if (opt == nng_optid_maxttl) {
 		rv = nni_setopt_int(&req->ttl, buf, sz, 1, 255);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
+
 	return (rv);
 }
 
@@ -268,21 +265,18 @@ static int
 nni_req_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_req_sock *req = arg;
-	int           rv;
+	int           rv  = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_RESENDTIME:
+	if (opt == nng_optid_req_resendtime) {
 		rv = nni_getopt_usec(&req->retry, buf, szp);
-		break;
-	case NNG_OPT_RAW:
+
+	} else if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&req->raw, buf, szp);
-		break;
-	case NNG_OPT_MAXTTL:
+
+	} else if (opt == nng_optid_maxttl) {
 		rv = nni_getopt_int(&req->ttl, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
+
 	return (rv);
 }
 

--- a/src/protocol/survey/respond.c
+++ b/src/protocol/survey/respond.c
@@ -348,14 +348,13 @@ static int
 nni_resp_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_resp_sock *psock = arg;
-	int            rv;
+	int            rv    = NNG_ENOTSUP;
 	int            oldraw;
 
-	switch (opt) {
-	case NNG_OPT_MAXTTL:
+	if (opt == nng_optid_maxttl) {
 		rv = nni_setopt_int(&psock->ttl, buf, sz, 1, 255);
-		break;
-	case NNG_OPT_RAW:
+
+	} else if (opt == nng_optid_raw) {
 		oldraw = psock->raw;
 		rv     = nni_setopt_int(&psock->raw, buf, sz, 0, 1);
 		if (oldraw != psock->raw) {
@@ -365,10 +364,8 @@ nni_resp_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 				nni_sock_senderr(psock->nsock, NNG_ESTATE);
 			}
 		}
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
+
 	return (rv);
 }
 
@@ -376,17 +373,12 @@ static int
 nni_resp_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_resp_sock *psock = arg;
-	int            rv;
+	int            rv    = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_MAXTTL:
+	if (opt == nng_optid_maxttl) {
 		rv = nni_getopt_int(&psock->ttl, buf, szp);
-		break;
-	case NNG_OPT_RAW:
+	} else if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&psock->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/protocol/survey/survey.c
+++ b/src/protocol/survey/survey.c
@@ -267,14 +267,13 @@ static int
 nni_surv_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 {
 	nni_surv_sock *psock = arg;
-	int            rv;
+	int            rv    = NNG_ENOTSUP;
 	int            oldraw;
 
-	switch (opt) {
-	case NNG_OPT_SURVEYTIME:
+	if (opt == nng_optid_surveyor_surveytime) {
 		rv = nni_setopt_usec(&psock->survtime, buf, sz);
-		break;
-	case NNG_OPT_RAW:
+
+	} else if (opt == nng_optid_raw) {
 		oldraw = psock->raw;
 		rv     = nni_setopt_int(&psock->raw, buf, sz, 0, 1);
 		if (oldraw != psock->raw) {
@@ -286,10 +285,8 @@ nni_surv_sock_setopt(void *arg, int opt, const void *buf, size_t sz)
 			psock->survid = 0;
 			nni_timer_cancel(&psock->timer);
 		}
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
+
 	return (rv);
 }
 
@@ -297,17 +294,12 @@ static int
 nni_surv_sock_getopt(void *arg, int opt, void *buf, size_t *szp)
 {
 	nni_surv_sock *psock = arg;
-	int            rv;
+	int            rv    = NNG_ENOTSUP;
 
-	switch (opt) {
-	case NNG_OPT_SURVEYTIME:
+	if (opt == nng_optid_surveyor_surveytime) {
 		rv = nni_getopt_usec(&psock->survtime, buf, szp);
-		break;
-	case NNG_OPT_RAW:
+	} else if (opt == nng_optid_raw) {
 		rv = nni_getopt_int(&psock->raw, buf, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
 	}
 	return (rv);
 }

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -179,10 +179,9 @@ nni_inproc_pipe_peer(void *arg)
 static int
 nni_inproc_pipe_getopt(void *arg, int option, void *buf, size_t *szp)
 {
-	nni_inproc_pipe *pipe = arg;
-	size_t           len;
-
 #if 0
+	nni_inproc_pipe *pipe = arg;
+
 	switch (option) {
 	case NNG_OPT_LOCALADDR:
 	case NNG_OPT_REMOTEADDR:

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -182,6 +182,7 @@ nni_inproc_pipe_getopt(void *arg, int option, void *buf, size_t *szp)
 	nni_inproc_pipe *pipe = arg;
 	size_t           len;
 
+#if 0
 	switch (option) {
 	case NNG_OPT_LOCALADDR:
 	case NNG_OPT_REMOTEADDR:
@@ -194,6 +195,7 @@ nni_inproc_pipe_getopt(void *arg, int option, void *buf, size_t *szp)
 		*szp = len;
 		return (0);
 	}
+#endif
 	return (NNG_ENOTSUP);
 }
 

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -64,8 +64,7 @@ static void nni_ipc_ep_cb(void *);
 static int
 nni_ipc_tran_chkopt(int o, const void *data, size_t sz)
 {
-	switch (o) {
-	case NNG_OPT_RCVMAXSZ:
+	if (o == nng_optid_recvmaxsz) {
 		return (nni_chkopt_size(data, sz, 0, NNI_MAXSZ));
 	}
 	return (NNG_ENOTSUP);
@@ -648,37 +647,28 @@ nni_ipc_ep_connect(void *arg, nni_aio *aio)
 static int
 nni_ipc_ep_setopt(void *arg, int opt, const void *v, size_t sz)
 {
-	int         rv;
+	int         rv = NNG_ENOTSUP;
 	nni_ipc_ep *ep = arg;
-	nni_mtx_lock(&ep->mtx);
-	switch (opt) {
-	case NNG_OPT_RCVMAXSZ:
+
+	if (opt == nng_optid_recvmaxsz) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_setopt_size(&ep->rcvmax, v, sz, 0, NNI_MAXSZ);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
-		break;
+		nni_mtx_unlock(&ep->mtx);
 	}
-	nni_mtx_unlock(&ep->mtx);
 	return (rv);
 }
 
 static int
 nni_ipc_ep_getopt(void *arg, int opt, void *v, size_t *szp)
 {
-	int         rv;
+	int         rv = NNG_ENOTSUP;
 	nni_ipc_ep *ep = arg;
 
-	nni_mtx_lock(&ep->mtx);
-	switch (opt) {
-	case NNG_OPT_RCVMAXSZ:
+	if (opt == nng_optid_recvmaxsz) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_getopt_size(&ep->rcvmax, v, szp);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
-		break;
+		nni_mtx_unlock(&ep->mtx);
 	}
-	nni_mtx_unlock(&ep->mtx);
 	return (rv);
 }
 

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -65,10 +65,10 @@ static void nni_tcp_ep_cb(void *arg);
 static int
 nni_tcp_tran_chkopt(int o, const void *data, size_t sz)
 {
-	switch (o) {
-	case NNG_OPT_RCVMAXSZ:
+	if (o == nng_optid_recvmaxsz) {
 		return (nni_chkopt_size(data, sz, 0, NNI_MAXSZ));
-	case NNG_OPT_LINGER:
+	}
+	if (o == nng_optid_linger) {
 		return (nni_chkopt_usec(data, sz));
 	}
 	return (NNG_ENOTSUP);
@@ -766,45 +766,39 @@ nni_tcp_ep_connect(void *arg, nni_aio *aio)
 static int
 nni_tcp_ep_setopt(void *arg, int opt, const void *v, size_t sz)
 {
-	int         rv;
+	int         rv = NNG_ENOTSUP;
 	nni_tcp_ep *ep = arg;
 
-	nni_mtx_lock(&ep->mtx);
-	switch (opt) {
-	case NNG_OPT_RCVMAXSZ:
+	if (opt == nng_optid_recvmaxsz) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_setopt_size(&ep->rcvmax, v, sz, 0, NNI_MAXSZ);
-		break;
-	case NNG_OPT_LINGER:
+		nni_mtx_unlock(&ep->mtx);
+
+	} else if (opt == nng_optid_linger) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_setopt_usec(&ep->linger, v, sz);
-		break;
-	default:
-		rv = NNG_ENOTSUP;
-		break;
+		nni_mtx_unlock(&ep->mtx);
 	}
-	nni_mtx_unlock(&ep->mtx);
 	return (rv);
 }
 
 static int
 nni_tcp_ep_getopt(void *arg, int opt, void *v, size_t *szp)
 {
-	int         rv;
+	int         rv = NNG_ENOTSUP;
 	nni_tcp_ep *ep = arg;
 
-	nni_mtx_lock(&ep->mtx);
-	switch (opt) {
-	case NNG_OPT_RCVMAXSZ:
+	if (opt == nng_optid_recvmaxsz) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_getopt_size(&ep->rcvmax, v, szp);
-		break;
-	case NNG_OPT_LINGER:
+		nni_mtx_unlock(&ep->mtx);
+
+	} else if (opt == nng_optid_linger) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_getopt_usec(&ep->linger, v, szp);
-		break;
-	default:
-		// XXX: add address properties
-		rv = NNG_ENOTSUP;
-		break;
+		nni_mtx_unlock(&ep->mtx);
 	}
-	nni_mtx_unlock(&ep->mtx);
+	// XXX: add address properties
 	return (rv);
 }
 

--- a/tests/bus.c
+++ b/tests/bus.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -56,14 +57,9 @@ TestMain("BUS pattern", {
 		So(nng_dial(bus3, addr, NULL, 0) == 0);
 
 		rtimeo = 50000;
-		So(nng_setopt(
-		       bus1, NNG_OPT_RCVTIMEO, &rtimeo, sizeof(rtimeo)) == 0);
-		rtimeo = 50000;
-		So(nng_setopt(
-		       bus2, NNG_OPT_RCVTIMEO, &rtimeo, sizeof(rtimeo)) == 0);
-		rtimeo = 50000;
-		So(nng_setopt(
-		       bus3, NNG_OPT_RCVTIMEO, &rtimeo, sizeof(rtimeo)) == 0);
+		So(nng_setopt_usec(bus1, nng_optid_recvtimeo, rtimeo) == 0);
+		So(nng_setopt_usec(bus2, nng_optid_recvtimeo, rtimeo) == 0);
+		So(nng_setopt_usec(bus3, nng_optid_recvtimeo, rtimeo) == 0);
 
 		Convey("Messages delivered", {
 			nng_msg *msg;

--- a/tests/compat_pipeline.c
+++ b/tests/compat_pipeline.c
@@ -39,12 +39,13 @@ int main ()
     test_bind (push1, SOCKET_ADDRESS);
     pull1 = test_socket (AF_SP, NN_PULL);
     test_connect (pull1, SOCKET_ADDRESS);
+    nn_sleep (20);
     pull2 = test_socket (AF_SP, NN_PULL);
     test_connect (pull2, SOCKET_ADDRESS);
 
     /*  Wait till both connections are established to get messages spread
         evenly between the two pull sockets. */
-    nn_sleep (10);
+    nn_sleep (20);
 
     test_send (push1, "ABC");
     test_send (push1, "DEF");

--- a/tests/device.c
+++ b/tests/device.c
@@ -42,19 +42,15 @@ Main({
 			nng_socket dev2;
 			nng_socket end1;
 			nng_socket end2;
-			int        raw;
 			uint64_t   tmo;
 			nng_msg *  msg;
 			void *     thr;
 
 			So(nng_pair1_open(&dev1) == 0);
 			So(nng_pair1_open(&dev2) == 0);
-			raw = 1;
-			So(nng_setopt(dev1, NNG_OPT_RAW, &raw, sizeof(raw)) ==
-			    0);
-			raw = 1;
-			So(nng_setopt(dev2, NNG_OPT_RAW, &raw, sizeof(raw)) ==
-			    0);
+
+			So(nng_setopt_int(dev1, nng_optid_raw, 1) == 0);
+			So(nng_setopt_int(dev2, nng_optid_raw, 1) == 0);
 
 			struct dev_data ddata;
 			ddata.s1 = dev1;
@@ -77,11 +73,10 @@ Main({
 			So(nng_dial(end2, addr2, NULL, 0) == 0);
 
 			tmo = 1000000;
-			So(nng_setopt(end1, NNG_OPT_RCVTIMEO, &tmo,
-			       sizeof(tmo)) == 0);
-			tmo = 1000000;
-			So(nng_setopt(end2, NNG_OPT_RCVTIMEO, &tmo,
-			       sizeof(tmo)) == 0);
+			So(nng_setopt_usec(end1, nng_optid_recvtimeo, tmo) ==
+			    0);
+			So(nng_setopt_usec(end2, nng_optid_recvtimeo, tmo) ==
+			    0);
 
 			nng_usleep(100000);
 			Convey("Device can send and receive", {

--- a/tests/pair1.c
+++ b/tests/pair1.c
@@ -172,7 +172,6 @@ TestMain("PAIRv1 protocol", {
 		});
 
 		Convey("Cannot set polyamorous mode after connect", {
-			int poly;
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
 			nng_usleep(100000);

--- a/tests/pair1.c
+++ b/tests/pair1.c
@@ -71,6 +71,7 @@ TestMain("PAIRv1 protocol", {
 
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "ALPHA");
@@ -132,6 +133,7 @@ TestMain("PAIRv1 protocol", {
 
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			for (i = 0, rv = 0; i < 10; i++) {
 				So(nng_msg_alloc(&msg, 0) == 0);
@@ -157,6 +159,7 @@ TestMain("PAIRv1 protocol", {
 
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			// We choose to allow some buffering.  In reality the
 			// buffer size is just 1, and we will fail after 2.
@@ -190,6 +193,7 @@ TestMain("PAIRv1 protocol", {
 
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			Convey("Send/recv work", {
 				So(nng_msg_alloc(&msg, 0) == 0);
@@ -356,6 +360,7 @@ TestMain("PAIRv1 protocol", {
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
 			So(nng_dial(c2, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "ONE");
@@ -412,6 +417,7 @@ TestMain("PAIRv1 protocol", {
 			So(nng_dial(c1, addr, NULL, 0) == 0);
 			nng_usleep(100000);
 			So(nng_dial(c2, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "YES");
@@ -453,6 +459,7 @@ TestMain("PAIRv1 protocol", {
 			So(nng_listen(s1, addr, NULL, 0) == 0);
 			So(nng_dial(c1, addr, NULL, 0) == 0);
 			So(nng_dial(c2, addr, NULL, 0) == 0);
+			nng_usleep(20000);
 
 			Convey("Send/recv works", {
 				So(nng_msg_alloc(&msg, 0) == 0);

--- a/tests/pipeline.c
+++ b/tests/pipeline.c
@@ -16,172 +16,155 @@
 	So(nng_msg_len(m) == strlen(s)); \
 	So(memcmp(nng_msg_body(m), s, strlen(s)) == 0)
 
-Main({
+TestMain("PIPELINE (PUSH/PULL) pattern", {
+	atexit(nng_fini);
 	const char *addr = "inproc://test";
+	Convey("We can create a PUSH socket", {
+		nng_socket push;
 
-	Test("PIPELINE (PUSH/PULL) pattern", {
-		Convey("We can create a PUSH socket", {
-			nng_socket push;
+		So(nng_push_open(&push) == 0);
 
-			So(nng_push_open(&push) == 0);
+		Reset({ nng_close(push); });
 
-			Reset({ nng_close(push); });
-
-			Convey("Protocols match", {
-				So(nng_protocol(push) == NNG_PROTO_PUSH);
-				So(nng_peer(push) == NNG_PROTO_PULL);
-			});
-
-			Convey("Recv fails", {
-				nng_msg *msg;
-				So(nng_recvmsg(push, &msg, 0) == NNG_ENOTSUP);
-			});
+		Convey("Protocols match", {
+			So(nng_protocol(push) == NNG_PROTO_PUSH);
+			So(nng_peer(push) == NNG_PROTO_PULL);
 		});
 
-		Convey("We can create a PULL socket", {
-			nng_socket pull;
-			So(nng_pull_open(&pull) == 0);
-
-			Reset({ nng_close(pull); });
-
-			Convey("Protocols match", {
-				So(nng_protocol(pull) == NNG_PROTO_PULL);
-				So(nng_peer(pull) == NNG_PROTO_PUSH);
-			});
-
-			Convey("Send fails", {
-				nng_msg *msg;
-				So(nng_msg_alloc(&msg, 0) == 0);
-				So(nng_sendmsg(pull, msg, 0) == NNG_ENOTSUP);
-				nng_msg_free(msg);
-			});
-		});
-
-		Convey("We can create a linked PUSH/PULL pair", {
-			nng_socket push;
-			nng_socket pull;
-			nng_socket what;
-
-			So(nng_push_open(&push) == 0);
-			So(nng_pull_open(&pull) == 0);
-			So(nng_push_open(&what) == 0);
-
-			Reset({
-				nng_close(push);
-				nng_close(pull);
-				nng_close(what);
-			});
-
-			// Its important to avoid a startup race that the
-			// sender be the dialer.  Otherwise you need a delay
-			// since the server accept is really asynchronous.
-			So(nng_listen(pull, addr, NULL, 0) == 0);
-			So(nng_dial(push, addr, NULL, 0) == 0);
-			So(nng_dial(what, addr, NULL, 0) == 0);
-			So(nng_shutdown(what) == 0);
-
-			Convey("Push can send messages, and pull can recv", {
-				nng_msg *msg;
-
-				So(nng_msg_alloc(&msg, 0) == 0);
-				APPENDSTR(msg, "hello");
-				So(nng_sendmsg(push, msg, 0) == 0);
-				msg = NULL;
-				So(nng_recvmsg(pull, &msg, 0) == 0);
-				So(msg != NULL);
-				CHECKSTR(msg, "hello");
-				nng_msg_free(msg);
-			});
-		});
-
-		Convey("Load balancing", {
-			nng_msg *  abc;
-			nng_msg *  def;
-			uint64_t   usecs;
-			int        len;
-			nng_socket push;
-			nng_socket pull1;
-			nng_socket pull2;
-			nng_socket pull3;
-
-			So(nng_push_open(&push) == 0);
-			So(nng_pull_open(&pull1) == 0);
-			So(nng_pull_open(&pull2) == 0);
-			So(nng_pull_open(&pull3) == 0);
-
-			Reset({
-				nng_close(push);
-				nng_close(pull1);
-				nng_close(pull2);
-				nng_close(pull3);
-			});
-
-			// We need to increase the buffer from zero, because
-			// there is no guarantee that the various listeners
-			// will be present, which means that they will push
-			// back during load balancing.  Adding a small buffer
-			// ensures that we can write to each stream, even if
-			// the listeners are not running yet.
-			len = 4;
-			So(nng_setopt(
-			       push, NNG_OPT_RCVBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       push, NNG_OPT_SNDBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       pull1, NNG_OPT_RCVBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       pull1, NNG_OPT_SNDBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       pull2, NNG_OPT_RCVBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       pull2, NNG_OPT_SNDBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       pull3, NNG_OPT_RCVBUF, &len, sizeof(len)) == 0);
-			So(nng_setopt(
-			       pull3, NNG_OPT_SNDBUF, &len, sizeof(len)) == 0);
-
-			So(nng_msg_alloc(&abc, 0) == 0);
-			APPENDSTR(abc, "abc");
-			So(nng_msg_alloc(&def, 0) == 0);
-			APPENDSTR(def, "def");
-
-			usecs = 100000;
-			So(nng_setopt(pull1, NNG_OPT_RCVTIMEO, &usecs,
-			       sizeof(usecs)) == 0);
-			So(nng_setopt(pull2, NNG_OPT_RCVTIMEO, &usecs,
-			       sizeof(usecs)) == 0);
-			So(nng_setopt(pull3, NNG_OPT_RCVTIMEO, &usecs,
-			       sizeof(usecs)) == 0);
-			So(nng_listen(push, addr, NULL, 0) == 0);
-			So(nng_dial(pull1, addr, NULL, 0) == 0);
-			So(nng_dial(pull2, addr, NULL, 0) == 0);
-			So(nng_dial(pull3, addr, NULL, 0) == 0);
-			So(nng_shutdown(pull3) == 0);
-
-			// So pull3 might not be done accepting yet, but pull1
-			// and pull2 definitely are, because otherwise the
-			// server couldn't have gotten to the accept.  (The
-			// accept logic is single threaded.)  Let's wait a bit
-			// though, to ensure that stuff has settled.
-			nng_usleep(100000);
-
-			So(nng_sendmsg(push, abc, 0) == 0);
-			So(nng_sendmsg(push, def, 0) == 0);
-
-			abc = NULL;
-			def = NULL;
-
-			So(nng_recvmsg(pull1, &abc, 0) == 0);
-			CHECKSTR(abc, "abc");
-			So(nng_recvmsg(pull2, &def, 0) == 0);
-			CHECKSTR(def, "def");
-			nng_msg_free(abc);
-			nng_msg_free(def);
-
-			So(nng_recvmsg(pull1, &abc, 0) == NNG_ETIMEDOUT);
-			So(nng_recvmsg(pull2, &abc, 0) == NNG_ETIMEDOUT);
+		Convey("Recv fails", {
+			nng_msg *msg;
+			So(nng_recvmsg(push, &msg, 0) == NNG_ENOTSUP);
 		});
 	});
 
-	nng_fini();
-})
+	Convey("We can create a PULL socket", {
+		nng_socket pull;
+		So(nng_pull_open(&pull) == 0);
+
+		Reset({ nng_close(pull); });
+
+		Convey("Protocols match", {
+			So(nng_protocol(pull) == NNG_PROTO_PULL);
+			So(nng_peer(pull) == NNG_PROTO_PUSH);
+		});
+
+		Convey("Send fails", {
+			nng_msg *msg;
+			So(nng_msg_alloc(&msg, 0) == 0);
+			So(nng_sendmsg(pull, msg, 0) == NNG_ENOTSUP);
+			nng_msg_free(msg);
+		});
+	});
+
+	Convey("We can create a linked PUSH/PULL pair", {
+		nng_socket push;
+		nng_socket pull;
+		nng_socket what;
+
+		So(nng_push_open(&push) == 0);
+		So(nng_pull_open(&pull) == 0);
+		So(nng_push_open(&what) == 0);
+
+		Reset({
+			nng_close(push);
+			nng_close(pull);
+			nng_close(what);
+		});
+
+		// Its important to avoid a startup race that the
+		// sender be the dialer.  Otherwise you need a delay
+		// since the server accept is really asynchronous.
+		So(nng_listen(pull, addr, NULL, 0) == 0);
+		So(nng_dial(push, addr, NULL, 0) == 0);
+		So(nng_dial(what, addr, NULL, 0) == 0);
+		So(nng_shutdown(what) == 0);
+
+		Convey("Push can send messages, and pull can recv", {
+			nng_msg *msg;
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "hello");
+			So(nng_sendmsg(push, msg, 0) == 0);
+			msg = NULL;
+			So(nng_recvmsg(pull, &msg, 0) == 0);
+			So(msg != NULL);
+			CHECKSTR(msg, "hello");
+			nng_msg_free(msg);
+		});
+	});
+
+	Convey("Load balancing", {
+		nng_msg *  abc;
+		nng_msg *  def;
+		uint64_t   usecs;
+		nng_socket push;
+		nng_socket pull1;
+		nng_socket pull2;
+		nng_socket pull3;
+
+		So(nng_push_open(&push) == 0);
+		So(nng_pull_open(&pull1) == 0);
+		So(nng_pull_open(&pull2) == 0);
+		So(nng_pull_open(&pull3) == 0);
+
+		Reset({
+			nng_close(push);
+			nng_close(pull1);
+			nng_close(pull2);
+			nng_close(pull3);
+		});
+
+		// We need to increase the buffer from zero, because
+		// there is no guarantee that the various listeners
+		// will be present, which means that they will push
+		// back during load balancing.  Adding a small buffer
+		// ensures that we can write to each stream, even if
+		// the listeners are not running yet.
+		So(nng_setopt_int(push, nng_optid_recvbuf, 4) == 0);
+		So(nng_setopt_int(push, nng_optid_sendbuf, 4) == 0);
+		So(nng_setopt_int(pull1, nng_optid_recvbuf, 4) == 0);
+		So(nng_setopt_int(pull1, nng_optid_sendbuf, 4) == 0);
+		So(nng_setopt_int(pull2, nng_optid_recvbuf, 4) == 0);
+		So(nng_setopt_int(pull2, nng_optid_sendbuf, 4) == 0);
+		So(nng_setopt_int(pull3, nng_optid_recvbuf, 4) == 0);
+		So(nng_setopt_int(pull3, nng_optid_sendbuf, 4) == 0);
+
+		So(nng_msg_alloc(&abc, 0) == 0);
+		APPENDSTR(abc, "abc");
+		So(nng_msg_alloc(&def, 0) == 0);
+		APPENDSTR(def, "def");
+
+		usecs = 100000;
+		So(nng_setopt_usec(pull1, nng_optid_recvtimeo, usecs) == 0);
+		So(nng_setopt_usec(pull2, nng_optid_recvtimeo, usecs) == 0);
+		So(nng_setopt_usec(pull3, nng_optid_recvtimeo, usecs) == 0);
+		So(nng_listen(push, addr, NULL, 0) == 0);
+		So(nng_dial(pull1, addr, NULL, 0) == 0);
+		So(nng_dial(pull2, addr, NULL, 0) == 0);
+		So(nng_dial(pull3, addr, NULL, 0) == 0);
+		So(nng_shutdown(pull3) == 0);
+
+		// So pull3 might not be done accepting yet, but pull1
+		// and pull2 definitely are, because otherwise the
+		// server couldn't have gotten to the accept.  (The
+		// accept logic is single threaded.)  Let's wait a bit
+		// though, to ensure that stuff has settled.
+		nng_usleep(100000);
+
+		So(nng_sendmsg(push, abc, 0) == 0);
+		So(nng_sendmsg(push, def, 0) == 0);
+
+		abc = NULL;
+		def = NULL;
+
+		So(nng_recvmsg(pull1, &abc, 0) == 0);
+		CHECKSTR(abc, "abc");
+		So(nng_recvmsg(pull2, &def, 0) == 0);
+		CHECKSTR(def, "def");
+		nng_msg_free(abc);
+		nng_msg_free(def);
+
+		So(nng_recvmsg(pull1, &abc, 0) == NNG_ETIMEDOUT);
+		So(nng_recvmsg(pull2, &abc, 0) == NNG_ETIMEDOUT);
+	});
+});

--- a/tests/pipeline.c
+++ b/tests/pipeline.c
@@ -79,6 +79,8 @@ TestMain("PIPELINE (PUSH/PULL) pattern", {
 		So(nng_dial(what, addr, NULL, 0) == 0);
 		So(nng_shutdown(what) == 0);
 
+		nng_usleep(20000);
+
 		Convey("Push can send messages, and pull can recv", {
 			nng_msg *msg;
 

--- a/tests/pubsub.c
+++ b/tests/pubsub.c
@@ -77,10 +77,11 @@ TestMain("PUB/SUB pattern", {
 		// and the sub dial.  However, this creates a problem
 		// for our tests, since we can wind up trying to push
 		// data before the pipe is fully registered (the accept
-		// runs asynchronously.)  Doing the reverse here
-		// ensures that we won't lose data.
+		// runs asynchronously.)
 		So(nng_listen(sub, addr, NULL, 0) == 0);
 		So(nng_dial(pub, addr, NULL, 0) == 0);
+
+		nng_usleep(20000); // give time for connecting threads
 
 		Convey("Sub can subscribe", {
 			So(nng_setopt(

--- a/tests/pubsub.c
+++ b/tests/pubsub.c
@@ -83,35 +83,35 @@ TestMain("PUB/SUB pattern", {
 		So(nng_dial(pub, addr, NULL, 0) == 0);
 
 		Convey("Sub can subscribe", {
-			So(nng_setopt(sub, NNG_OPT_SUBSCRIBE, "ABC", 3) == 0);
-			So(nng_setopt(sub, NNG_OPT_SUBSCRIBE, "", 0) == 0);
+			So(nng_setopt(
+			       sub, nng_optid_sub_subscribe, "ABC", 3) == 0);
+			So(nng_setopt(sub, nng_optid_sub_subscribe, "", 0) ==
+			    0);
 			Convey("Unsubscribe works", {
-				So(nng_setopt(sub, NNG_OPT_UNSUBSCRIBE, "ABC",
-				       3) == 0);
-				So(nng_setopt(
-				       sub, NNG_OPT_UNSUBSCRIBE, "", 0) == 0);
+				So(nng_setopt(sub, nng_optid_sub_unsubscribe,
+				       "ABC", 3) == 0);
+				So(nng_setopt(sub, nng_optid_sub_unsubscribe,
+				       "", 0) == 0);
 
-				So(nng_setopt(sub, NNG_OPT_UNSUBSCRIBE, "",
-				       0) == NNG_ENOENT);
-				So(nng_setopt(sub, NNG_OPT_UNSUBSCRIBE,
+				So(nng_setopt(sub, nng_optid_sub_unsubscribe,
+				       "", 0) == NNG_ENOENT);
+				So(nng_setopt(sub, nng_optid_sub_unsubscribe,
 				       "HELLO", 0) == NNG_ENOENT);
 			});
 		});
 
 		Convey("Pub cannot subscribe", {
-			So(nng_setopt(pub, NNG_OPT_SUBSCRIBE, "", 0) ==
+			So(nng_setopt(pub, nng_optid_sub_subscribe, "", 0) ==
 			    NNG_ENOTSUP);
 		});
 
 		Convey("Subs can receive from pubs", {
 			nng_msg *msg;
-			uint64_t rtimeo;
 
-			So(nng_setopt(sub, NNG_OPT_SUBSCRIBE, "/some/",
+			So(nng_setopt(sub, nng_optid_sub_subscribe, "/some/",
 			       strlen("/some/")) == 0);
-			rtimeo = 50000; // 50ms
-			So(nng_setopt(sub, NNG_OPT_RCVTIMEO, &rtimeo,
-			       sizeof(rtimeo)) == 0);
+			So(nng_setopt_usec(sub, nng_optid_recvtimeo, 90000) ==
+			    0);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "/some/like/it/hot");
@@ -139,10 +139,9 @@ TestMain("PUB/SUB pattern", {
 
 		Convey("Subs without subsciptions don't receive", {
 
-			uint64_t rtimeo = 50000; // 50ms
 			nng_msg *msg;
-			So(nng_setopt(sub, NNG_OPT_RCVTIMEO, &rtimeo,
-			       sizeof(rtimeo)) == 0);
+			So(nng_setopt_usec(sub, nng_optid_recvtimeo, 90000) ==
+			    0);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "/some/don't/like/it");
@@ -152,14 +151,11 @@ TestMain("PUB/SUB pattern", {
 
 		Convey("Subs in raw receive", {
 
-			uint64_t rtimeo = 50000; // 500ms
-			int      raw    = 1;
 			nng_msg *msg;
 
-			So(nng_setopt(sub, NNG_OPT_RCVTIMEO, &rtimeo,
-			       sizeof(rtimeo)) == 0);
-			So(nng_setopt(sub, NNG_OPT_RAW, &raw, sizeof(raw)) ==
+			So(nng_setopt_usec(sub, nng_optid_recvtimeo, 90000) ==
 			    0);
+			So(nng_setopt_int(sub, nng_optid_raw, 1) == 0);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "/some/like/it/raw");

--- a/tests/scalability.c
+++ b/tests/scalability.c
@@ -115,4 +115,7 @@ Main({
 			}
 		});
 	});
+
+	free(clients);
+	free(results);
 });

--- a/tests/survey.c
+++ b/tests/survey.c
@@ -9,142 +9,133 @@
 //
 
 #include "convey.h"
-#include "core/nng_impl.h"
 #include "nng.h"
 
 #include <string.h>
+
+extern const char *nng_opt_surveyor_surveytime;
+extern int         nng_optid_surveyor_surveytime;
 
 #define APPENDSTR(m, s) nng_msg_append(m, s, strlen(s))
 #define CHECKSTR(m, s)                   \
 	So(nng_msg_len(m) == strlen(s)); \
 	So(memcmp(nng_msg_body(m), s, strlen(s)) == 0)
 
-Main({
+TestMain("SURVEY pattern", {
 	const char *addr = "inproc://test";
 
-	nni_init();
+	atexit(nng_fini);
 
-	Test("SURVEY pattern", {
-		Convey("We can create a SURVEYOR socket",
-		    {
-			    nng_socket surv;
+	Convey("We can create a SURVEYOR socket", {
+		nng_socket surv;
 
-			    So(nng_surveyor_open(&surv) == 0);
+		So(nng_surveyor_open(&surv) == 0);
 
-			    Reset({ nng_close(surv); });
+		Reset({ nng_close(surv); });
 
-			    Convey("Protocols match", {
-				    So(nng_protocol(surv) ==
-				        NNG_PROTO_SURVEYOR);
-				    So(nng_peer(surv) == NNG_PROTO_RESPONDENT);
-			    });
+		Convey("Surveytime option id works", {
+			int         opt;
+			const char *name;
+			opt = nng_option_lookup(nng_opt_surveyor_surveytime);
+			So(opt >= 0);
+			So(opt == nng_optid_surveyor_surveytime);
+			name = nng_option_name(opt);
+			So(name != NULL);
+			So(strcmp(name, nng_opt_surveyor_surveytime) == 0);
+		});
 
-			    Convey("Recv with no survey fails", {
-				    nng_msg *msg;
-				    So(nng_recvmsg(surv, &msg, 0) ==
-				        NNG_ESTATE);
-			    });
+		Convey("Protocols match", {
+			So(nng_protocol(surv) == NNG_PROTO_SURVEYOR);
+			So(nng_peer(surv) == NNG_PROTO_RESPONDENT);
+		});
 
-			    Convey("Survey without responder times out", {
-				    uint64_t expire = 50000;
-				    nng_msg *msg;
+		Convey("Recv with no survey fails", {
+			nng_msg *msg;
+			So(nng_recvmsg(surv, &msg, 0) == NNG_ESTATE);
+		});
 
-				    So(nng_setopt(surv, NNG_OPT_SURVEYTIME,
-				           &expire, sizeof(expire)) == 0);
-				    So(nng_msg_alloc(&msg, 0) == 0);
-				    So(nng_sendmsg(surv, msg, 0) == 0);
-				    So(nng_recvmsg(surv, &msg, 0) ==
-				        NNG_ETIMEDOUT);
-			    });
-		    })
+		Convey("Survey without responder times out", {
+			nng_msg *msg;
 
-		    Convey("We can create a RESPONDENT socket",
-		        {
-			        nng_socket resp;
-			        So(nng_respondent_open(&resp) == 0);
-
-			        Reset({ nng_close(resp); });
-
-			        Convey("Protocols match", {
-				        So(nng_protocol(resp) ==
-				            NNG_PROTO_RESPONDENT);
-				        So(nng_peer(resp) ==
-				            NNG_PROTO_SURVEYOR);
-			        });
-
-			        Convey("Send fails with no suvey", {
-				        nng_msg *msg;
-				        So(nng_msg_alloc(&msg, 0) == 0);
-				        So(nng_sendmsg(resp, msg, 0) ==
-				            NNG_ESTATE);
-				        nng_msg_free(msg);
-			        });
-		        })
-
-		        Convey("We can create a linked survey pair", {
-			        nng_socket surv;
-			        nng_socket resp;
-			        nng_socket sock;
-			        uint64_t   expire;
-
-			        So(nng_surveyor_open(&surv) == 0);
-			        So(nng_respondent_open(&resp) == 0);
-
-			        Reset({
-				        nng_close(surv);
-				        nng_close(resp);
-			        });
-
-			        expire = 50000;
-			        So(nng_setopt(surv, NNG_OPT_SURVEYTIME,
-			               &expire, sizeof(expire)) == 0);
-
-			        So(nng_listen(surv, addr, NULL, 0) == 0);
-			        So(nng_dial(resp, addr, NULL, 0) == 0);
-
-			        // We dial another socket as that will force
-			        // the earlier dial to have completed *fully*.
-			        // This is a hack that only works because our
-			        // listen logic is single threaded.
-			        So(nng_respondent_open(&sock) == 0);
-			        So(nng_dial(sock, addr, NULL, 0) == 0);
-			        nng_close(sock);
-
-			        Convey("Survey works", {
-				        nng_msg *msg;
-				        uint64_t rtimeo;
-
-				        So(nng_msg_alloc(&msg, 0) == 0);
-				        APPENDSTR(msg, "abc");
-				        So(nng_sendmsg(surv, msg, 0) == 0);
-				        msg = NULL;
-				        So(nng_recvmsg(resp, &msg, 0) == 0);
-				        CHECKSTR(msg, "abc");
-				        nng_msg_chop(msg, 3);
-				        APPENDSTR(msg, "def");
-				        So(nng_sendmsg(resp, msg, 0) == 0);
-				        msg = NULL;
-				        So(nng_recvmsg(surv, &msg, 0) == 0);
-				        CHECKSTR(msg, "def");
-				        nng_msg_free(msg);
-
-				        So(nng_recvmsg(surv, &msg, 0) ==
-				            NNG_ETIMEDOUT);
-
-				        Convey(
-				            "And goes to non-survey state", {
-					            rtimeo = 200000;
-					            So(nng_setopt(surv,
-					                   NNG_OPT_RCVTIMEO,
-					                   &rtimeo,
-					                   sizeof(rtimeo)) ==
-					                0);
-					            So(nng_recvmsg(surv, &msg,
-					                   0) == NNG_ESTATE);
-				            });
-			        });
-		        });
+			So(nng_setopt_usec(surv, nng_optid_surveyor_surveytime,
+			       50000) == 0);
+			So(nng_msg_alloc(&msg, 0) == 0);
+			So(nng_sendmsg(surv, msg, 0) == 0);
+			So(nng_recvmsg(surv, &msg, 0) == NNG_ETIMEDOUT);
+		});
 	});
 
-	nni_fini();
-})
+	Convey("We can create a RESPONDENT socket", {
+		nng_socket resp;
+		So(nng_respondent_open(&resp) == 0);
+
+		Reset({ nng_close(resp); });
+
+		Convey("Protocols match", {
+			So(nng_protocol(resp) == NNG_PROTO_RESPONDENT);
+			So(nng_peer(resp) == NNG_PROTO_SURVEYOR);
+		});
+
+		Convey("Send fails with no suvey", {
+			nng_msg *msg;
+			So(nng_msg_alloc(&msg, 0) == 0);
+			So(nng_sendmsg(resp, msg, 0) == NNG_ESTATE);
+			nng_msg_free(msg);
+		});
+	});
+
+	Convey("We can create a linked survey pair", {
+		nng_socket surv;
+		nng_socket resp;
+		nng_socket sock;
+
+		So(nng_surveyor_open(&surv) == 0);
+		So(nng_respondent_open(&resp) == 0);
+
+		Reset({
+			nng_close(surv);
+			nng_close(resp);
+		});
+
+		So(nng_setopt_usec(
+		       surv, nng_optid_surveyor_surveytime, 50000) == 0);
+		So(nng_listen(surv, addr, NULL, 0) == 0);
+		So(nng_dial(resp, addr, NULL, 0) == 0);
+
+		// We dial another socket as that will force
+		// the earlier dial to have completed *fully*.
+		// This is a hack that only works because our
+		// listen logic is single threaded.
+		So(nng_respondent_open(&sock) == 0);
+		So(nng_dial(sock, addr, NULL, 0) == 0);
+		nng_close(sock);
+
+		Convey("Survey works", {
+			nng_msg *msg;
+			uint64_t rtimeo;
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "abc");
+			So(nng_sendmsg(surv, msg, 0) == 0);
+			msg = NULL;
+			So(nng_recvmsg(resp, &msg, 0) == 0);
+			CHECKSTR(msg, "abc");
+			nng_msg_chop(msg, 3);
+			APPENDSTR(msg, "def");
+			So(nng_sendmsg(resp, msg, 0) == 0);
+			msg = NULL;
+			So(nng_recvmsg(surv, &msg, 0) == 0);
+			CHECKSTR(msg, "def");
+			nng_msg_free(msg);
+
+			So(nng_recvmsg(surv, &msg, 0) == NNG_ETIMEDOUT);
+
+			Convey("And goes to non-survey state", {
+				rtimeo = 200000;
+				So(nng_setopt_usec(surv, nng_optid_recvtimeo,
+				       200000) == 0);
+				So(nng_recvmsg(surv, &msg, 0) == NNG_ESTATE);
+			});
+		});
+	});
+});


### PR DESCRIPTION
This eliminates all the old #define's or enum values, making all
option IDs now totally dynamic, and providing well-known string
values for well-behaved applications.

We have added tests of some of these options, including lookups, and
so forth.  We have also fixed a few problems; including at least
one crasher bug when the timeouts on reconnect were zero.

Protocol specific options are now handled in the protocol.  We will
be moving the initialization for a few of those well known entities
to the protocol startup code, following the PAIRv1 pattern, later.

Applications must therefore not depend on the value of the integer IDs,
at least until the application has opened a socket of the appropriate
type.