### PR TITLE
fixes #84 Consider using msec for durations

### DIFF
--- a/perf/perf.c
+++ b/perf/perf.c
@@ -225,7 +225,7 @@ do_inproc_lat(int argc, char **argv)
 	nni_thr_run(&thr);
 
 	// Sleep a bit.
-	nng_usleep(100000);
+	nng_msleep(100);
 
 	latency_client("inproc://latency_test", ia.msgsize, ia.count);
 	nni_thr_fini(&thr);
@@ -297,9 +297,9 @@ latency_client(const char *addr, int msgsize, int trips)
 	nni_msg_free(msg);
 	nng_close(s);
 
-	total   = (float) (end - start);
-	latency = (total / (trips * 2));
-	printf("total time: %.3f [s]\n", total / 1000000.0);
+	total   = (float) ((end - start)) / 1000;
+	latency = ((float) ((total * 1000000)) / (trips * 2));
+	printf("total time: %.3f [s]\n", total);
 	printf("message size: %d [B]\n", msgsize);
 	printf("round trip count: %d\n", trips);
 	printf("average latency: %.3f [us]\n", latency);
@@ -339,7 +339,7 @@ latency_server(const char *addr, int msgsize, int trips)
 
 	// Wait a bit for things to drain... linger should do this.
 	// 100ms ought to be enough.
-	nni_usleep(100000);
+	nng_msleep(100);
 	nng_close(s);
 }
 
@@ -355,7 +355,7 @@ throughput_server(const char *addr, int msgsize, int count)
 	int        rv;
 	int        i;
 	uint64_t   start, end;
-	double     msgpersec, mbps, total;
+	float      msgpersec, mbps, total;
 
 	if ((rv = nng_pair_open(&s)) != 0) {
 		die("nng_socket: %s", nng_strerror(rv));
@@ -391,11 +391,10 @@ throughput_server(const char *addr, int msgsize, int count)
 	}
 	end = nni_clock();
 	nng_close(s);
-	total     = (end - start) / 1.0;
-	msgpersec = (count * 1000000.0) / total;
-	mbps      = (count * 8.0 * msgsize);
-	mbps /= total;
-	printf("total time: %.3f [s]\n", total / 1000000.0);
+	total     = (float) ((end - start)) / 1000;
+	msgpersec = (float) (count) / total;
+	mbps      = (float) (msgpersec * 8 * msgsize) / (1024 * 1024);
+	printf("total time: %.3f [s]\n", total);
 	printf("message size: %d [B]\n", msgsize);
 	printf("message count: %d\n", count);
 	printf("throughput: %.f [msg/s]\n", msgpersec);
@@ -447,6 +446,6 @@ throughput_client(const char *addr, int msgsize, int count)
 	}
 
 	// Wait 100msec for pipes to drain.
-	nni_usleep(100000);
+	nng_msleep(100);
 	nng_close(s);
 }

--- a/src/core/clock.c
+++ b/src/core/clock.c
@@ -16,7 +16,7 @@ nni_clock(void)
 }
 
 void
-nni_usleep(nni_duration usec)
+nni_msleep(nni_duration msec)
 {
-	nni_plat_usleep(usec);
+	nni_plat_sleep(msec);
 }

--- a/src/core/clock.h
+++ b/src/core/clock.h
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -14,6 +15,6 @@
 
 extern nni_time nni_clock(void);
 
-extern void nni_usleep(nni_duration usec);
+extern void nni_msleep(nni_duration);
 
 #endif // CORE_CLOCK_H

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -53,8 +53,8 @@ typedef struct nni_thr      nni_thr;
 typedef void (*nni_thr_func)(void *);
 
 typedef int      nni_signal;   // Wakeup channel.
-typedef uint64_t nni_time;     // Abs. time (usec).
-typedef int64_t  nni_duration; // Rel. time (usec).
+typedef uint64_t nni_time;     // Abs. time (ms).
+typedef int32_t  nni_duration; // Rel. time (ms).
 
 typedef struct nni_aio nni_aio;
 
@@ -76,7 +76,7 @@ typedef struct {
 // Some default timing things.
 #define NNI_TIME_NEVER ((nni_time) -1)
 #define NNI_TIME_ZERO ((nni_time) 0)
-#define NNI_SECOND (1000000)
+#define NNI_SECOND (1000)
 
 // Structure allocation conveniences.
 #define NNI_ALLOC_STRUCT(s) nni_alloc(sizeof(*s))

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -66,7 +66,7 @@ nni_device(nni_sock *sock1, nni_sock *sock2)
 {
 	nni_device_pair pair;
 	int             rv;
-	nni_time        never = NNI_TIME_NEVER;
+	nni_duration    never = -1;
 	size_t          sz;
 
 	memset(&pair, 0, sizeof(pair));

--- a/src/core/options.c
+++ b/src/core/options.c
@@ -14,7 +14,7 @@
 #include <string.h>
 
 int
-nni_chkopt_usec(const void *v, size_t sz)
+nni_chkopt_ms(const void *v, size_t sz)
 {
 	nni_duration val;
 	if (sz != sizeof(val)) {
@@ -56,7 +56,7 @@ nni_chkopt_size(const void *v, size_t sz, size_t minv, size_t maxv)
 }
 
 int
-nni_setopt_usec(nni_duration *dp, const void *v, size_t sz)
+nni_setopt_ms(nni_duration *dp, const void *v, size_t sz)
 {
 	nni_duration dur;
 
@@ -110,7 +110,7 @@ nni_setopt_size(size_t *sp, const void *v, size_t sz, size_t minv, size_t maxv)
 }
 
 int
-nni_getopt_usec(nni_duration u, void *val, size_t *sizep)
+nni_getopt_ms(nni_duration u, void *val, size_t *sizep)
 {
 	size_t sz = sizeof(u);
 

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -23,10 +23,10 @@ extern int nni_getopt_buf(nni_msgq *, void *, size_t *);
 
 // nni_setopt_duration sets the duration.  Durations must be legal,
 // either a positive value, 0, or -1 to indicate forever.
-extern int nni_setopt_usec(nni_duration *, const void *, size_t);
+extern int nni_setopt_ms(nni_duration *, const void *, size_t);
 
 // nni_getopt_duration gets the duration.
-extern int nni_getopt_usec(nni_duration, void *, size_t *);
+extern int nni_getopt_ms(nni_duration, void *, size_t *);
 
 // nni_setopt_int sets an integer, which must be between the minimum and
 // maximum values (inclusive).
@@ -61,7 +61,7 @@ extern int nni_getopt_size(size_t, void *, size_t *);
 // nni_getopt_fd obtains a notification file descriptor.
 extern int nni_getopt_fd(nni_sock *, nni_notifyfd *, int, void *, size_t *);
 
-extern int nni_chkopt_usec(const void *, size_t);
+extern int nni_chkopt_ms(const void *, size_t);
 extern int nni_chkopt_int(const void *, size_t, int, int);
 extern int nni_chkopt_size(const void *, size_t, size_t, size_t);
 

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -153,8 +153,8 @@ extern void nni_plat_thr_fini(nni_plat_thr *);
 // of using negative values for other purposes in the future.)
 extern nni_time nni_plat_clock(void);
 
-// nni_plat_usleep sleeps for the specified number of microseconds (at least).
-extern void nni_plat_usleep(nni_duration);
+// nni_plat_sleep sleeps for the specified number of milliseconds (at least).
+extern void nni_plat_sleep(nni_duration);
 
 //
 // Entropy Support

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -95,49 +95,49 @@ nni_sock_getopt_recvfd(nni_sock *s, void *buf, size_t *szp)
 static int
 nni_sock_setopt_recvtimeo(nni_sock *s, const void *buf, size_t sz)
 {
-	return (nni_setopt_usec(&s->s_rcvtimeo, buf, sz));
+	return (nni_setopt_ms(&s->s_rcvtimeo, buf, sz));
 }
 
 static int
 nni_sock_getopt_recvtimeo(nni_sock *s, void *buf, size_t *szp)
 {
-	return (nni_getopt_usec(s->s_rcvtimeo, buf, szp));
+	return (nni_getopt_ms(s->s_rcvtimeo, buf, szp));
 }
 
 static int
 nni_sock_setopt_sendtimeo(nni_sock *s, const void *buf, size_t sz)
 {
-	return (nni_setopt_usec(&s->s_sndtimeo, buf, sz));
+	return (nni_setopt_ms(&s->s_sndtimeo, buf, sz));
 }
 
 static int
 nni_sock_getopt_sendtimeo(nni_sock *s, void *buf, size_t *szp)
 {
-	return (nni_getopt_usec(s->s_sndtimeo, buf, szp));
+	return (nni_getopt_ms(s->s_sndtimeo, buf, szp));
 }
 
 static int
 nni_sock_setopt_reconnmint(nni_sock *s, const void *buf, size_t sz)
 {
-	return (nni_setopt_usec(&s->s_reconn, buf, sz));
+	return (nni_setopt_ms(&s->s_reconn, buf, sz));
 }
 
 static int
 nni_sock_getopt_reconnmint(nni_sock *s, void *buf, size_t *szp)
 {
-	return (nni_getopt_usec(s->s_reconn, buf, szp));
+	return (nni_getopt_ms(s->s_reconn, buf, szp));
 }
 
 static int
 nni_sock_setopt_reconnmaxt(nni_sock *s, const void *buf, size_t sz)
 {
-	return (nni_setopt_usec(&s->s_reconnmax, buf, sz));
+	return (nni_setopt_ms(&s->s_reconnmax, buf, sz));
 }
 
 static int
 nni_sock_getopt_reconnmaxt(nni_sock *s, void *buf, size_t *szp)
 {
-	return (nni_getopt_usec(s->s_reconnmax, buf, szp));
+	return (nni_getopt_ms(s->s_reconnmax, buf, szp));
 }
 
 static int
@@ -500,8 +500,8 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 		return (NNG_ENOMEM);
 	}
 	s->s_linger          = 0;
-	s->s_sndtimeo        = NNI_TIME_NEVER;
-	s->s_rcvtimeo        = NNI_TIME_NEVER;
+	s->s_sndtimeo        = -1;
+	s->s_rcvtimeo        = -1;
 	s->s_closing         = 0;
 	s->s_reconn          = NNI_SECOND;
 	s->s_reconnmax       = 0;
@@ -1026,7 +1026,7 @@ nni_sock_setopt(nni_sock *s, const char *name, const void *val, size_t size)
 	// was found, or even if a transport rejected one of the settings.
 	if ((rv == NNG_ENOTSUP) || (rv == 0)) {
 		if ((strcmp(name, NNG_OPT_LINGER) == 0)) {
-			rv = nni_chkopt_usec(val, size);
+			rv = nni_chkopt_ms(val, size);
 		} else if (strcmp(name, NNG_OPT_RECVMAXSZ) == 0) {
 			// just a sanity test on the size; it also ensures that
 			// a size can be set even with no transport configured.
@@ -1090,7 +1090,7 @@ nni_sock_setopt(nni_sock *s, const char *name, const void *val, size_t size)
 	// will already have had a chance to veto this.
 
 	if (strcmp(name, NNG_OPT_LINGER) == 0) {
-		rv = nni_setopt_usec(&s->s_linger, val, size);
+		rv = nni_setopt_ms(&s->s_linger, val, size);
 	}
 
 	if (rv == 0) {

--- a/src/nng.c
+++ b/src/nng.c
@@ -389,7 +389,7 @@ nng_dialer_setopt_size(nng_dialer id, const char *name, size_t val)
 }
 
 int
-nng_dialer_setopt_usec(nng_dialer id, const char *name, uint64_t val)
+nng_dialer_setopt_ms(nng_dialer id, const char *name, nng_duration val)
 {
 	return (nng_dialer_setopt(id, name, &val, sizeof(val)));
 }
@@ -428,9 +428,10 @@ nng_dialer_getopt_uint64(nng_dialer id, const char *name, uint64_t *valp)
 }
 
 int
-nng_dialer_getopt_usec(nng_dialer id, const char *name, uint64_t *valp)
+nng_dialer_getopt_ms(nng_dialer id, const char *name, nng_duration *valp)
 {
-	return (nng_dialer_getopt_uint64(id, name, valp));
+	size_t sz = sizeof(*valp);
+	return (nng_dialer_getopt(id, name, valp, &sz));
 }
 
 int
@@ -453,7 +454,7 @@ nng_listener_setopt_size(nng_listener id, const char *name, size_t val)
 }
 
 int
-nng_listener_setopt_usec(nng_listener id, const char *name, uint64_t val)
+nng_listener_setopt_ms(nng_listener id, const char *name, nng_duration val)
 {
 	return (nng_listener_setopt(id, name, &val, sizeof(val)));
 }
@@ -492,9 +493,10 @@ nng_listener_getopt_uint64(nng_listener id, const char *name, uint64_t *valp)
 }
 
 int
-nng_listener_getopt_usec(nng_listener id, const char *name, uint64_t *valp)
+nng_listener_getopt_ms(nng_listener id, const char *name, nng_duration *valp)
 {
-	return (nng_listener_getopt_uint64(id, name, valp));
+	size_t sz = sizeof(*valp);
+	return (nng_listener_getopt(id, name, valp, &sz));
 }
 
 static int
@@ -570,7 +572,7 @@ nng_setopt_size(nng_socket sid, const char *name, size_t val)
 }
 
 int
-nng_setopt_usec(nng_socket sid, const char *name, uint64_t val)
+nng_setopt_ms(nng_socket sid, const char *name, nng_duration val)
 {
 	return (nng_setopt(sid, name, &val, sizeof(val)));
 }
@@ -603,9 +605,10 @@ nng_getopt_uint64(nng_socket sid, const char *name, uint64_t *valp)
 }
 
 int
-nng_getopt_usec(nng_socket sid, const char *name, uint64_t *valp)
+nng_getopt_ms(nng_socket sid, const char *name, nng_duration *valp)
 {
-	return (nng_getopt_uint64(sid, name, valp));
+	size_t sz = sizeof(*valp);
+	return (nng_getopt(sid, name, valp, &sz));
 }
 
 nng_notify *
@@ -775,9 +778,10 @@ nng_pipe_getopt_uint64(nng_pipe id, const char *name, uint64_t *valp)
 }
 
 int
-nng_pipe_getopt_usec(nng_pipe id, const char *name, uint64_t *valp)
+nng_pipe_getopt_ms(nng_pipe id, const char *name, nng_duration *valp)
 {
-	return (nng_pipe_getopt_uint64(id, name, valp));
+	size_t sz = sizeof(*valp);
+	return (nng_pipe_getopt(id, name, valp, &sz));
 }
 
 int
@@ -1042,9 +1046,9 @@ nng_stat_value(nng_stat *stat)
 // API, and applications should refrain from their use.
 
 void
-nng_usleep(uint64_t usec)
+nng_msleep(nng_duration ms)
 {
-	nni_usleep(usec);
+	nni_msleep(ms);
 }
 
 uint64_t

--- a/src/nng.h
+++ b/src/nng.h
@@ -46,6 +46,7 @@ typedef uint32_t            nng_socket;
 typedef uint32_t            nng_dialer;
 typedef uint32_t            nng_listener;
 typedef uint32_t            nng_pipe;
+typedef int32_t             nng_duration; // in milliseconds
 typedef struct nng_msg      nng_msg;
 typedef struct nng_event    nng_event;
 typedef struct nng_notify   nng_notify;
@@ -88,14 +89,14 @@ NNG_DECL uint16_t nng_peer(nng_socket);
 // nng_setopt sets an option for a specific socket.
 NNG_DECL int nng_setopt(nng_socket, const char *, const void *, size_t);
 NNG_DECL int nng_setopt_int(nng_socket, const char *, int);
-NNG_DECL int nng_setopt_usec(nng_socket, const char *, uint64_t);
+NNG_DECL int nng_setopt_ms(nng_socket, const char *, nng_duration);
 NNG_DECL int nng_setopt_size(nng_socket, const char *, size_t);
 NNG_DECL int nng_setopt_uint64(nng_socket, const char *, uint64_t);
 
 // nng_socket_getopt obtains the option for a socket.
 NNG_DECL int nng_getopt(nng_socket, const char *, void *, size_t *);
 NNG_DECL int nng_getopt_int(nng_socket, const char *, int *);
-NNG_DECL int nng_getopt_usec(nng_socket, const char *, uint64_t *);
+NNG_DECL int nng_getopt_ms(nng_socket, const char *, nng_duration *);
 NNG_DECL int nng_getopt_size(nng_socket, const char *, size_t *);
 NNG_DECL int nng_getopt_uint64(nng_socket, const char *, uint64_t *);
 
@@ -203,7 +204,7 @@ NNG_DECL int nng_listener_close(nng_listener);
 // dialer options may not be altered on a running dialer.
 NNG_DECL int nng_dialer_setopt(nng_dialer, const char *, const void *, size_t);
 NNG_DECL int nng_dialer_setopt_int(nng_dialer, const char *, int);
-NNG_DECL int nng_dialer_setopt_usec(nng_dialer, const char *, uint64_t);
+NNG_DECL int nng_dialer_setopt_ms(nng_dialer, const char *, nng_duration);
 NNG_DECL int nng_dialer_setopt_size(nng_dialer, const char *, size_t);
 NNG_DECL int nng_dialer_setopt_uint64(nng_dialer, const char *, uint64_t);
 
@@ -212,7 +213,7 @@ NNG_DECL int nng_dialer_setopt_uint64(nng_dialer, const char *, uint64_t);
 // even if they were set on the socket.
 NNG_DECL int nng_dialer_getopt(nng_dialer, const char *, void *, size_t *);
 NNG_DECL int nng_dialer_getopt_int(nng_dialer, const char *, int *);
-NNG_DECL int nng_dialer_getopt_usec(nng_dialer, const char *, uint64_t *);
+NNG_DECL int nng_dialer_getopt_ms(nng_dialer, const char *, nng_duration *);
 NNG_DECL int nng_dialer_getopt_size(nng_dialer, const char *, size_t *);
 NNG_DECL int nng_dialer_getopt_uint64(nng_dialer, const char *, uint64_t *);
 
@@ -223,7 +224,7 @@ NNG_DECL int nng_dialer_getopt_uint64(nng_dialer, const char *, uint64_t *);
 NNG_DECL int nng_listener_setopt(
     nng_listener, const char *, const void *, size_t);
 NNG_DECL int nng_listener_setopt_int(nng_listener, const char *, int);
-NNG_DECL int nng_listener_setopt_usec(nng_listener, const char *, uint64_t);
+NNG_DECL int nng_listener_setopt_ms(nng_listener, const char *, nng_duration);
 NNG_DECL int nng_listener_setopt_size(nng_listener, const char *, size_t);
 NNG_DECL int nng_listener_setopt_uint64(nng_listener, const char *, uint64_t);
 
@@ -232,7 +233,8 @@ NNG_DECL int nng_listener_setopt_uint64(nng_listener, const char *, uint64_t);
 // even if they were set on the socket.
 NNG_DECL int nng_listener_getopt(nng_listener, const char *, void *, size_t *);
 NNG_DECL int nng_listener_getopt_int(nng_listener, const char *, int *);
-NNG_DECL int nng_listener_getopt_usec(nng_listener, const char *, uint64_t *);
+NNG_DECL int nng_listener_getopt_ms(
+    nng_listener, const char *, nng_duration *);
 NNG_DECL int nng_listener_getopt_size(nng_listener, const char *, size_t *);
 NNG_DECL int nng_listener_getopt_uint64(
     nng_listener, const char *, uint64_t *);
@@ -330,7 +332,7 @@ NNG_DECL const char *nng_option_name(int);
 // is associated with an invalid or untrusted remote peer.
 NNG_DECL int nng_pipe_getopt(nng_pipe, const char *, void *, size_t *);
 NNG_DECL int nng_pipe_getopt_int(nng_pipe, const char *, int *);
-NNG_DECL int nng_pipe_getopt_usec(nng_pipe, const char *, uint64_t *);
+NNG_DECL int nng_pipe_getopt_ms(nng_pipe, const char *, nng_duration *);
 NNG_DECL int nng_pipe_getopt_size(nng_pipe, const char *, size_t *);
 NNG_DECL int nng_pipe_getopt_uint64(nng_pipe, const char *, uint64_t *);
 NNG_DECL int nng_pipe_close(nng_pipe);
@@ -517,11 +519,8 @@ NNG_DECL int nng_device(nng_socket, nng_socket);
 
 #ifdef NNG_PRIVATE
 
-// Sleep for specified usecs.
-NNG_DECL void nng_usleep(uint64_t);
-
-// Return usecs since some arbitrary time in past.
-NNG_DECL uint64_t nng_clock(void);
+// Sleep for specified msecs.
+NNG_DECL void nng_msleep(nng_duration);
 
 // Create and start a thread.
 NNG_DECL int nng_thread_create(void **, void (*)(void *), void *);

--- a/src/platform/posix/posix_clock.c
+++ b/src/platform/posix/posix_clock.c
@@ -1,5 +1,6 @@
 //
-// Copyright 2016 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -23,28 +24,28 @@ nni_time
 nni_plat_clock(void)
 {
 	struct timespec ts;
-	nni_time        usec;
+	nni_time        msec;
 
 	if (clock_gettime(NNG_USE_CLOCKID, &ts) != 0) {
-		/* This should never ever occur. */
+		// This should never ever occur.
 		nni_panic("clock_gettime failed: %s", strerror(errno));
 	}
 
-	usec = ts.tv_sec;
-	usec *= 1000000;
-	usec += (ts.tv_nsec / 1000);
-	return (usec);
+	msec = ts.tv_sec;
+	msec *= 1000;
+	msec += (ts.tv_nsec / 1000000);
+	return (msec);
 }
 
 void
-nni_plat_usleep(nni_duration usec)
+nni_plat_sleep(nni_duration ms)
 {
 	struct timespec ts;
 
-	ts.tv_sec  = usec / 1000000;
-	ts.tv_nsec = (usec % 1000000) * 1000;
+	ts.tv_sec  = ms / 1000;
+	ts.tv_nsec = (ms % 1000) * 1000000;
 
-	/* Do this in a loop, so that interrupts don't actually wake us. */
+	// Do this in a loop, so that interrupts don't actually wake us.
 	while (ts.tv_sec || ts.tv_nsec) {
 		if (nanosleep(&ts, &ts) == 0) {
 			break;
@@ -67,10 +68,10 @@ nni_plat_usleep(nni_duration usec)
 #include <pthread.h>
 #include <sys/time.h>
 
-nni_time
+static nni_time
 nni_plat_clock(void)
 {
-	nni_time usec;
+	nni_time ms;
 
 	struct timeval tv;
 
@@ -78,14 +79,14 @@ nni_plat_clock(void)
 		nni_panic("gettimeofday failed: %s", strerror(errno));
 	}
 
-	usec = tv.tv_sec;
-	usec *= 1000000;
-	usec += tv.tv_usec;
-	return (usec);
+	ms = tv.tv_sec;
+	msec *= 1000;
+	msec += (tv.tv_usec / 1000);
+	return (msec);
 }
 
 void
-nni_plat_usleep(nni_duration usec)
+nni_plat_sleep(nni_duration ms)
 {
 	// So probably there is no nanosleep.  We could in theory use
 	// pthread condition variables, but that means doing memory
@@ -93,8 +94,7 @@ nni_plat_usleep(nni_duration usec)
 	// might be preferring the use of another threading package.
 	// Additionally, use of pthreads means that we cannot use
 	// relative times in a clock_settime safe manner.
-	// So we can use poll() instead, which is rather coarse, but
-	// pretty much guaranteed to work.
+	// So we can use poll() instead.
 	struct pollfd pfd;
 	nni_time      now;
 	nni_time      expire;
@@ -105,16 +105,11 @@ nni_plat_usleep(nni_duration usec)
 	pfd.fd     = -1;
 	pfd.events = 0;
 
-	now    = nni_clock();
-	expire = now + usec;
+	now    = nni_plat_clock(); // XXX: until nni_plat_clock returns ms.
+	expire = now + ms;
 
 	while (now < expire) {
-		// In theory we could round up to a whole number of msec,
-		// but under the covers poll already does some rounding up,
-		// and the loop above guarantees that we will not bail out
-		// early.  So this gives us a better chance to avoid adding
-		// nearly an extra unneeded millisecond to the wait.
-		(void) poll(&pfd, 0, (int) ((expire - now) / 1000));
+		(void) poll(&pfd, 0, (int) (expire - now));
 		now = nni_clock();
 	}
 }

--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -354,8 +354,8 @@ nni_plat_cv_until(nni_plat_cv *cv, nni_time until)
 	NNI_ASSERT(cv->mtx->owner == pthread_self());
 
 	// Our caller has already guaranteed a sane value for until.
-	ts.tv_sec  = until / 1000000;
-	ts.tv_nsec = (until % 1000000) * 1000;
+	ts.tv_sec  = until / 1000;
+	ts.tv_nsec = (until % 1000) * 1000000;
 
 	if (cv->fallback) {
 		rv = nni_plat_cv_until_fallback(cv, &ts);

--- a/src/platform/windows/win_clock.c
+++ b/src/platform/windows/win_clock.c
@@ -1,5 +1,6 @@
 //
-// Copyright 2016 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -15,17 +16,13 @@ nni_time
 nni_plat_clock(void)
 {
 	// We are limited by the system clock, but that is ok.
-	return (GetTickCount64() * 1000);
+	return (GetTickCount64());
 }
 
 void
-nni_plat_usleep(nni_duration dur)
+nni_plat_sleep(nni_duration dur)
 {
 	uint64_t exp;
-
-	// Convert duration to msec, rounding up.
-	dur += 999;
-	dur /= 1000;
 
 	exp = (uint64_t) GetTickCount64() + dur;
 

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -91,8 +91,7 @@ nni_plat_cv_until(nni_plat_cv *cv, nni_time until)
 	if (now > until) {
 		msec = 0;
 	} else {
-		// times are in usec, but win32 wants millis
-		msec = (DWORD)(((until - now) + 999) / 1000);
+		msec = (DWORD)(until - now);
 	}
 
 	ok = SleepConditionVariableSRW(&cv->cv, cv->srl, msec, 0);

--- a/src/protocol/reqrep/req.c
+++ b/src/protocol/reqrep/req.c
@@ -282,14 +282,14 @@ static int
 req_sock_setopt_resendtime(void *arg, const void *buf, size_t sz)
 {
 	req_sock *s = arg;
-	return (nni_setopt_usec(&s->retry, buf, sz));
+	return (nni_setopt_ms(&s->retry, buf, sz));
 }
 
 static int
 req_sock_getopt_resendtime(void *arg, void *buf, size_t *szp)
 {
 	req_sock *s = arg;
-	return (nni_getopt_usec(s->retry, buf, szp));
+	return (nni_getopt_ms(s->retry, buf, szp));
 }
 
 // Raw and cooked mode differ in the way they send messages out.

--- a/src/protocol/survey/survey.c
+++ b/src/protocol/survey/survey.c
@@ -292,14 +292,14 @@ static int
 surv_sock_setopt_surveytime(void *arg, const void *buf, size_t sz)
 {
 	surv_sock *s = arg;
-	return (nni_setopt_usec(&s->survtime, buf, sz));
+	return (nni_setopt_ms(&s->survtime, buf, sz));
 }
 
 static int
 surv_sock_getopt_surveytime(void *arg, void *buf, size_t *szp)
 {
 	surv_sock *s = arg;
-	return (nni_getopt_usec(s->survtime, buf, szp));
+	return (nni_getopt_ms(s->survtime, buf, szp));
 }
 
 static void

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -800,16 +800,16 @@ nni_tcp_ep_setopt_linger(void *arg, const void *v, size_t sz)
 {
 	nni_tcp_ep *ep = arg;
 	if (ep == NULL) {
-		return (nni_chkopt_usec(v, sz));
+		return (nni_chkopt_ms(v, sz));
 	}
-	return (nni_setopt_usec(&ep->linger, v, sz));
+	return (nni_setopt_ms(&ep->linger, v, sz));
 }
 
 static int
 nni_tcp_ep_getopt_linger(void *arg, void *v, size_t *szp)
 {
 	nni_tcp_ep *ep = arg;
-	return (nni_getopt_usec(ep->linger, v, szp));
+	return (nni_getopt_ms(ep->linger, v, szp));
 }
 
 static nni_tran_pipe_option nni_tcp_pipe_options[] = {

--- a/src/transport/zerotier/zerotier.h
+++ b/src/transport/zerotier/zerotier.h
@@ -81,7 +81,7 @@
 // is sent.  This will be done up to ping-count times.  If no traffic from
 // the remote peer is seen after all ping requests are sent, then the peer
 // is assumed to be dead or offline, and the session is closed.  The
-// NNG_OPT_ZT_PING_TIME is a duration (usec, stored as an nng_duration, and
+// NNG_OPT_ZT_PING_TIME is a duration (msec, stored as an nng_duration, and
 // NNG_OPT_ZT_PING_COUNT is an integer.)  This ping process can be disabled
 // by setting either ping-time or ping-count to zero.
 #define NNG_OPT_ZT_PING_TIME "zt:ping-time"

--- a/tests/bus.c
+++ b/tests/bus.c
@@ -37,10 +37,10 @@ TestMain("BUS pattern", {
 	});
 
 	Convey("We can create a linked BUS topology", {
-		nng_socket bus1;
-		nng_socket bus2;
-		nng_socket bus3;
-		uint64_t   rtimeo;
+		nng_socket   bus1;
+		nng_socket   bus2;
+		nng_socket   bus3;
+		nng_duration rtimeo;
 
 		So(nng_bus_open(&bus1) == 0);
 		So(nng_bus_open(&bus2) == 0);
@@ -56,10 +56,10 @@ TestMain("BUS pattern", {
 		So(nng_dial(bus2, addr, NULL, 0) == 0);
 		So(nng_dial(bus3, addr, NULL, 0) == 0);
 
-		rtimeo = 50000;
-		So(nng_setopt_usec(bus1, NNG_OPT_RECVTIMEO, rtimeo) == 0);
-		So(nng_setopt_usec(bus2, NNG_OPT_RECVTIMEO, rtimeo) == 0);
-		So(nng_setopt_usec(bus3, NNG_OPT_RECVTIMEO, rtimeo) == 0);
+		rtimeo = 50;
+		So(nng_setopt_ms(bus1, NNG_OPT_RECVTIMEO, rtimeo) == 0);
+		So(nng_setopt_ms(bus2, NNG_OPT_RECVTIMEO, rtimeo) == 0);
+		So(nng_setopt_ms(bus3, NNG_OPT_RECVTIMEO, rtimeo) == 0);
 
 		Convey("Messages delivered", {
 			nng_msg *msg;

--- a/tests/compat_bug777.c
+++ b/tests/compat_bug777.c
@@ -1,5 +1,6 @@
 /*
-    Copyright 2016 Garrett D'Amore <garrett@damore.org>
+    Copyright 2017 Garrett D'Amore <garrett@damore.org>
+    Copyright 2017 Capitar IT Group BV <info@capitar.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -34,7 +35,7 @@ int main (int argc, const char *argv[])
     test_bind (sb, "inproc://pair");
     sc1 = test_socket (AF_SP, NN_PAIR);
     test_connect (sc1, "inproc://pair");
-    nng_usleep(100000);
+    nn_sleep (100);
     sc2 = test_socket (AF_SP, NN_PAIR);
     test_connect (sc2, "inproc://pair");
 
@@ -45,4 +46,3 @@ int main (int argc, const char *argv[])
     test_recv (sb, "THERE");
     return 0;
 }
-

--- a/tests/compat_reqrep.c
+++ b/tests/compat_reqrep.c
@@ -1,5 +1,7 @@
 /*
     Copyright (c) 2012 Martin Sustrik  All rights reserved.
+    Copyright 2017 Garrett D'Amore <garrett@damore.org>
+    Copyright 2017 Capitar IT Group BV <info@capitar.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"),
@@ -25,8 +27,6 @@
 #include "compat_testutil.h"
 
 #define SOCKET_ADDRESS "inproc://test"
-
-extern void nng_usleep(uint64_t);
 
 int main ()
 {
@@ -75,7 +75,7 @@ int main ()
     rep1 = test_socket (AF_SP, NN_REP);
     test_connect (rep1, SOCKET_ADDRESS);
 
-    nng_usleep(10000);  // ensure rep1 binds before rep2
+    nn_sleep(10);  // ensure rep1 binds before rep2
 
     rep2 = test_socket (AF_SP, NN_REP);
     test_connect (rep2, SOCKET_ADDRESS);
@@ -86,7 +86,7 @@ int main ()
     test_setsockopt (rep2, NN_SOL_SOCKET, NN_RCVTIMEO, &timeo, sizeof (timeo));
 
     // Give time for connections to settle -- required for LB stuff.
-    nng_usleep(100000);
+    nn_sleep(100);
 
     test_send (req1, "ABC");
     test_recv (rep1, "ABC");
@@ -148,7 +148,7 @@ int main ()
     rep1 = test_socket (AF_SP, NN_REP);
     test_connect (rep1, SOCKET_ADDRESS);
     rep2 = test_socket (AF_SP, NN_REP);
-    nng_usleep(10000); // give time for rep1 to connect
+    nn_sleep (10); // give time for rep1 to connect
     test_connect (rep2, SOCKET_ADDRESS);
 
     timeo = 500; // Was 200, but Windows occasionally fails at that rate.

--- a/tests/compat_testutil.h
+++ b/tests/compat_testutil.h
@@ -222,10 +222,10 @@ test_addr_from(char *out, const char *proto, const char *ip, int port)
 }
 
 void
-nn_sleep(uint64_t msec)
+nn_sleep(int32_t msec)
 {
-	void nng_usleep(uint64_t);
-	nng_usleep(msec * 1000);
+	void nng_msleep(int32_t);
+	nng_msleep(msec);
 }
 
 struct nn_thread {

--- a/tests/device.c
+++ b/tests/device.c
@@ -31,6 +31,8 @@ dodev(void *arg)
 	nng_device(d->s1, d->s2);
 }
 
+#define SECOND(x) ((x) *1000)
+
 Main({
 
 	Test("PAIRv1 device", {
@@ -38,13 +40,13 @@ Main({
 		const char *addr2 = "inproc://dev2";
 
 		Convey("We can create a PAIRv1 device", {
-			nng_socket dev1;
-			nng_socket dev2;
-			nng_socket end1;
-			nng_socket end2;
-			uint64_t   tmo;
-			nng_msg *  msg;
-			void *     thr;
+			nng_socket   dev1;
+			nng_socket   dev2;
+			nng_socket   end1;
+			nng_socket   end2;
+			nng_duration tmo;
+			nng_msg *    msg;
+			void *       thr;
 
 			So(nng_pair1_open(&dev1) == 0);
 			So(nng_pair1_open(&dev2) == 0);
@@ -72,11 +74,11 @@ Main({
 			So(nng_dial(end1, addr1, NULL, 0) == 0);
 			So(nng_dial(end2, addr2, NULL, 0) == 0);
 
-			tmo = 1000000;
-			So(nng_setopt_usec(end1, NNG_OPT_RECVTIMEO, tmo) == 0);
-			So(nng_setopt_usec(end2, NNG_OPT_RECVTIMEO, tmo) == 0);
+			tmo = SECOND(1);
+			So(nng_setopt_ms(end1, NNG_OPT_RECVTIMEO, tmo) == 0);
+			So(nng_setopt_ms(end2, NNG_OPT_RECVTIMEO, tmo) == 0);
 
-			nng_usleep(100000);
+			nng_msleep(100);
 			Convey("Device can send and receive", {
 
 				So(nng_msg_alloc(&msg, 0) == 0);

--- a/tests/event.c
+++ b/tests/event.c
@@ -1,5 +1,6 @@
 //
 // Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -103,7 +104,7 @@ TestMain("Event Handling", {
 		So(nng_dial(sock2, addr, NULL, 0) == 0);
 
 		// Let everything connect.
-		nng_usleep(100000);
+		nng_msleep(100);
 
 		Convey("We can register callbacks", {
 			So((notify1 = nng_setnotify(sock1, NNG_EV_CAN_SND,
@@ -125,7 +126,7 @@ TestMain("Event Handling", {
 				// this.  Probably the msgq needs to
 				// toggle on reads.
 
-				// nng_usleep(20000);
+				// nng_msleep(20);
 
 				// So(nng_recvmsg(sock2, &msg, 0) ==
 				// 0);
@@ -134,7 +135,7 @@ TestMain("Event Handling", {
 				// nng_msg_free(msg);
 
 				// The notify runs async...
-				nng_usleep(100000);
+				nng_msleep(100);
 
 				So(evcnt1.writeable == 1);
 				So(evcnt2.readable == 1);

--- a/tests/pipeline.c
+++ b/tests/pipeline.c
@@ -16,6 +16,7 @@
 #define CHECKSTR(m, s)                   \
 	So(nng_msg_len(m) == strlen(s)); \
 	So(memcmp(nng_msg_body(m), s, strlen(s)) == 0)
+#define MILLISECOND(x) (x)
 
 TestMain("PIPELINE (PUSH/PULL) pattern", {
 	atexit(nng_fini);
@@ -80,7 +81,7 @@ TestMain("PIPELINE (PUSH/PULL) pattern", {
 		So(nng_dial(what, addr, NULL, 0) == 0);
 		So(nng_shutdown(what) == 0);
 
-		nng_usleep(20000);
+		nng_msleep(20);
 
 		Convey("Push can send messages, and pull can recv", {
 			nng_msg *msg;
@@ -97,13 +98,13 @@ TestMain("PIPELINE (PUSH/PULL) pattern", {
 	});
 
 	Convey("Load balancing", {
-		nng_msg *  abc;
-		nng_msg *  def;
-		uint64_t   usecs;
-		nng_socket push;
-		nng_socket pull1;
-		nng_socket pull2;
-		nng_socket pull3;
+		nng_msg *    abc;
+		nng_msg *    def;
+		nng_duration msecs;
+		nng_socket   push;
+		nng_socket   pull1;
+		nng_socket   pull2;
+		nng_socket   pull3;
 
 		So(nng_push_open(&push) == 0);
 		So(nng_pull_open(&pull1) == 0);
@@ -137,10 +138,10 @@ TestMain("PIPELINE (PUSH/PULL) pattern", {
 		So(nng_msg_alloc(&def, 0) == 0);
 		APPENDSTR(def, "def");
 
-		usecs = 100000;
-		So(nng_setopt_usec(pull1, NNG_OPT_RECVTIMEO, usecs) == 0);
-		So(nng_setopt_usec(pull2, NNG_OPT_RECVTIMEO, usecs) == 0);
-		So(nng_setopt_usec(pull3, NNG_OPT_RECVTIMEO, usecs) == 0);
+		msecs = MILLISECOND(100);
+		So(nng_setopt_ms(pull1, NNG_OPT_RECVTIMEO, msecs) == 0);
+		So(nng_setopt_ms(pull2, NNG_OPT_RECVTIMEO, msecs) == 0);
+		So(nng_setopt_ms(pull3, NNG_OPT_RECVTIMEO, msecs) == 0);
 		So(nng_listen(push, addr, NULL, 0) == 0);
 		So(nng_dial(pull1, addr, NULL, 0) == 0);
 		So(nng_dial(pull2, addr, NULL, 0) == 0);
@@ -152,7 +153,7 @@ TestMain("PIPELINE (PUSH/PULL) pattern", {
 		// server couldn't have gotten to the accept.  (The
 		// accept logic is single threaded.)  Let's wait a bit
 		// though, to ensure that stuff has settled.
-		nng_usleep(100000);
+		nng_msleep(100);
 
 		So(nng_sendmsg(push, abc, 0) == 0);
 		So(nng_sendmsg(push, def, 0) == 0);

--- a/tests/pollfd.c
+++ b/tests/pollfd.c
@@ -45,10 +45,8 @@ TestMain("Poll FDs", {
 			nng_close(s2);
 		});
 		So(nng_listen(s1, "inproc://yeahbaby", NULL, 0) == 0);
-		nng_usleep(50000);
-
 		So(nng_dial(s2, "inproc://yeahbaby", NULL, 0) == 0);
-		nng_usleep(50000);
+		nng_msleep(50);
 
 		Convey("We can get a recv FD", {
 			int    fd;

--- a/tests/pubsub.c
+++ b/tests/pubsub.c
@@ -81,7 +81,7 @@ TestMain("PUB/SUB pattern", {
 		So(nng_listen(sub, addr, NULL, 0) == 0);
 		So(nng_dial(pub, addr, NULL, 0) == 0);
 
-		nng_usleep(20000); // give time for connecting threads
+		nng_msleep(20); // give time for connecting threads
 
 		Convey("Sub can subscribe", {
 			So(nng_setopt(sub, NNG_OPT_SUB_SUBSCRIBE, "ABC", 3) ==
@@ -110,8 +110,7 @@ TestMain("PUB/SUB pattern", {
 
 			So(nng_setopt(sub, NNG_OPT_SUB_SUBSCRIBE, "/some/",
 			       strlen("/some/")) == 0);
-			So(nng_setopt_usec(sub, NNG_OPT_RECVTIMEO, 90000) ==
-			    0);
+			So(nng_setopt_ms(sub, NNG_OPT_RECVTIMEO, 90) == 0);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "/some/like/it/hot");
@@ -140,8 +139,7 @@ TestMain("PUB/SUB pattern", {
 		Convey("Subs without subsciptions don't receive", {
 
 			nng_msg *msg;
-			So(nng_setopt_usec(sub, NNG_OPT_RECVTIMEO, 90000) ==
-			    0);
+			So(nng_setopt_ms(sub, NNG_OPT_RECVTIMEO, 90) == 0);
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "/some/don't/like/it");
@@ -153,8 +151,7 @@ TestMain("PUB/SUB pattern", {
 
 			nng_msg *msg;
 
-			So(nng_setopt_usec(sub, NNG_OPT_RECVTIMEO, 90000) ==
-			    0);
+			So(nng_setopt_ms(sub, NNG_OPT_RECVTIMEO, 90) == 0);
 			So(nng_setopt_int(sub, NNG_OPT_RAW, 1) == 0);
 
 			So(nng_msg_alloc(&msg, 0) == 0);

--- a/tests/reconnect.c
+++ b/tests/reconnect.c
@@ -32,18 +32,18 @@ TestMain("Reconnect works", {
 			nng_close(pull);
 		});
 
-		So(nng_setopt_usec(pull, NNG_OPT_RECONNMINT, 10000) == 0);
-		So(nng_setopt_usec(pull, NNG_OPT_RECONNMAXT, 10000) == 0);
+		So(nng_setopt_ms(pull, NNG_OPT_RECONNMINT, 10) == 0);
+		So(nng_setopt_ms(pull, NNG_OPT_RECONNMAXT, 10) == 0);
 
 		Convey("Dialing before listening works", {
 			So(nng_dial(push, addr, NULL, NNG_FLAG_NONBLOCK) == 0);
-			nng_usleep(100000);
+			nng_msleep(100);
 			So(nng_listen(pull, addr, NULL, 0) == 0);
 
 			Convey("We can send a frame", {
 				nng_msg *msg;
 
-				nng_usleep(100000);
+				nng_msleep(100);
 				So(nng_msg_alloc(&msg, 0) == 0);
 				APPENDSTR(msg, "hello");
 				So(nng_sendmsg(push, msg, 0) == 0);
@@ -58,7 +58,7 @@ TestMain("Reconnect works", {
 			nng_listener l;
 			So(nng_dial(push, addr, NULL, NNG_FLAG_NONBLOCK) == 0);
 			So(nng_listen(pull, addr, &l, 0) == 0);
-			nng_usleep(100000);
+			nng_msleep(100);
 			nng_listener_close(l);
 			So(nng_listen(pull, addr, NULL, 0) == 0);
 
@@ -66,7 +66,7 @@ TestMain("Reconnect works", {
 				nng_msg *msg;
 				nng_pipe p1;
 
-				nng_usleep(100000);
+				nng_msleep(100);
 				So(nng_msg_alloc(&msg, 0) == 0);
 				APPENDSTR(msg, "hello");
 				So(nng_sendmsg(push, msg, 0) == 0);
@@ -81,7 +81,7 @@ TestMain("Reconnect works", {
 					nng_pipe p2;
 
 					nng_pipe_close(p1);
-					nng_usleep(100000);
+					nng_msleep(100);
 					So(nng_msg_alloc(&msg, 0) == 0);
 					APPENDSTR(msg, "again");
 					So(nng_sendmsg(push, msg, 0) == 0);

--- a/tests/reqrep.c
+++ b/tests/reqrep.c
@@ -31,8 +31,8 @@ TestMain("REQ/REP pattern", {
 		Convey("Resend time option id works", {
 
 			// Set timeout.
-			So(nng_setopt_usec(
-			       req, NNG_OPT_REQ_RESENDTIME, 10000) == 0);
+			So(nng_setopt_ms(req, NNG_OPT_REQ_RESENDTIME, 10) ==
+			    0);
 			// Check invalid size
 			So(nng_setopt(req, NNG_OPT_REQ_RESENDTIME, "", 1) ==
 			    NNG_EINVAL);
@@ -66,7 +66,7 @@ TestMain("REQ/REP pattern", {
 		});
 
 		Convey("Cannot set resend time", {
-			So(nng_setopt_usec(rep, NNG_OPT_REQ_RESENDTIME, 100) ==
+			So(nng_setopt_ms(rep, NNG_OPT_REQ_RESENDTIME, 100) ==
 			    NNG_ENOTSUP);
 		});
 	});
@@ -114,10 +114,10 @@ TestMain("REQ/REP pattern", {
 	});
 
 	Convey("Request cancellation works", {
-		nng_msg *abc;
-		nng_msg *def;
-		nng_msg *cmd;
-		uint64_t retry = 100000; // 100 ms
+		nng_msg *    abc;
+		nng_msg *    def;
+		nng_msg *    cmd;
+		nng_duration retry = 100; // 100 ms
 
 		nng_socket req;
 		nng_socket rep;
@@ -131,7 +131,7 @@ TestMain("REQ/REP pattern", {
 			nng_close(req);
 		});
 
-		So(nng_setopt_usec(req, NNG_OPT_REQ_RESENDTIME, retry) == 0);
+		So(nng_setopt_ms(req, NNG_OPT_REQ_RESENDTIME, retry) == 0);
 		So(nng_setopt_int(req, NNG_OPT_SENDBUF, 16) == 0);
 
 		So(nng_msg_alloc(&abc, 0) == 0);

--- a/tests/scalability.c
+++ b/tests/scalability.c
@@ -48,15 +48,15 @@ stop(void)
 int
 openclients(nng_socket *clients, int num)
 {
-	int      rv;
-	int      i;
-	uint64_t t;
+	int          rv;
+	int          i;
+	nng_duration t;
 	for (i = 0; i < num; i++) {
-		t = 100000; // 100ms
+		t = 100; // 100ms
 		nng_socket c;
 		if (((rv = nng_req_open(&c)) != 0) ||
-		    ((rv = nng_setopt_usec(c, NNG_OPT_RECVTIMEO, t)) != 0) ||
-		    ((rv = nng_setopt_usec(c, NNG_OPT_SENDTIMEO, t)) != 0) ||
+		    ((rv = nng_setopt_ms(c, NNG_OPT_RECVTIMEO, t)) != 0) ||
+		    ((rv = nng_setopt_ms(c, NNG_OPT_SENDTIMEO, t)) != 0) ||
 		    ((rv = nng_dial(c, addr, NULL, 0)) != 0)) {
 			return (rv);
 		}

--- a/tests/stubs.h
+++ b/tests/stubs.h
@@ -10,12 +10,12 @@
 #ifndef STUBS_H
 #define STUBS_H
 
-#include <stdint.h>
-#ifdef	_WIN32
+#ifdef _WIN32
 #include <windows.h>
 #else
-#include <time.h>
+#include <stdint.h>
 #include <sys/time.h>
+#include <time.h>
 #endif
 
 // Stub handlers for some common things.
@@ -23,10 +23,10 @@
 uint64_t
 getms(void)
 {
-#ifdef	_WIN32
-	return (GetTickCount64())	;
+#ifdef _WIN32
+	return (GetTickCount64());
 #else
-	static time_t epoch;
+	static time_t  epoch;
 	struct timeval tv;
 
 	if (epoch == 0) {
@@ -40,7 +40,7 @@ getms(void)
 		return (0);
 	}
 	tv.tv_sec -= epoch;
-	return (((uint64_t)(tv.tv_sec ) * 1000) + (tv.tv_usec / 1000));
+	return (((uint64_t)(tv.tv_sec) * 1000) + (tv.tv_usec / 1000));
 #endif
 }
 

--- a/tests/survey.c
+++ b/tests/survey.c
@@ -43,8 +43,8 @@ TestMain("SURVEY pattern", {
 		Convey("Survey without responder times out", {
 			nng_msg *msg;
 
-			So(nng_setopt_usec(
-			       surv, NNG_OPT_SURVEYOR_SURVEYTIME, 50000) == 0);
+			So(nng_setopt_ms(
+			       surv, NNG_OPT_SURVEYOR_SURVEYTIME, 50) == 0);
 			So(nng_msg_alloc(&msg, 0) == 0);
 			So(nng_sendmsg(surv, msg, 0) == 0);
 			So(nng_recvmsg(surv, &msg, 0) == NNG_ETIMEDOUT);
@@ -83,8 +83,7 @@ TestMain("SURVEY pattern", {
 			nng_close(resp);
 		});
 
-		So(nng_setopt_usec(surv, NNG_OPT_SURVEYOR_SURVEYTIME, 50000) ==
-		    0);
+		So(nng_setopt_ms(surv, NNG_OPT_SURVEYOR_SURVEYTIME, 50) == 0);
 		So(nng_listen(surv, addr, NULL, 0) == 0);
 		So(nng_dial(resp, addr, NULL, 0) == 0);
 
@@ -98,7 +97,6 @@ TestMain("SURVEY pattern", {
 
 		Convey("Survey works", {
 			nng_msg *msg;
-			uint64_t rtimeo;
 
 			So(nng_msg_alloc(&msg, 0) == 0);
 			APPENDSTR(msg, "abc");
@@ -117,9 +115,8 @@ TestMain("SURVEY pattern", {
 			So(nng_recvmsg(surv, &msg, 0) == NNG_ETIMEDOUT);
 
 			Convey("And goes to non-survey state", {
-				rtimeo = 200000;
-				So(nng_setopt_usec(
-				       surv, NNG_OPT_RECVTIMEO, 200000) == 0);
+				So(nng_setopt_ms(
+				       surv, NNG_OPT_RECVTIMEO, 200) == 0);
 				So(nng_recvmsg(surv, &msg, 0) == NNG_ESTATE);
 			});
 		});

--- a/tests/synch.c
+++ b/tests/synch.c
@@ -14,10 +14,10 @@
 
 // Notify tests for verifying condvars.
 struct notifyarg {
-	int     did;
-	int     when;
-	nni_mtx mx;
-	nni_cv  cv;
+	int          did;
+	nng_duration when;
+	nni_mtx      mx;
+	nni_cv       cv;
 };
 
 #ifdef NNG_PLATFORM_POSIX
@@ -31,7 +31,7 @@ notifyafter(void *arg)
 {
 	struct notifyarg *na = arg;
 
-	nni_usleep(na->when);
+	nni_msleep(na->when);
 	nni_mtx_lock(&na->mx);
 	na->did = 1;
 	nni_cv_wake(&na->cv);
@@ -71,10 +71,10 @@ test_sync(void)
 				arg.when = 0;
 				nni_mtx_lock(&arg.mx);
 				nni_thr_run(&thr);
-				nng_usleep(10000);
+				nng_msleep(10);
 				So(arg.did == 0);
 				nni_mtx_unlock(&arg.mx);
-				nng_usleep(10000);
+				nng_msleep(10);
 				nni_mtx_lock(&arg.mx);
 				while (!arg.did) {
 					nni_cv_wait(&arg.cv);
@@ -103,7 +103,7 @@ test_sync(void)
 
 		Convey("Notification works", {
 			arg.did  = 0;
-			arg.when = 10000;
+			arg.when = 10;
 			nni_thr_run(&thr);
 
 			nni_mtx_lock(&arg.mx);
@@ -117,11 +117,11 @@ test_sync(void)
 
 		Convey("Timeout works", {
 			arg.did  = 0;
-			arg.when = 200000;
+			arg.when = 200;
 			nni_thr_run(&thr);
 			nni_mtx_lock(&arg.mx);
 			if (!arg.did) {
-				nni_cv_until(&arg.cv, nni_clock() + 10000);
+				nni_cv_until(&arg.cv, nni_clock() + 10);
 			}
 			So(arg.did == 0);
 			nni_mtx_unlock(&arg.mx);
@@ -139,7 +139,7 @@ test_sync(void)
 			arg.when = 1;
 			nni_mtx_lock(&arg.mx);
 			if (!arg.did) {
-				nni_cv_until(&arg.cv, nni_clock() + 10000);
+				nni_cv_until(&arg.cv, nni_clock() + 10);
 			}
 			So(arg.did == 0);
 			nni_mtx_unlock(&arg.mx);
@@ -184,10 +184,10 @@ test_sync_fallback(void)
 				arg.when = 0;
 				nni_mtx_lock(&arg.mx);
 				nni_thr_run(&thr);
-				nng_usleep(10000);
+				nng_msleep(10);
 				So(arg.did == 0);
 				nni_mtx_unlock(&arg.mx);
-				nng_usleep(10000);
+				nng_msleep(10);
 				nni_mtx_lock(&arg.mx);
 				while (!arg.did) {
 					nni_cv_wait(&arg.cv);
@@ -216,7 +216,7 @@ test_sync_fallback(void)
 
 		Convey("Notification works", {
 			arg.did  = 0;
-			arg.when = 10000;
+			arg.when = 10;
 			nni_thr_run(&thr);
 
 			nni_mtx_lock(&arg.mx);
@@ -230,11 +230,11 @@ test_sync_fallback(void)
 
 		Convey("Timeout works", {
 			arg.did  = 0;
-			arg.when = 200000;
+			arg.when = 200;
 			nni_thr_run(&thr);
 			nni_mtx_lock(&arg.mx);
 			if (!arg.did) {
-				nni_cv_until(&arg.cv, nni_clock() + 10000);
+				nni_cv_until(&arg.cv, nni_clock() + 10);
 			}
 			So(arg.did == 0);
 			nni_mtx_unlock(&arg.mx);
@@ -252,7 +252,7 @@ test_sync_fallback(void)
 			arg.when = 1;
 			nni_mtx_lock(&arg.mx);
 			if (!arg.did) {
-				nni_cv_until(&arg.cv, nni_clock() + 10000);
+				nni_cv_until(&arg.cv, nni_clock() + 10);
 			}
 			So(arg.did == 0);
 			nni_mtx_unlock(&arg.mx);
@@ -278,7 +278,7 @@ TestMain("Synchronization", {
 		So(nni_thr_init(&thr, notifyafter, &arg) == 0);
 
 		arg.did  = 0;
-		arg.when = 10000;
+		arg.when = 10;
 		nni_thr_run(&thr);
 
 		nni_mtx_lock(&arg.mx);

--- a/tests/trantest.h
+++ b/tests/trantest.h
@@ -139,7 +139,7 @@ trantest_send_recv(trantest *tt)
 		So(nng_dial(tt->reqsock, tt->addr, &d, 0) == 0);
 		So(d != 0);
 
-		nng_usleep(20000); // listener may be behind slightly
+		nng_msleep(20); // listener may be behind slightly
 
 		send = NULL;
 		So(nng_msg_alloc(&send, 0) == 0);
@@ -186,7 +186,7 @@ trantest_check_properties(trantest *tt, trantest_proptest_t f)
 		So(nng_dial(tt->reqsock, tt->addr, &d, 0) == 0);
 		So(d != 0);
 
-		nng_usleep(20000); // listener may be behind slightly
+		nng_msleep(20); // listener may be behind slightly
 
 		send = NULL;
 		So(nng_msg_alloc(&send, 0) == 0);
@@ -228,7 +228,7 @@ trantest_send_recv_large(trantest *tt)
 		So(nng_dial(tt->reqsock, tt->addr, &d, 0) == 0);
 		So(d != 0);
 
-		nng_usleep(20000); // listener may be behind slightly
+		nng_msleep(20); // listener may be behind slightly
 
 		send = NULL;
 		So(nng_msg_alloc(&send, size) == 0);

--- a/tests/udp.c
+++ b/tests/udp.c
@@ -162,7 +162,7 @@ TestMain("UDP support", {
 			nni_plat_udp_send(u1, aio2);
 			// This delay here is required to test for a race
 			// condition that does not occur if it is absent.
-			nng_usleep(200);
+			nng_msleep(1);
 			nni_plat_udp_send(u1, aio1);
 
 			nni_aio_wait(aio2);


### PR DESCRIPTION
There is now a public nng_duration type.  We have also updated the
zerotier work to work with the signed int64_t's that the latst ZeroTier
dev branch is using.