### PR TITLE
Protover

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,11 +93,83 @@ option (NNG_TESTS "Build and run tests" ON)
 option (NNG_TOOLS "Build extra tools" OFF)
 option (NNG_ENABLE_NNGCAT "Enable building nngcat utility." ${NNG_TOOLS})
 option (NNG_ENABLE_COVERAGE "Enable coverage reporting." OFF)
-option (NNG_ENABLE_ZEROTIER "Enable ZeroTier transport (requires libzerotiercore)." OFF)
-set (NNG_ZEROTIER_SOURCE "" CACHE PATH "Location of ZeroTier source tree.")
 # Enable access to private APIs for our own use.
 add_definitions (-DNNG_PRIVATE)
 
+option (NNG_PROTO_BUS0 "Enable BUSv0 protocol." ON)
+if (NNG_PROTO_BUS0)
+    add_definitions (-DNNG_HAVE_BUS0)
+endif ()
+
+option (NNG_PROTO_PAIR0 "Enable PAIRv0 protocol." ON)
+if (NNG_PROTO_PAIR0)
+    add_definitions (-DNNG_HAVE_PAIR0)
+endif ()
+
+option (NNG_PROTO_PAIR1 "Enable PAIRv1 protocol." ON)
+if (NNG_PROTO_PAIR1)
+    add_definitions (-DNNG_HAVE_PAIR1)
+endif ()
+
+option (NNG_PROTO_REQ0 "Enable REQv0 protocol." ON)
+if (NNG_PROTO_REQ0)
+    add_definitions (-DNNG_HAVE_REQ0)
+endif ()
+
+option (NNG_PROTO_REP0 "Enable REPv0 protocol." ON)
+if (NNG_PROTO_REP0)
+    add_definitions (-DNNG_HAVE_REP0)
+endif ()
+
+option (NNG_PROTO_PUB0 "Enable PUBv0 protocol." ON)
+if (NNG_PROTO_PUB0)
+    add_definitions (-DNNG_HAVE_PUB0)
+endif ()
+
+option (NNG_PROTO_SUB0 "Enable SUBv0 protocol." ON)
+if (NNG_PROTO_SUB0)
+    add_definitions (-DNNG_HAVE_SUB0)
+endif ()
+
+option (NNG_PROTO_PUSH0 "Enable PUSHv0 protocol." ON)
+if (NNG_PROTO_PUSH0)
+    add_definitions (-DNNG_HAVE_PUSH0)
+endif ()
+
+option (NNG_PROTO_PULL0 "Enable PULLv0 protocol." ON)
+if (NNG_PROTO_PULL0)
+    add_definitions (-DNNG_HAVE_PULL0)
+endif ()
+
+option (NNG_PROTO_SURVEYOR0 "Enable SURVEYORv0 protocol." ON)
+if (NNG_PROTO_SURVEYOR0)
+    add_definitions (-DNNG_HAVE_SURVEYOR0)
+endif ()
+
+option (NNG_PROTO_RESPONDENT0 "Enable RESPONDENTv0 protocol." ON)
+if (NNG_PROTO_RESPONDENT0)
+    add_definitions (-DNNG_HAVE_RESPONDENT0)
+endif ()
+
+option (NNG_TRANSPORT_INPROC "Enable inproc transport." ON)
+if (NNG_TRANSPORT_INPROC)
+    add_definitions (-DNNG_HAVE_INPROC)
+endif ()
+
+option (NNG_TRANSPORT_IPC "Enable IPC transport." ON)
+if (NNG_TRANSPORT_IPC)
+    add_definitions (-DNNG_HAVE_IPC)
+endif ()
+
+option (NNG_TRANSPORT_TCP "Enable TCP transport." ON)
+if (NNG_TRANSPORT_TCP)
+    add_definitions (-DNNG_HAVE_TCP)
+endif ()
+
+option (NNG_TRANSPORT_ZEROTIER "Enable ZeroTier transport (requires libzerotiercore)." OFF)
+if (NNG_TRANSPORT_ZEROTIER)
+    add_definitions (-DNNG_HAVE_ZEROTIER)
+endif ()
 #  Platform checks.
 
 if (NNG_ENABLE_COVERAGE)
@@ -246,39 +318,6 @@ nng_check_sym (strdup string.h NNG_HAVE_STRDUP)
 nng_check_sym (strlcat string.h NNG_HAVE_STRLCAT)
 nng_check_sym (strlcpy string.h NNG_HAVE_STRLCPY)
 nng_check_sym (strnlen string.h NNG_HAVE_STRNLEN)
-
-# Search for ZeroTier
-# We use the libzerotiercore.a library, which is unfortunately a C++ object
-# even though it exposes only public C symbols.  It would be extremely
-# helpful if libzerotiercore didn't make us carry the whole C++ runtime
-# behind us.  The user must specify the location of the ZeroTier source
-# tree (dev branch for now, and already compiled please) by setting the
-# NNG_ZEROTIER_SOURCE macro.
-# NB: This needs to be the zerotierone tree, not the libzt library.
-# This is because we don't access the API, but instead use the low
-# level zerotiercore functionality directly.
-# NB: As we wind up linking libzerotiercore.a into the application,
-# this means that your application will *also* need to either be licensed
-# under the GPLv3, or you will need to have a commercial license from
-# ZeroTier permitting its use elsewhere.
-if (NNG_ENABLE_ZEROTIER)
-    enable_language(CXX)
-    find_library(NNG_LIBZTCORE zerotiercore PATHS ${NNG_ZEROTIER_SOURCE})
-    if (NNG_LIBZTCORE)
-        set(CMAKE_REQUIRED_INCLUDES ${NNG_ZEROTIER_SOURCE}/include)
-#        set(CMAKE_REQUIRED_LIBRARIES ${NNG_LIBZTCORE} c++)
-#        set(NNG_REQUIRED_LIBRARIES ${NNG_REQUIRED_LIBRARIES} ${NNG_LIBZTCORE} c++)
-        message(STATUS "C++ ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}")
-        set(CMAKE_REQUIRED_LIBRARIES ${NNG_LIBZTCORE} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
-        set(NNG_REQUIRED_LIBRARIES ${NNG_REQUIRED_LIBRARIES} ${NNG_LIBZTCORE} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
-        set(NNG_REQUIRED_INCLUDES ${NNG_REQUIRED_INCLUDES} ${NNG_ZEROTIER_SOURCE}/include)
-        nng_check_sym(ZT_Node_join ZeroTierOne.h NNG_HAVE_ZEROTIER)
-    endif()
-    if (NOT NNG_HAVE_ZEROTIER)
-        message (FATAL_ERROR "Cannot find ZeroTier components")
-    endif()
-    message(STATUS "Found ZeroTier at ${NNG_LIBZTCORE}")
-endif()
 
 add_subdirectory (src)
 

--- a/docs/nng_bus.adoc
+++ b/docs/nng_bus.adoc
@@ -21,11 +21,9 @@ SYNOPSIS
 
 [source,c]
 ----------
-#include <nng/protocol/bus/bus.h>
+#include <nng/protocol/bus0/bus.h>
 
-int nng_bus_open(nng_socket *s);
 int nng_bus0_open(nng_socket *s);
-
 ----------
 
 DESCRIPTION
@@ -57,7 +55,7 @@ likely that message loss is to occur.
 Socket Operations
 ~~~~~~~~~~~~~~~~~
 
-The `nng_bus_open()` call creates a bus socket.  This socket
+The `nng_bus0_open()` call creates a bus socket.  This socket
 may be used to send and receive messages. Sending messages will
 attempt to deliver to each directly connected peer.
 

--- a/docs/nng_bus.adoc
+++ b/docs/nng_bus.adoc
@@ -1,0 +1,95 @@
+nng_bus(7)
+==========
+:doctype: manpage
+:manmanual: nng
+:mansource: nng
+:icons: font
+:source-highlighter: pygments
+:copyright: Copyright 2017 Garrett D'Amore <garrett@damore.org> \
+            Copyright 2017 Capitar IT Group BV <info@capitar.com> \
+            This software is supplied under the terms of the MIT License, a \
+            copy of which should be located in the distribution where this \
+            file was obtained (LICENSE.txt).  A copy of the license may also \
+            be found online at https://opensource.org/licenses/MIT.
+
+NAME
+----
+nng_bus - bus protocol
+
+SYNOPSIS
+--------
+
+[source,c]
+----------
+#include <nng/protocol/bus/bus.h>
+
+int nng_bus_open(nng_socket *s);
+int nng_bus0_open(nng_socket *s);
+
+----------
+
+DESCRIPTION
+-----------
+
+The _nng_bus_ protocol provides for building mesh networks where
+every peer is connected to every other peer.  In this protocol,
+each message sent by a node is sent to every one of its directly
+connected peers.
+
+TIP: Messages are only sent to directly connected peers.  This means
+that in the event that a peer is connected indirectly, it will not
+receive messages.  When using this protocol to build mesh networks, it
+is therefore important that a _fully-connected_ mesh network be
+constructed.
+
+All message delivery in this pattern is best-effort, which means that
+peers may not receive messages. Furthermore, delivery may occur to some,
+all, or none of the directly connected peers. (Messages are not delivered
+when peer nodes are unable to receive.)  Hence, send operations will never
+block; instead if the message cannot be delivered for any reason it is
+discarded.
+
+TIP: In order to minimize the likelihood of message loss, this protocol
+should not be used for high throughput communications.  Furthermore, the
+more traffic _in aggregate_ that occurs across the topology, the more
+likely that message loss is to occur.
+
+Socket Operations
+~~~~~~~~~~~~~~~~~
+
+The `nng_bus_open()` call creates a bus socket.  This socket
+may be used to send and receive messages. Sending messages will
+attempt to deliver to each directly connected peer.
+
+Protocol Versions
+~~~~~~~~~~~~~~~~~
+
+Only version 0 of this protocol is supported.  (At the time of writing,
+no other versions of this protocol have been defined.)
+
+Protocol Options
+~~~~~~~~~~~~~~~~
+
+The _nng_bus_ protocol has no protocol-specific options.
+
+Protocol Headers
+~~~~~~~~~~~~~~~~
+
+The _nng_bus_ protocol has no protocol-specific headers.
+    
+AUTHORS
+-------
+link:mailto:garrett@damore.org[Garrett D'Amore]
+
+SEE ALSO
+--------
+<<nng.adoc#,nng(7)>>
+
+COPYRIGHT
+---------
+
+Copyright 2017 mailto:garrett@damore.org[Garrett D'Amore] +
+Copyright 2017 mailto:info@capitar.com[Capitar IT Group BV]
+
+This document is supplied under the terms of the
+https://opensource.org/licenses/LICENSE.txt[MIT License].

--- a/docs/nng_inproc.adoc
+++ b/docs/nng_inproc.adoc
@@ -47,8 +47,7 @@ URI Format
 
 This transport uses URIs using the scheme `inproc://`, followed by
 an arbitrary string of text, terminated by a `NUL` byte.  The
-entire URI must be less than `NNG_MAXADDRLEN` bytes long, including
-the terminating `NUL`.
+entire URI must be less than `NNG_MAXADDRLEN` bytes long.
 
 Multiple URIs can be used within the
 same application, and they will not interfere with one another.
@@ -65,16 +64,22 @@ When using an `nng_sockaddr` structure, the actual structure is of type
 
 [source,c]
 --------
-#define NNG_AF_INPROC 1
+#define NNG_AF_INPROC 1 <1>
 #define NNG_MAXADDRLEN 128
 
-struct nng_sockaddr_inproc {
+typedef nng_sockaddr_inproc {
+    // <2>
     uint16_t sa_family;                  // must be NNG_AF_INPROC
-    uint32_t sa_path[NNG_MAXADDRLEN];    // arbitrary "path"
+    char     sa_path[NNG_MAXADDRLEN];    // arbitrary "path"
+    //
 }
 --------
+<1> The values of these macros may change, so applications
+should avoid depending upon their values and instead use them symbolically.
+<2> Other members may be present, but only those listed here
+are suitable for application use.
 
-The `sa_family` member will have the value `NNG_AF_INPROC` (1).
+The `sa_family` member will have the value `NNG_AF_INPROC`.
 The `sa_path` member is an ASCIIZ string, and may contain any characters,
 terminated by a `NUL` byte.
 

--- a/docs/nng_ipc.adoc
+++ b/docs/nng_ipc.adoc
@@ -1,0 +1,110 @@
+nng_ipc(7)
+==========
+:doctype: manpage
+:manmanual: nng
+:mansource: nng
+:icons: font
+:source-highlighter: pygments
+:copyright: Copyright 2017 Garrett D'Amore <garrett@damore.org> \
+            Copyright 2017 Capitar IT Group BV <info@capitar.com> \
+            This software is supplied under the terms of the MIT License, a \
+            copy of which should be located in the distribution where this \
+            file was obtained (LICENSE.txt).  A copy of the license may also \
+            be found online at https://opensource.org/licenses/MIT.
+
+NAME
+----
+nng_ipc - IPC transport for nng
+
+SYNOPSIS
+--------
+
+[source,c]
+----------
+#include <nng/transport/ipc/ipc.h>
+
+int nng_ipc_register(void);
+----------
+
+DESCRIPTION
+-----------
+
+The _nng_ipc_ transport provides communication support between
+_nng_ sockets within different processes on the same host. For POSIX
+platforms, this is implemented using UNIX domain sockets.  For Windows,
+this is implemented using Windows Named Pipes.  Other platforms may
+have different implementation strategies.
+
+// We need to insert a reference to the nanomsg RFC.
+
+Registration
+~~~~~~~~~~~~
+
+The _ipc_ transport is generally built-in to the _nng_ core, so
+no extra steps to use it should be necessary.
+
+URI Format
+~~~~~~~~~~
+
+This transport uses URIs using the scheme `ipc://`, followed by
+a path name in the file system where the socket or named pipe
+should be created.
+
+TIP: On Windows, all names are prefixed by `\.\pipe\` and do not
+occupy the normal file system.  On POSIX platforms, the path is
+taken literally, and is relative to the current directory, unless
+an extra leading `/` is provided.  For example, `ipc://myname` refers
+to the name `myname` in the current directory, whereas `ipc:///tmp/myname`
+refers to `myname` located in `/tmp`.
+
+The entire URI must be less than `NNG_MAXADDRLEN` bytes long.
+
+Socket Address
+~~~~~~~~~~~~~~
+
+When using an `nng_sockaddr` structure, the actual structure is of type
+`nng_sockaddr_ipc`.  This is a `struct` type with the following definition:
+
+[source,c]
+--------
+#define NNG_AF_IPC 2 <1>
+#define NNG_MAXADDRLEN 128
+
+typedef struct {
+    // ... <2>
+    uint16_t sa_family;                 // must be NNG_AF_IPC
+    char     sa_path[NNG_MAXADDRLEN];   // arbitrary "path"
+    // ...
+} nng_sockaddr_ipc;
+--------
+<1> The values of these macros may change, so applications
+should avoid depending upon their values and instead use them symbolically.
+<2> Other members may be present, but only those listed here
+are suitable for application use.
+
+The `sa_family` member will have the value `NNG_AF_IPC`.
+The `sa_path` member is an ASCIIZ string, and may contain any legal
+path name (platform-dependent), terminated by a `NUL` byte.
+
+Transport Options
+~~~~~~~~~~~~~~~~~
+
+The _ipc_ transport has no special
+options.footnote:[Options for security attributes and credentials are planned.]
+
+AUTHORS
+-------
+link:mailto:garrett@damore.org[Garrett D'Amore]
+
+SEE ALSO
+--------
+<<nng.adoc#,nng(7)>>
+
+COPYRIGHT
+---------
+
+Copyright 2017 mailto:garrett@damore.org[Garrett D'Amore] +
+Copyright 2017 mailto:info@capitar.com[Capitar IT Group BV]
+
+This document is supplied under the terms of the
+https://opensource.org/licenses/LICENSE.txt[MIT License].

--- a/docs/nng_pair.adoc
+++ b/docs/nng_pair.adoc
@@ -1,0 +1,155 @@
+nng_pair(7)
+===========
+:doctype: manpage
+:manmanual: nng
+:mansource: nng
+:icons: font
+:source-highlighter: pygments
+:copyright: Copyright 2017 Garrett D'Amore <garrett@damore.org> \
+            Copyright 2017 Capitar IT Group BV <info@capitar.com> \
+            This software is supplied under the terms of the MIT License, a \
+            copy of which should be located in the distribution where this \
+            file was obtained (LICENSE.txt).  A copy of the license may also \
+            be found online at https://opensource.org/licenses/MIT.
+
+NAME
+----
+nng_pair - pair protocol
+
+SYNOPSIS
+--------
+
+.Version 0
+[source,c]
+----------
+#include <nng/protocol/pair0/pair.h>
+
+int nng_pair0_open(nng_socket *s);
+----------
+
+.Version 1
+[source,c]
+----------
+#include <nng/protocol/pair1/pair.h>
+
+int nng_pair1_open(nng_socket *s);
+----------
+
+DESCRIPTION
+-----------
+
+The _nng_pair_ protocol implements a peer-to-peer pattern, where
+relationships between peers are one-to-one.
+
+Version 1 of this protocol supports an optional _polyamorous_ mode where a
+peer can maintain multiple partnerships.  Using this mode requires
+some additional sophistication in the application.
+
+Socket Operations
+~~~~~~~~~~~~~~~~~
+
+The `nng_pair_open()` call creates a _pair_ socket.  Normally, this
+pattern will block when attempting to send a message, if no peer is
+able to receive the message.
+
+NOTE: Even though this mode may appear to be "reliable", because back-pressure
+prevents discarding messages most of the time, there are topologies involving
+_devices_ (see <<nng_device.adoc#,nng_device(3)>>) or raw mode sockets where
+messages may be discarded.  Applications that require reliable delivery
+semantics should consider using <<nng_req.adoc#,nng_req(7)>> sockets, or
+implement their own acknowledgement layer on top of pair sockets.
+
+In order to avoid head-of-line blocking conditions, _polyamorous_ mode pair
+sockets (version 1 only) discard messages if they are unable to deliver them
+to a peer.
+
+Protocol Versions
+~~~~~~~~~~~~~~~~~
+
+Version 0 is the legacy version of this protocol.  It lacks any header
+information, and is suitable when building simple one-to-one topologies.
+
+TIP: Use version 0 if you need to communicate with other implementations,
+including the legacy https://github.com/nanomsg/nanomsg[nanomsg] library or
+https://github.com/go-mangos/mangos[mangos].
+
+Version 1 of the protocol offers improved protection against loops when
+used with <<nng_device.adoc#,nng_device(3)>>.   It also offers _polyamorous_
+mode for forming multiple partnerships on a single socket.
+
+NOTE: Version 1 of this protocol is considered experimental at this time.
+
+Polyamorous Mode
+~~~~~~~~~~~~~~~~
+
+Normally pair sockets are for one-to-one communication, and a given peer
+will reject new connections if it already has an active connection to another
+peer.
+
+In _polyamorous_ mode, which is only available with version 1, a socket can
+support many one-to-one connections.  In this mode, the application must
+choose the remote peer to receive an ougoing message by setting the value
+of the pipe ID on the outgoing message using
+the <<nng_msg_set_pipe.adoc#,nng_msg_set_pipe(3)>> function.
+
+Most often the value of the outgoing pipe ID will be obtained from an incoming
+message using the <<nng_msg_get_pipe.adoc#,nng_msg_get_pipe(3)>> function,
+such as when replying to an incoming message.
+
+In order to prevent head-of-line blocking, if the peer on the given pipe
+is not able to receive (or the pipe is no longer available, such as if the
+peer has disconnected), then the message will be discarded with no notification
+to the sender.
+
+Protocol Options
+~~~~~~~~~~~~~~~~
+
+The following protocol-specific options are available.
+
+`NNG_OPT_PAIR1_POLY`::
+
+   (Version 1 only).  This option enables the use of _polyamorous_ mode.
+   The value is read-write, and takes an integer boolean value.  The default
+   false value (0) indicates that legacy monogamous mode should be used.
+
+`NNG_OPT_MAXTTL`::
+
+   (Version 1 only).  Maximum time-to-live.  This option is an integer value
+   between 0 and 255,
+   inclusive, and is the maximum number of "hops" that a message may
+   pass through until it is discarded.  The default value is 8.  A value
+   of 0 may be used to disable the loop protection, allowing an infinite
+   number of hops.
++
+TIP: Each node along a forwarding path may have it's own value for the
+maximum time-to-live, and performs its own checks before forwarding a message.
+Therefore it is helpful if all nodes in the topology use the same value for
+this option.
+
+Protocol Headers
+~~~~~~~~~~~~~~~~
+
+Version 0 of the pair protocol has no protocol-specific headers.
+
+Version 1 of the pair protocol uses a single 32-bit unsigned value.  The
+low-order (big-endian) byte of this value contains a "hop" count, and is
+used in conjuction with the `NNG_OPT_MAXTTL` option to guard against
+device forwarding loops.  This value is initialized to 1, and incremented
+each time the message is received by a new node.
+    
+AUTHORS
+-------
+link:mailto:garrett@damore.org[Garrett D'Amore]
+
+SEE ALSO
+--------
+<<nng.adoc#,nng(7)>>
+
+COPYRIGHT
+---------
+
+Copyright 2017 mailto:garrett@damore.org[Garrett D'Amore] +
+Copyright 2017 mailto:info@capitar.com[Capitar IT Group BV]
+
+This document is supplied under the terms of the
+https://opensource.org/licenses/LICENSE.txt[MIT License].

--- a/docs/nng_pub.adoc
+++ b/docs/nng_pub.adoc
@@ -21,11 +21,9 @@ SYNOPSIS
 
 [source,c]
 ----------
-#include <nng/protocol/pubsub/pubsub.h>
+#include <nng/protocol/pubsub0/pub.h>
 
-int nng_pub_open(nng_socket *s);
 int nng_pub0_open(nng_socket *s);
-
 ----------
 
 DESCRIPTION
@@ -51,7 +49,7 @@ accordingly.
 Socket Operations
 ~~~~~~~~~~~~~~~~~
 
-The `nng_pub_open()` call creates a publisher socket.  This socket
+The `nng_pub0_open()` call creates a publisher socket.  This socket
 may be used to send messages, but is unable to receive them.  Attempts
 to receive messages will result in `NNG_ENOTSUP`.
 

--- a/docs/nng_pull.adoc
+++ b/docs/nng_pull.adoc
@@ -1,0 +1,85 @@
+nng_pull(7)
+===========
+:doctype: manpage
+:manmanual: nng
+:mansource: nng
+:icons: font
+:source-highlighter: pygments
+:copyright: Copyright 2017 Garrett D'Amore <garrett@damore.org> \
+            Copyright 2017 Capitar IT Group BV <info@capitar.com> \
+            This software is supplied under the terms of the MIT License, a \
+            copy of which should be located in the distribution where this \
+            file was obtained (LICENSE.txt).  A copy of the license may also \
+            be found online at https://opensource.org/licenses/MIT.
+
+NAME
+----
+nng_pull - pull protocol
+
+SYNOPSIS
+--------
+
+[source,c]
+----------
+#include <nng/protocol/pipeline0/pull.h>
+
+int nng_pull0_open(nng_socket *s);
+----------
+
+DESCRIPTION
+-----------
+
+The _nng_pull_ protocol is one half of a pipeline pattern. The other half
+is the <<nng_push.adoc#,nng_push(7)>> protocol.
+
+In the pipeline pattern, pushers distribute messages to pullers. 
+Each message sent
+by a pusher will be sent to one of its peer pullers,
+chosen in a round-robin fashion
+from the set of connected peers available for receiving.
+This property makes this pattern useful in load-balancing scenarios.
+
+Socket Operations
+~~~~~~~~~~~~~~~~~
+
+The `nng_pull0_open()` call creates a puller socket.  This socket
+may be used to receive messages, but is unable to send them.  Attempts
+to send messages will result in `NNG_ENOTSUP`.
+
+When receiving messages, the _nng_pull_ protocol accepts messages as
+they arrive from peers.  If two peers both have a message ready, the
+order in which messages are handled is undefined.
+
+Protocol Versions
+~~~~~~~~~~~~~~~~~
+
+Only version 0 of this protocol is supported.  (At the time of writing,
+no other versions of this protocol have been defined.)
+
+Protocol Options
+~~~~~~~~~~~~~~~~
+
+The _nng_pull_ protocol has no protocol-specific options.
+
+Protocol Headers
+~~~~~~~~~~~~~~~~
+
+The _nng_pull_ protocol has no protocol-specific headers.
+    
+AUTHORS
+-------
+link:mailto:garrett@damore.org[Garrett D'Amore]
+
+SEE ALSO
+--------
+<<nng.adoc#,nng(7)>>
+<<nng_push.adoc#,nng_push(7)>>
+
+COPYRIGHT
+---------
+
+Copyright 2017 mailto:garrett@damore.org[Garrett D'Amore] +
+Copyright 2017 mailto:info@capitar.com[Capitar IT Group BV]
+
+This document is supplied under the terms of the
+https://opensource.org/licenses/LICENSE.txt[MIT License].

--- a/docs/nng_push.adoc
+++ b/docs/nng_push.adoc
@@ -1,0 +1,93 @@
+nng_push(7)
+===========
+:doctype: manpage
+:manmanual: nng
+:mansource: nng
+:icons: font
+:source-highlighter: pygments
+:copyright: Copyright 2017 Garrett D'Amore <garrett@damore.org> \
+            Copyright 2017 Capitar IT Group BV <info@capitar.com> \
+            This software is supplied under the terms of the MIT License, a \
+            copy of which should be located in the distribution where this \
+            file was obtained (LICENSE.txt).  A copy of the license may also \
+            be found online at https://opensource.org/licenses/MIT.
+
+NAME
+----
+nng_push - push protocol
+
+SYNOPSIS
+--------
+
+[source,c]
+----------
+#include <nng/protocol/pipeline0/push.h>
+
+int nng_push0_open(nng_socket *s);
+----------
+
+DESCRIPTION
+-----------
+
+The _nng_push_ protocol is one half of a pipeline pattern.  The
+other side is the <<nng_pull.adoc#,nng_pull(7)>> protocol.
+
+In the pipeline pattern, pushers distribute messages to pullers. 
+Each message sent
+by a pusher will be sent to one of its peer pullers,
+chosen in a round-robin fashion
+from the set of connected peers available for receiving.
+This property makes this pattern useful in load-balancing scenarios.
+
+Socket Operations
+~~~~~~~~~~~~~~~~~
+
+The `nng_push0_open()` call creates a pusher socket.  This socket
+may be used to send messages, but is unable to receive them.  Attempts
+to receive messages will result in `NNG_ENOTSUP`.
+
+Send operations will observe flow control (back-pressure), so that
+only peers capable of accepting a message will be considered.  If no
+peer is available to receive a message, then the send operation will
+wait until one is available, or the operation times out.
+
+NOTE: Although the pipeline protocol honors flow control, and attempts
+to avoid dropping messages, no guarantee of delivery is made.  Furthermore,
+as there is no capability for message acknowledgement, applications that
+need reliable delivery are encouraged to consider the
+<<nng_req.adoc#,nng_req(7)>> protocol instead.
+
+Protocol Versions
+~~~~~~~~~~~~~~~~~
+
+Only version 0 of this protocol is supported.  (At the time of writing,
+no other versions of this protocol have been defined.)
+
+Protocol Options
+~~~~~~~~~~~~~~~~
+
+The _nng_push_ protocol has no protocol-specific options.
+
+Protocol Headers
+~~~~~~~~~~~~~~~~
+
+The _nng_push_ protocol has no protocol-specific headers.
+    
+AUTHORS
+-------
+link:mailto:garrett@damore.org[Garrett D'Amore]
+
+SEE ALSO
+--------
+<<nng.adoc#,nng(7)>>
+<<nng_pull.adoc#,nng_pull(7)>>
+<<nng_req.adoc#,nng_req(7)>>
+
+COPYRIGHT
+---------
+
+Copyright 2017 mailto:garrett@damore.org[Garrett D'Amore] +
+Copyright 2017 mailto:info@capitar.com[Capitar IT Group BV]
+
+This document is supplied under the terms of the
+https://opensource.org/licenses/LICENSE.txt[MIT License].

--- a/docs/nng_sub.adoc
+++ b/docs/nng_sub.adoc
@@ -21,11 +21,9 @@ SYNOPSIS
 
 [source,c]
 ----------
-#include <nng/protocol/pubsub/pubsub.h>
+#include <nng/protocol/pubsub0/sub.h>
 
-int nng_sub_open(nng_socket *s);
 int nng_sub0_open(nng_socket *s);
-
 ----------
 
 DESCRIPTION
@@ -51,7 +49,7 @@ accordingly.
 Socket Operations
 ~~~~~~~~~~~~~~~~~
 
-The `nng_sub_open()` call creates a subscriber socket.  This socket
+The `nng_sub0_open()` call creates a subscriber socket.  This socket
 may be used to receive messages, but is unable to send them.  Attempts
 to send messages will result in `NNG_ENOTSUP`.
 

--- a/docs/nng_tcp.adoc
+++ b/docs/nng_tcp.adoc
@@ -1,0 +1,137 @@
+nng_tcp(7)
+==========
+:doctype: manpage
+:manmanual: nng
+:mansource: nng
+:icons: font
+:source-highlighter: pygments
+:copyright: Copyright 2017 Garrett D'Amore <garrett@damore.org> \
+            Copyright 2017 Capitar IT Group BV <info@capitar.com> \
+            This software is supplied under the terms of the MIT License, a \
+            copy of which should be located in the distribution where this \
+            file was obtained (LICENSE.txt).  A copy of the license may also \
+            be found online at https://opensource.org/licenses/MIT.
+
+NAME
+----
+nng_tcp - TCP/IP transport for nng
+
+SYNOPSIS
+--------
+
+[source,c]
+----------
+#include <nng/transport/tcp/tcp.h>
+
+int nng_tcp_register(void);
+----------
+
+DESCRIPTION
+-----------
+
+The _nng_tcp_ transport provides communication support between
+_nng_ sockets across a TCP/IP network.  Both IPv4 and IPv6
+are supported when the underlying platform also supports it.
+
+// We need to insert a reference to the nanomsg RFC.
+
+Registration
+~~~~~~~~~~~~
+
+The _tcp_ transport is generally built-in to the _nng_ core, so
+no extra steps to use it should be necessary.
+
+URI Format
+~~~~~~~~~~
+
+This transport uses URIs using the scheme `tcp://`, followed by
+an IP address or hostname, followed by a colon and finally a
+TCP port number.  For example, to contact port 80 on the localhost
+either of the following URIs could be used: `tcp://127.0.0.1:80` or
+`tcp://localhost:80`.
+
+When specifying IPv6 addresses, the address must be enclosed in
+square brackets (`[]`) to avoid confusion with the final colon
+separating the port.
+
+For example, the same port 80 on the IPv6 loopback address ('::1') would
+be specified as `tcp://[::1]:80`.
+
+NOTE: When using symbolic names, the name is resolved when the
+name is first used. _nng_ won't become aware of changes in the
+name resolution until restart,
+usually.footnote:[This is a bug and will likely be fixed in the future.]
+
+The special value of 0 (`INADDR_ANY`) can be used for a listener
+to indicate that it should listen on all interfaces on the host.
+A short-hand for this form is to either omit the address, or specify
+the asterisk (`*`) character.  For example, the following three
+URIs are all equivalent, and could be used to listen to port 9999
+on the host:
+
+  1. `tcp://0.0.0.0:9999`
+  2. `tcp://*:9999`
+  3. `tcp://:9999`
+
+The entire URI must be less than `NNG_MAXADDRLEN` bytes long.
+
+Socket Address
+~~~~~~~~~~~~~~
+
+When using an `nng_sockaddr` structure, the actual structure is either
+of type `nng_sockaddr_in` (for IPv4) or `nng_sockaddr_in6` (for IPv6).
+These are `struct` types with the following definitions:
+
+[source,c]
+--------
+#define NNG_AF_INET    3 <1>
+#define NNG_AF_INET6   4
+#define NNG_MAXADDRLEN 128
+
+typedef struct {
+    // ... <2>
+    uint16_t sa_family;                 // must be NNG_AF_INET
+    uint16_t sa_port;                   // TCP port number
+    uint32_t sa_addr;
+    // ...
+} nng_sockaddr_in;
+
+typedef struct {
+    // ... <2>
+    uint16_t sa_family;                 // must be NNG_AF_INET6
+    uint16_t sa_port;                   // TCP port number
+    uint8_t  sa_addr[16];
+    // ...
+} nng_sockaddr_in6;
+--------
+<1> The values of these macros may change, so applications
+should avoid depending upon their values and instead use them symbolically.
+<2> Other members may be present, but only those listed here
+are suitable for application use.
+
+The `sa_family` member will have the value `NNG_AF_INET` or `NNG_AF_INET6`.
+The `sa_port` and `sa_addr` are the TCP port number and address, both in
+network byte order (most significant byte is first).
+
+Transport Options
+~~~~~~~~~~~~~~~~~
+
+The _tcp_ transport has no special
+options.footnote:[Options for TCP keepalive, linger, and nodelay are planned.]
+ 
+AUTHORS
+-------
+link:mailto:garrett@damore.org[Garrett D'Amore]
+
+SEE ALSO
+--------
+<<nng.adoc#,nng(7)>>
+
+COPYRIGHT
+---------
+
+Copyright 2017 mailto:garrett@damore.org[Garrett D'Amore] +
+Copyright 2017 mailto:info@capitar.com[Capitar IT Group BV]
+
+This document is supplied under the terms of the
+https://opensource.org/licenses/LICENSE.txt[MIT License].

--- a/perf/perf.c
+++ b/perf/perf.c
@@ -22,6 +22,24 @@
 // change without notice, and not part of the stable API or ABI.
 #include "core/nng_impl.h"
 
+#if defined(NNG_ENABLE_PAIR1)
+#include "protocol/pair1/pair.h"
+
+#elif defined(NNG_ENABLE_PAIR0)
+#include "protocol/pair0/pair.h"
+
+#else
+
+static void die(const char *, ...);
+
+static int
+nng_pair_open(nng_socket *rv)
+{
+	die("No pair protocol enabled in this build!");
+	return (NNG_ENOTSUP);
+}
+#endif // NNG_ENABLE_PAIR
+
 static void latency_client(const char *, int, int);
 static void latency_server(const char *, int, int);
 static void throughput_client(const char *, int, int);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,30 +74,6 @@ set (NNG_SOURCES
     core/timer.h
     core/transport.c
     core/transport.h
-
-    protocol/bus/bus.c
-
-    protocol/pair/pair_v0.c
-    protocol/pair/pair_v1.c
-
-    protocol/pipeline/pull.c
-    protocol/pipeline/push.c
-
-    protocol/pubsub/pub.c
-    protocol/pubsub/sub.c
-
-    protocol/reqrep/rep.c
-    protocol/reqrep/req.c
-
-    protocol/survey/respond.c
-    protocol/survey/survey.c
-
-    transport/inproc/inproc.c
-
-    transport/ipc/ipc.c
-
-    transport/tcp/tcp.c
-
 )
 
 if (NNG_PLATFORM_POSIX)
@@ -146,14 +122,19 @@ endif()
 install(FILES transport/inproc/inproc.h
     DESTINATION include/nng/transport/inproc)
     
-if (NNG_ENABLE_ZEROTIER)
-    set (NNG_SOURCES ${NNG_SOURCES}
-        transport/zerotier/zerotier.c
-        transport/zerotier/zerotier.h
-    )
-    install(FILES transport/zerotier/zerotier.h
-        DESTINATION include/nng/transport/zerotier)
-endif()
+
+add_subdirectory(protocol/bus0)
+add_subdirectory(protocol/pair0)
+add_subdirectory(protocol/pair1)
+add_subdirectory(protocol/pipeline0)
+add_subdirectory(protocol/pubsub0)
+add_subdirectory(protocol/reqrep0)
+add_subdirectory(protocol/survey0)
+
+add_subdirectory(transport/inproc)
+add_subdirectory(transport/ipc)
+add_subdirectory(transport/tcp)
+add_subdirectory(transport/zerotier)
 
 include_directories(AFTER SYSTEM ${PROJECT_SOURCE_DIR}/src
     ${NNG_REQUIRED_INCLUDES})
@@ -216,3 +197,7 @@ install (TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_static
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
+
+# Promote settings to parent
+set(NNG_REQUIRED_LIBRARIES ${NNG_REQUIRED_LIBRARIES} PARENT_SCOPE)
+set(NNG_REQUIRED_LFLAGS ${NNG_REQUIRED_LFLAGS} PARENT_SCOPE)

--- a/src/core/msgqueue.c
+++ b/src/core/msgqueue.c
@@ -297,7 +297,6 @@ nni_msgq_run_getq(nni_msgq *mq)
 static void
 nni_msgq_run_notify(nni_msgq *mq)
 {
-	nni_aio *aio;
 	if (mq->mq_cb_fn != NULL) {
 		int flags = 0;
 

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -147,21 +147,26 @@ extern int nni_proto_open(nng_socket *, const nni_proto *);
 // Protocol numbers are never more than 16 bits.  Also, there will never be
 // a valid protocol numbered 0 (NNG_PROTO_NONE).
 #define NNI_PROTO(major, minor) (((major) *16) + (minor))
-enum nng_proto_enum {
-	NNI_PROTO_NONE          = NNI_PROTO(0, 0),
-	NNI_PROTO_PAIR_V0       = NNI_PROTO(1, 0),
-	NNI_PROTO_PAIR_V1       = NNI_PROTO(1, 1),
-	NNI_PROTO_PUB_V0        = NNI_PROTO(2, 0),
-	NNI_PROTO_SUB_V0        = NNI_PROTO(2, 1),
-	NNI_PROTO_REQ_V0        = NNI_PROTO(3, 0),
-	NNI_PROTO_REP_V0        = NNI_PROTO(3, 1),
-	NNI_PROTO_PUSH_V0       = NNI_PROTO(5, 0),
-	NNI_PROTO_PULL_V0       = NNI_PROTO(5, 1),
-	NNI_PROTO_SURVEYOR_V0   = NNI_PROTO(6, 2),
-	NNI_PROTO_RESPONDENT_V0 = NNI_PROTO(6, 3),
-	NNI_PROTO_BUS_V0        = NNI_PROTO(7, 0),
-	NNI_PROTO_STAR_V0       = NNI_PROTO(100, 0),
-};
+
+// Protocol major numbers.  This is here for documentation only, and
+// to serve as a "registry" for managing new protocol numbers.  Consider
+// updating this table when adding new protocols.
+//
+// Protocol     Maj Min Name       Notes
+// -------------------------------------------
+// NONE          0   0             reserved
+// PAIRv0        1   0  pair
+// PAIRv1        1   1  pair1      nng only, experimental
+// PUBv0         2   0  pub
+// SUBv0         2   1  sub
+// REQv0         3   0  req
+// REPv0         3   1  rep
+// PUSHv0        5   0  push
+// PULLv0        5   1  pull
+// SURVEYORv0    6   2  surveyor   minors 0 & 1 retired
+// RESPONDENTv0  6   3  respondent
+// BUSv0         7   0  bus
+// STARv0      100   0  star       mangos only, experimental
 
 extern int  nni_proto_sys_init(void);
 extern void nni_proto_sys_fini(void);

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -102,7 +102,6 @@ static int
 nni_sock_getopt_fd(nni_sock *s, int flag, void *val, size_t *szp)
 {
 	int           rv;
-	uint32_t      flags;
 	nni_notifyfd *fd;
 	nni_msgq *    mq;
 	nni_msgq_cb   cb;

--- a/src/nng.h
+++ b/src/nng.h
@@ -337,33 +337,6 @@ enum nng_flag_enum {
 	NNG_FLAG_NONBLOCK = 2, // Non-blocking operations.
 };
 
-// Builtin protocol socket constructors.
-NNG_DECL int nng_bus0_open(nng_socket *);
-NNG_DECL int nng_pair0_open(nng_socket *);
-NNG_DECL int nng_pair1_open(nng_socket *);
-NNG_DECL int nng_pub0_open(nng_socket *);
-NNG_DECL int nng_sub0_open(nng_socket *);
-NNG_DECL int nng_push0_open(nng_socket *);
-NNG_DECL int nng_pull0_open(nng_socket *);
-NNG_DECL int nng_req0_open(nng_socket *);
-NNG_DECL int nng_rep0_open(nng_socket *);
-NNG_DECL int nng_surveyor0_open(nng_socket *);
-NNG_DECL int nng_respondent0_open(nng_socket *);
-
-// Default versions.  These provide compile time defaults; note that
-// the actual protocols are baked into the binary; this should avoid
-// suprising.  Choosing a new protocol should be done explicitly.
-#define nng_bus_open nng_bus0_open
-#define nng_pair_open nng_pair1_open
-#define nng_pub_open nng_pub0_open
-#define nng_sub_open nng_sub0_open
-#define nng_push_open nng_push0_open
-#define nng_pull_open nng_pull0_open
-#define nng_req_open nng_req0_open
-#define nng_rep_open nng_rep0_open
-#define nng_surveyor_open nng_surveyor0_open
-#define nng_respondent_open nng_respondent0_open
-
 // Options.
 #define NNG_OPT_SOCKNAME "socket-name"
 #define NNG_OPT_DOMAIN "compat:domain" // legacy compat only
@@ -384,15 +357,6 @@ NNG_DECL int nng_respondent0_open(nng_socket *);
 #define NNG_OPT_RECVMAXSZ "recv-size-max"
 #define NNG_OPT_RECONNMINT "reconnect-time-min"
 #define NNG_OPT_RECONNMAXT "reconnect-time-max"
-
-#define NNG_OPT_PAIR1_POLY "pair1:polyamorous"
-
-#define NNG_OPT_SUB_SUBSCRIBE "sub:subscribe"
-#define NNG_OPT_SUB_UNSUBSCRIBE "sub:unsubscribe"
-
-#define NNG_OPT_REQ_RESENDTIME "req:resend-time"
-
-#define NNG_OPT_SURVEYOR_SURVEYTIME "surveyor:survey-time"
 
 // XXX: TBD: priorities, socket names, ipv4only
 

--- a/src/nng_compat.c
+++ b/src/nng_compat.c
@@ -10,6 +10,16 @@
 
 #include "nng_compat.h"
 #include "nng.h"
+#include "protocol/bus0/bus.h"
+#include "protocol/pair0/pair.h"
+#include "protocol/pipeline0/pull.h"
+#include "protocol/pipeline0/push.h"
+#include "protocol/pubsub0/pub.h"
+#include "protocol/pubsub0/sub.h"
+#include "protocol/reqrep0/rep.h"
+#include "protocol/reqrep0/req.h"
+#include "protocol/survey0/respond.h"
+#include "protocol/survey0/survey.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -92,17 +102,37 @@ static const struct {
 	uint16_t p_id;
 	int (*p_open)(nng_socket *);
 } nn_protocols[] = {
-	// clang-format off
+// clang-format off
+#ifdef NNG_HAVE_BUS0
 	{ NN_BUS, nng_bus0_open },
+#endif
+#ifdef NNG_HAVE_PAIR0
 	{ NN_PAIR, nng_pair0_open },
+#endif
+#ifdef NNG_HAVE_PUSH0
 	{ NN_PUSH, nng_push0_open },
+#endif
+#ifdef NNG_HAVE_PULL0
 	{ NN_PULL, nng_pull0_open },
+#endif
+#ifdef NNG_HAVE_PUB0
 	{ NN_PUB, nng_pub0_open },
+#endif
+#ifdef NNG_HAVE_SUB0
 	{ NN_SUB, nng_sub0_open },
+#endif
+#ifdef NNG_HAVE_REQ0
 	{ NN_REQ, nng_req0_open },
+#endif
+#ifdef NNG_HAVE_REP0
 	{ NN_REP, nng_rep0_open },
+#endif
+#ifdef NNG_HAVE_SURVEYOR0
 	{ NN_SURVEYOR, nng_surveyor0_open },
+#endif
+#ifdef NNG_HAVE_RESPONDENT0
 	{ NN_RESPONDENT, nng_respondent0_open },
+#endif
 	{ 0, NULL },
 	// clang-format on
 };
@@ -115,7 +145,7 @@ nn_socket(int domain, int protocol)
 	int        i;
 
 	if ((domain != AF_SP) && (domain != AF_SP_RAW)) {
-		nn_seterror(EAFNOSUPPORT);
+		errno = EAFNOSUPPORT;
 		return (-1);
 	}
 
@@ -125,7 +155,7 @@ nn_socket(int domain, int protocol)
 		}
 	}
 	if (nn_protocols[i].p_open == NULL) {
-		nn_seterror(ENOTSUP);
+		errno = ENOTSUP;
 		return (-1);
 	}
 

--- a/src/protocol/bus0/CMakeLists.txt
+++ b/src/protocol/bus0/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  Bus protocol
+
+if (NNG_PROTO_BUS0)
+    set(BUS0_SOURCES protocol/bus0/bus.c protocol/bus0/bus.h)
+    install(FILES bus.h DESTINATION include/nng/protocol/bus0)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${BUS0_SOURCES} PARENT_SCOPE)

--- a/src/protocol/bus0/bus.h
+++ b/src/protocol/bus0/bus.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_BUS0_BUS_H
+#define NNG_PROTOCOL_BUS0_BUS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_bus0_open(nng_socket *);
+
+#ifndef nng_bus_open
+#define nng_bus_open nng_bus0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_BUS0_BUS_H

--- a/src/protocol/pair0/CMakeLists.txt
+++ b/src/protocol/pair0/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  PAIRv0 protocol
+
+if (NNG_PROTO_PAIR0)
+    set(PAIR0_SOURCES protocol/pair0/pair.c protocol/pair0/pair.h)
+    install(FILES pair.h DESTINATION include/nng/protocol/pair0)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${PAIR0_SOURCES} PARENT_SCOPE)

--- a/src/protocol/pair0/pair.c
+++ b/src/protocol/pair0/pair.c
@@ -17,6 +17,10 @@
 // While a peer is connected to the server, all other peer connection
 // attempts are discarded.
 
+#ifndef NNI_PROTO_PAIR_V0
+#define NNI_PROTO_PAIR_V0 NNI_PROTO(1, 0)
+#endif
+
 typedef struct pair0_pipe pair0_pipe;
 typedef struct pair0_sock pair0_sock;
 

--- a/src/protocol/pair0/pair.h
+++ b/src/protocol/pair0/pair.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_PAIR0_PAIR_H
+#define NNG_PROTOCOL_PAIR0_PAIR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_pair0_open(nng_socket *);
+
+#ifndef nng_pair_open
+#define nng_pair_open nng_pair0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_PAIR0_PAIR_H

--- a/src/protocol/pair1/CMakeLists.txt
+++ b/src/protocol/pair1/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  PAIRv1 protocol
+
+if (NNG_PROTO_PAIR1)
+    set(PAIR1_SOURCES protocol/pair1/pair.c protocol/pair1/pair.h)
+    install(FILES pair.h DESTINATION include/nng/protocol/pair1)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${PAIR1_SOURCES} PARENT_SCOPE)

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -13,9 +13,15 @@
 
 #include "core/nng_impl.h"
 
+#include "protocol/pair1/pair.h"
+
 // Pair protocol.  The PAIRv1 protocol is a simple 1:1 messaging pattern,
 // usually, but it can support a polyamorous mode where a single server can
 // communicate with multiple partners.
+
+#ifndef NNI_PROTO_PAIR_V1
+#define NNI_PROTO_PAIR_V1 NNI_PROTO(1, 1)
+#endif
 
 typedef struct pair1_pipe pair1_pipe;
 typedef struct pair1_sock pair1_sock;

--- a/src/protocol/pair1/pair.h
+++ b/src/protocol/pair1/pair.h
@@ -1,0 +1,30 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_PAIR1_PAIR_H
+#define NNG_PROTOCOL_PAIR1_PAIR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_pair1_open(nng_socket *);
+
+#ifndef nng_pair_open
+#define nng_pair_open nng_pair1_open
+#endif
+
+#define NNG_OPT_PAIR1_POLY "pair1:polyamorous"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_PAIR1_PAIR_H

--- a/src/protocol/pipeline0/CMakeLists.txt
+++ b/src/protocol/pipeline0/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  Pub/Sub protocol
+
+if (NNG_PROTO_PUSH0)
+    set(PUSH0_SOURCES protocol/pipeline0/push.c protocol/pipeline0/push.h)
+    install(FILES push.h DESTINATION include/nng/protocol/pipeline0)
+endif()
+
+if (NNG_PROTO_PULL0)
+    set(PULL0_SOURCES protocol/pipeline0/pull.c protocol/pipeline0/pull.h)
+    install(FILES pull.h DESTINATION include/nng/protocol/pipeline0)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${PUSH0_SOURCES} ${PULL0_SOURCES} PARENT_SCOPE)

--- a/src/protocol/pipeline0/pull.h
+++ b/src/protocol/pipeline0/pull.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_PIPELINE0_PULL_H
+#define NNG_PROTOCOL_PIPELINE0_PULL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_pull0_open(nng_socket *);
+
+#ifndef nng_pull_open
+#define nng_pull_open nng_pull0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_PIPELINE0_PULL_H

--- a/src/protocol/pipeline0/push.h
+++ b/src/protocol/pipeline0/push.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_PIPELINE0_PUSH_H
+#define NNG_PROTOCOL_PIPELINE0_PUSH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_push0_open(nng_socket *);
+
+#ifndef nng_push_open
+#define nng_push_open nng_push0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_PIPELINE0_PUSH_H

--- a/src/protocol/pubsub0/CMakeLists.txt
+++ b/src/protocol/pubsub0/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  Pub/Sub protocol
+
+if (NNG_PROTO_PUB0)
+    set(PUB0_SOURCES protocol/pubsub0/pub.c protocol/pubsub0/pub.h)
+    install(FILES pub.h DESTINATION include/nng/protocol/pubsub0)
+endif()
+
+if (NNG_PROTO_SUB0)
+    set(SUB0_SOURCES protocol/pubsub0/sub.c protocol/pubsub0/sub.h)
+    install(FILES sub.h DESTINATION include/nng/protocol/pubsub0)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${PUB0_SOURCES} ${SUB0_SOURCES} PARENT_SCOPE)

--- a/src/protocol/pubsub0/pub.h
+++ b/src/protocol/pubsub0/pub.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_PUBSUB0_PUB_H
+#define NNG_PROTOCOL_PUBSUB0_PUB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_pub0_open(nng_socket *);
+
+#ifndef nng_pub_open
+#define nng_pub_open nng_pub0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_PUBSUB0_PUB_H

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -12,54 +12,60 @@
 #include <string.h>
 
 #include "core/nng_impl.h"
-
-const char *nng_opt_sub_subscribe   = NNG_OPT_SUB_SUBSCRIBE;
-const char *nng_opt_sub_unsubscribe = NNG_OPT_SUB_UNSUBSCRIBE;
+#include "protocol/pubsub0/sub.h"
 
 // Subscriber protocol.  The SUB protocol receives messages sent to
 // it from publishers, and filters out those it is not interested in,
 // only passing up ones that match known subscriptions.
 
-typedef struct sub_pipe  sub_pipe;
-typedef struct sub_sock  sub_sock;
-typedef struct sub_topic sub_topic;
+#ifndef NNI_PROTO_SUB_V0
+#define NNI_PROTO_SUB_V0 NNI_PROTO(2, 1)
+#endif
 
-static void sub_recv_cb(void *);
-static void sub_putq_cb(void *);
-static void sub_pipe_fini(void *);
+#ifndef NNI_PROTO_PUB_V0
+#define NNI_PROTO_PUB_V0 NNI_PROTO(2, 0)
+#endif
 
-struct sub_topic {
+typedef struct sub0_pipe  sub0_pipe;
+typedef struct sub0_sock  sub0_sock;
+typedef struct sub0_topic sub0_topic;
+
+static void sub0_recv_cb(void *);
+static void sub0_putq_cb(void *);
+static void sub0_pipe_fini(void *);
+
+struct sub0_topic {
 	nni_list_node node;
 	size_t        len;
 	void *        buf;
 };
 
-// An nni_rep_sock is our per-socket protocol private structure.
-struct sub_sock {
+// sub0_sock is our per-socket protocol private structure.
+struct sub0_sock {
 	nni_list  topics;
 	nni_msgq *urq;
 	int       raw;
 	nni_mtx   lk;
 };
 
-// An nni_rep_pipe is our per-pipe protocol private structure.
-struct sub_pipe {
-	nni_pipe *pipe;
-	sub_sock *sub;
-	nni_aio * aio_recv;
-	nni_aio * aio_putq;
+// sub0_pipe is our per-pipe protocol private structure.
+struct sub0_pipe {
+	nni_pipe * pipe;
+	sub0_sock *sub;
+	nni_aio *  aio_recv;
+	nni_aio *  aio_putq;
 };
 
 static int
-sub_sock_init(void **sp, nni_sock *sock)
+sub0_sock_init(void **sp, nni_sock *sock)
 {
-	sub_sock *s;
+	sub0_sock *s;
 
 	if ((s = NNI_ALLOC_STRUCT(s)) == NULL) {
 		return (NNG_ENOMEM);
 	}
 	nni_mtx_init(&s->lk);
-	NNI_LIST_INIT(&s->topics, sub_topic, node);
+	NNI_LIST_INIT(&s->topics, sub0_topic, node);
 	s->raw = 0;
 
 	s->urq = nni_sock_recvq(sock);
@@ -68,10 +74,10 @@ sub_sock_init(void **sp, nni_sock *sock)
 }
 
 static void
-sub_sock_fini(void *arg)
+sub0_sock_fini(void *arg)
 {
-	sub_sock * s = arg;
-	sub_topic *topic;
+	sub0_sock * s = arg;
+	sub0_topic *topic;
 
 	while ((topic = nni_list_first(&s->topics)) != NULL) {
 		nni_list_remove(&s->topics, topic);
@@ -83,21 +89,21 @@ sub_sock_fini(void *arg)
 }
 
 static void
-sub_sock_open(void *arg)
+sub0_sock_open(void *arg)
 {
 	NNI_ARG_UNUSED(arg);
 }
 
 static void
-sub_sock_close(void *arg)
+sub0_sock_close(void *arg)
 {
 	NNI_ARG_UNUSED(arg);
 }
 
 static void
-sub_pipe_fini(void *arg)
+sub0_pipe_fini(void *arg)
 {
-	sub_pipe *p = arg;
+	sub0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_recv);
@@ -105,17 +111,17 @@ sub_pipe_fini(void *arg)
 }
 
 static int
-sub_pipe_init(void **pp, nni_pipe *pipe, void *s)
+sub0_pipe_init(void **pp, nni_pipe *pipe, void *s)
 {
-	sub_pipe *p;
-	int       rv;
+	sub0_pipe *p;
+	int        rv;
 
 	if ((p = NNI_ALLOC_STRUCT(p)) == NULL) {
 		return (NNG_ENOMEM);
 	}
-	if (((rv = nni_aio_init(&p->aio_putq, sub_putq_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->aio_recv, sub_recv_cb, p)) != 0)) {
-		sub_pipe_fini(p);
+	if (((rv = nni_aio_init(&p->aio_putq, sub0_putq_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->aio_recv, sub0_recv_cb, p)) != 0)) {
+		sub0_pipe_fini(p);
 		return (rv);
 	}
 
@@ -126,30 +132,30 @@ sub_pipe_init(void **pp, nni_pipe *pipe, void *s)
 }
 
 static int
-sub_pipe_start(void *arg)
+sub0_pipe_start(void *arg)
 {
-	sub_pipe *p = arg;
+	sub0_pipe *p = arg;
 
 	nni_pipe_recv(p->pipe, p->aio_recv);
 	return (0);
 }
 
 static void
-sub_pipe_stop(void *arg)
+sub0_pipe_stop(void *arg)
 {
-	sub_pipe *p = arg;
+	sub0_pipe *p = arg;
 
 	nni_aio_stop(p->aio_putq);
 	nni_aio_stop(p->aio_recv);
 }
 
 static void
-sub_recv_cb(void *arg)
+sub0_recv_cb(void *arg)
 {
-	sub_pipe *p   = arg;
-	sub_sock *s   = p->sub;
-	nni_msgq *urq = s->urq;
-	nni_msg * msg;
+	sub0_pipe *p   = arg;
+	sub0_sock *s   = p->sub;
+	nni_msgq * urq = s->urq;
+	nni_msg *  msg;
 
 	if (nni_aio_result(p->aio_recv) != 0) {
 		nni_pipe_stop(p->pipe);
@@ -164,9 +170,9 @@ sub_recv_cb(void *arg)
 }
 
 static void
-sub_putq_cb(void *arg)
+sub0_putq_cb(void *arg)
 {
-	sub_pipe *p = arg;
+	sub0_pipe *p = arg;
 
 	if (nni_aio_result(p->aio_putq) != 0) {
 		nni_msg_free(nni_aio_get_msg(p->aio_putq));
@@ -184,11 +190,11 @@ sub_putq_cb(void *arg)
 // to replace this with a patricia trie, like old nanomsg had.
 
 static int
-sub_subscribe(void *arg, const void *buf, size_t sz)
+sub0_subscribe(void *arg, const void *buf, size_t sz)
 {
-	sub_sock * s = arg;
-	sub_topic *topic;
-	sub_topic *newtopic;
+	sub0_sock * s = arg;
+	sub0_topic *topic;
+	sub0_topic *newtopic;
 
 	nni_mtx_lock(&s->lk);
 	NNI_LIST_FOREACH (&s->topics, topic) {
@@ -234,11 +240,11 @@ sub_subscribe(void *arg, const void *buf, size_t sz)
 }
 
 static int
-sub_unsubscribe(void *arg, const void *buf, size_t sz)
+sub0_unsubscribe(void *arg, const void *buf, size_t sz)
 {
-	sub_sock * s = arg;
-	sub_topic *topic;
-	int        rv;
+	sub0_sock * s = arg;
+	sub0_topic *topic;
+	int         rv;
 
 	nni_mtx_lock(&s->lk);
 	NNI_LIST_FOREACH (&s->topics, topic) {
@@ -270,41 +276,41 @@ sub_unsubscribe(void *arg, const void *buf, size_t sz)
 }
 
 static int
-sub_sock_setopt_raw(void *arg, const void *buf, size_t sz)
+sub0_sock_setopt_raw(void *arg, const void *buf, size_t sz)
 {
-	sub_sock *s = arg;
+	sub0_sock *s = arg;
 	return (nni_setopt_int(&s->raw, buf, sz, 0, 1));
 }
 
 static int
-sub_sock_getopt_raw(void *arg, void *buf, size_t *szp)
+sub0_sock_getopt_raw(void *arg, void *buf, size_t *szp)
 {
-	sub_sock *s = arg;
+	sub0_sock *s = arg;
 	return (nni_getopt_int(s->raw, buf, szp));
 }
 
 static void
-sub_sock_send(void *arg, nni_aio *aio)
+sub0_sock_send(void *arg, nni_aio *aio)
 {
 	nni_aio_finish_error(aio, NNG_ENOTSUP);
 }
 
 static void
-sub_sock_recv(void *arg, nni_aio *aio)
+sub0_sock_recv(void *arg, nni_aio *aio)
 {
-	sub_sock *s = arg;
+	sub0_sock *s = arg;
 
 	nni_msgq_aio_get(s->urq, aio);
 }
 
 static nni_msg *
-sub_sock_filter(void *arg, nni_msg *msg)
+sub0_sock_filter(void *arg, nni_msg *msg)
 {
-	sub_sock * s = arg;
-	sub_topic *topic;
-	char *     body;
-	size_t     len;
-	int        match;
+	sub0_sock * s = arg;
+	sub0_topic *topic;
+	char *      body;
+	size_t      len;
+	int         match;
 
 	nni_mtx_lock(&s->lk);
 	if (s->raw) {
@@ -344,55 +350,55 @@ sub_sock_filter(void *arg, nni_msg *msg)
 
 // This is the global protocol structure -- our linkage to the core.
 // This should be the only global non-static symbol in this file.
-static nni_proto_pipe_ops sub_pipe_ops = {
-	.pipe_init  = sub_pipe_init,
-	.pipe_fini  = sub_pipe_fini,
-	.pipe_start = sub_pipe_start,
-	.pipe_stop  = sub_pipe_stop,
+static nni_proto_pipe_ops sub0_pipe_ops = {
+	.pipe_init  = sub0_pipe_init,
+	.pipe_fini  = sub0_pipe_fini,
+	.pipe_start = sub0_pipe_start,
+	.pipe_stop  = sub0_pipe_stop,
 };
 
-static nni_proto_sock_option sub_sock_options[] = {
+static nni_proto_sock_option sub0_sock_options[] = {
 	{
 	    .pso_name   = NNG_OPT_RAW,
-	    .pso_getopt = sub_sock_getopt_raw,
-	    .pso_setopt = sub_sock_setopt_raw,
+	    .pso_getopt = sub0_sock_getopt_raw,
+	    .pso_setopt = sub0_sock_setopt_raw,
 	},
 	{
 	    .pso_name   = NNG_OPT_SUB_SUBSCRIBE,
 	    .pso_getopt = NULL,
-	    .pso_setopt = sub_subscribe,
+	    .pso_setopt = sub0_subscribe,
 	},
 	{
 	    .pso_name   = NNG_OPT_SUB_UNSUBSCRIBE,
 	    .pso_getopt = NULL,
-	    .pso_setopt = sub_unsubscribe,
+	    .pso_setopt = sub0_unsubscribe,
 	},
 	// terminate list
 	{ NULL, NULL, NULL },
 };
 
-static nni_proto_sock_ops sub_sock_ops = {
-	.sock_init    = sub_sock_init,
-	.sock_fini    = sub_sock_fini,
-	.sock_open    = sub_sock_open,
-	.sock_close   = sub_sock_close,
-	.sock_send    = sub_sock_send,
-	.sock_recv    = sub_sock_recv,
-	.sock_filter  = sub_sock_filter,
-	.sock_options = sub_sock_options,
+static nni_proto_sock_ops sub0_sock_ops = {
+	.sock_init    = sub0_sock_init,
+	.sock_fini    = sub0_sock_fini,
+	.sock_open    = sub0_sock_open,
+	.sock_close   = sub0_sock_close,
+	.sock_send    = sub0_sock_send,
+	.sock_recv    = sub0_sock_recv,
+	.sock_filter  = sub0_sock_filter,
+	.sock_options = sub0_sock_options,
 };
 
-static nni_proto sub_proto = {
+static nni_proto sub0_proto = {
 	.proto_version  = NNI_PROTOCOL_VERSION,
 	.proto_self     = { NNI_PROTO_SUB_V0, "sub" },
 	.proto_peer     = { NNI_PROTO_PUB_V0, "pub" },
 	.proto_flags    = NNI_PROTO_FLAG_RCV,
-	.proto_sock_ops = &sub_sock_ops,
-	.proto_pipe_ops = &sub_pipe_ops,
+	.proto_sock_ops = &sub0_sock_ops,
+	.proto_pipe_ops = &sub0_pipe_ops,
 };
 
 int
 nng_sub0_open(nng_socket *sidp)
 {
-	return (nni_proto_open(sidp, &sub_proto));
+	return (nni_proto_open(sidp, &sub0_proto));
 }

--- a/src/protocol/pubsub0/sub.h
+++ b/src/protocol/pubsub0/sub.h
@@ -1,0 +1,31 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_PUBSUB0_SUB_H
+#define NNG_PROTOCOL_PUBSUB0_SUB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_sub0_open(nng_socket *);
+
+#ifndef nng_sub_open
+#define nng_sub_open nng_sub0_open
+#endif
+
+#define NNG_OPT_SUB_SUBSCRIBE "sub:subscribe"
+#define NNG_OPT_SUB_UNSUBSCRIBE "sub:unsubscribe"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_PUBSUB0_SUB_H

--- a/src/protocol/reqrep0/CMakeLists.txt
+++ b/src/protocol/reqrep0/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  Req/Rep protocol
+
+if (NNG_PROTO_REQ0)
+    set(REQ0_SOURCES protocol/reqrep0/req.c protocol/reqrep0/req.h)
+    install(FILES req.h DESTINATION include/nng/protocol/reqrep0)
+endif()
+
+if (NNG_PROTO_REP0)
+    set(REP0_SOURCES protocol/reqrep0/rep.c protocol/reqrep0/rep.h)
+    install(FILES rep.h DESTINATION include/nng/protocol/reqrep0)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${REQ0_SOURCES} ${REP0_SOURCES} PARENT_SCOPE)

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -12,23 +12,32 @@
 #include <string.h>
 
 #include "core/nng_impl.h"
+#include "protocol/reqrep0/rep.h"
 
 // Response protocol.  The REP protocol is the "reply" side of a
 // request-reply pair.  This is useful for building RPC servers, for
 // example.
 
-typedef struct rep_pipe rep_pipe;
-typedef struct rep_sock rep_sock;
+#ifndef NNI_PROTO_REQ_V0
+#define NNI_PROTO_REQ_V0 NNI_PROTO(3, 0)
+#endif
 
-static void rep_sock_getq_cb(void *);
-static void rep_pipe_getq_cb(void *);
-static void rep_pipe_putq_cb(void *);
-static void rep_pipe_send_cb(void *);
-static void rep_pipe_recv_cb(void *);
-static void rep_pipe_fini(void *);
+#ifndef NNI_PROTO_REP_V0
+#define NNI_PROTO_REP_V0 NNI_PROTO(3, 1)
+#endif
 
-// A rep_sock is our per-socket protocol private structure.
-struct rep_sock {
+typedef struct rep0_pipe rep0_pipe;
+typedef struct rep0_sock rep0_sock;
+
+static void rep0_sock_getq_cb(void *);
+static void rep0_pipe_getq_cb(void *);
+static void rep0_pipe_putq_cb(void *);
+static void rep0_pipe_send_cb(void *);
+static void rep0_pipe_recv_cb(void *);
+static void rep0_pipe_fini(void *);
+
+// rep0_sock is our per-socket protocol private structure.
+struct rep0_sock {
 	nni_msgq *  uwq;
 	nni_msgq *  urq;
 	nni_mtx     lk;
@@ -40,21 +49,21 @@ struct rep_sock {
 	nni_aio *   aio_getq;
 };
 
-// A rep_pipe is our per-pipe protocol private structure.
-struct rep_pipe {
-	nni_pipe *pipe;
-	rep_sock *rep;
-	nni_msgq *sendq;
-	nni_aio * aio_getq;
-	nni_aio * aio_send;
-	nni_aio * aio_recv;
-	nni_aio * aio_putq;
+// rep0_pipe is our per-pipe protocol private structure.
+struct rep0_pipe {
+	nni_pipe * pipe;
+	rep0_sock *rep;
+	nni_msgq * sendq;
+	nni_aio *  aio_getq;
+	nni_aio *  aio_send;
+	nni_aio *  aio_recv;
+	nni_aio *  aio_putq;
 };
 
 static void
-rep_sock_fini(void *arg)
+rep0_sock_fini(void *arg)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 
 	nni_aio_stop(s->aio_getq);
 	nni_aio_fini(s->aio_getq);
@@ -67,18 +76,18 @@ rep_sock_fini(void *arg)
 }
 
 static int
-rep_sock_init(void **sp, nni_sock *sock)
+rep0_sock_init(void **sp, nni_sock *sock)
 {
-	rep_sock *s;
-	int       rv;
+	rep0_sock *s;
+	int        rv;
 
 	if ((s = NNI_ALLOC_STRUCT(s)) == NULL) {
 		return (NNG_ENOMEM);
 	}
 	nni_mtx_init(&s->lk);
 	if (((rv = nni_idhash_init(&s->pipes)) != 0) ||
-	    ((rv = nni_aio_init(&s->aio_getq, rep_sock_getq_cb, s)) != 0)) {
-		rep_sock_fini(s);
+	    ((rv = nni_aio_init(&s->aio_getq, rep0_sock_getq_cb, s)) != 0)) {
+		rep0_sock_fini(s);
 		return (rv);
 	}
 
@@ -95,25 +104,25 @@ rep_sock_init(void **sp, nni_sock *sock)
 }
 
 static void
-rep_sock_open(void *arg)
+rep0_sock_open(void *arg)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 
 	nni_msgq_aio_get(s->uwq, s->aio_getq);
 }
 
 static void
-rep_sock_close(void *arg)
+rep0_sock_close(void *arg)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 
 	nni_aio_cancel(s->aio_getq, NNG_ECLOSED);
 }
 
 static void
-rep_pipe_fini(void *arg)
+rep0_pipe_fini(void *arg)
 {
-	rep_pipe *p = arg;
+	rep0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -124,20 +133,20 @@ rep_pipe_fini(void *arg)
 }
 
 static int
-rep_pipe_init(void **pp, nni_pipe *pipe, void *s)
+rep0_pipe_init(void **pp, nni_pipe *pipe, void *s)
 {
-	rep_pipe *p;
-	int       rv;
+	rep0_pipe *p;
+	int        rv;
 
 	if ((p = NNI_ALLOC_STRUCT(p)) == NULL) {
 		return (NNG_ENOMEM);
 	}
 	if (((rv = nni_msgq_init(&p->sendq, 2)) != 0) ||
-	    ((rv = nni_aio_init(&p->aio_getq, rep_pipe_getq_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->aio_send, rep_pipe_send_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->aio_recv, rep_pipe_recv_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->aio_putq, rep_pipe_putq_cb, p)) != 0)) {
-		rep_pipe_fini(p);
+	    ((rv = nni_aio_init(&p->aio_getq, rep0_pipe_getq_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->aio_send, rep0_pipe_send_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->aio_recv, rep0_pipe_recv_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->aio_putq, rep0_pipe_putq_cb, p)) != 0)) {
+		rep0_pipe_fini(p);
 		return (rv);
 	}
 
@@ -148,11 +157,11 @@ rep_pipe_init(void **pp, nni_pipe *pipe, void *s)
 }
 
 static int
-rep_pipe_start(void *arg)
+rep0_pipe_start(void *arg)
 {
-	rep_pipe *p = arg;
-	rep_sock *s = p->rep;
-	int       rv;
+	rep0_pipe *p = arg;
+	rep0_sock *s = p->rep;
+	int        rv;
 
 	if ((rv = nni_idhash_insert(s->pipes, nni_pipe_id(p->pipe), p)) != 0) {
 		return (rv);
@@ -164,10 +173,10 @@ rep_pipe_start(void *arg)
 }
 
 static void
-rep_pipe_stop(void *arg)
+rep0_pipe_stop(void *arg)
 {
-	rep_pipe *p = arg;
-	rep_sock *s = p->rep;
+	rep0_pipe *p = arg;
+	rep0_sock *s = p->rep;
 
 	nni_msgq_close(p->sendq);
 	nni_aio_stop(p->aio_getq);
@@ -179,14 +188,14 @@ rep_pipe_stop(void *arg)
 }
 
 static void
-rep_sock_getq_cb(void *arg)
+rep0_sock_getq_cb(void *arg)
 {
-	rep_sock *s   = arg;
-	nni_msgq *uwq = s->uwq;
-	nni_msg * msg;
-	uint32_t  id;
-	rep_pipe *p;
-	int       rv;
+	rep0_sock *s   = arg;
+	nni_msgq * uwq = s->uwq;
+	nni_msg *  msg;
+	uint32_t   id;
+	rep0_pipe *p;
+	int        rv;
 
 	// This watches for messages from the upper write queue,
 	// extracts the destination pipe, and forwards it to the appropriate
@@ -228,9 +237,9 @@ rep_sock_getq_cb(void *arg)
 }
 
 static void
-rep_pipe_getq_cb(void *arg)
+rep0_pipe_getq_cb(void *arg)
 {
-	rep_pipe *p = arg;
+	rep0_pipe *p = arg;
 
 	if (nni_aio_result(p->aio_getq) != 0) {
 		nni_pipe_stop(p->pipe);
@@ -244,9 +253,9 @@ rep_pipe_getq_cb(void *arg)
 }
 
 static void
-rep_pipe_send_cb(void *arg)
+rep0_pipe_send_cb(void *arg)
 {
-	rep_pipe *p = arg;
+	rep0_pipe *p = arg;
 
 	if (nni_aio_result(p->aio_send) != 0) {
 		nni_msg_free(nni_aio_get_msg(p->aio_send));
@@ -259,14 +268,14 @@ rep_pipe_send_cb(void *arg)
 }
 
 static void
-rep_pipe_recv_cb(void *arg)
+rep0_pipe_recv_cb(void *arg)
 {
-	rep_pipe *p = arg;
-	rep_sock *s = p->rep;
-	nni_msg * msg;
-	int       rv;
-	uint8_t * body;
-	int       hops;
+	rep0_pipe *p = arg;
+	rep0_sock *s = p->rep;
+	nni_msg *  msg;
+	int        rv;
+	uint8_t *  body;
+	int        hops;
 
 	if (nni_aio_result(p->aio_recv) != 0) {
 		nni_pipe_stop(p->pipe);
@@ -329,9 +338,9 @@ drop:
 }
 
 static void
-rep_pipe_putq_cb(void *arg)
+rep0_pipe_putq_cb(void *arg)
 {
-	rep_pipe *p = arg;
+	rep0_pipe *p = arg;
 
 	if (nni_aio_result(p->aio_putq) != 0) {
 		nni_msg_free(nni_aio_get_msg(p->aio_putq));
@@ -344,10 +353,10 @@ rep_pipe_putq_cb(void *arg)
 }
 
 static int
-rep_sock_setopt_raw(void *arg, const void *buf, size_t sz)
+rep0_sock_setopt_raw(void *arg, const void *buf, size_t sz)
 {
-	rep_sock *s = arg;
-	int       rv;
+	rep0_sock *s = arg;
+	int        rv;
 
 	nni_mtx_lock(&s->lk);
 	rv = nni_setopt_int(&s->raw, buf, sz, 0, 1);
@@ -356,32 +365,32 @@ rep_sock_setopt_raw(void *arg, const void *buf, size_t sz)
 }
 
 static int
-rep_sock_getopt_raw(void *arg, void *buf, size_t *szp)
+rep0_sock_getopt_raw(void *arg, void *buf, size_t *szp)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 	return (nni_getopt_int(s->raw, buf, szp));
 }
 
 static int
-rep_sock_setopt_maxttl(void *arg, const void *buf, size_t sz)
+rep0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 	return (nni_setopt_int(&s->ttl, buf, sz, 1, 255));
 }
 
 static int
-rep_sock_getopt_maxttl(void *arg, void *buf, size_t *szp)
+rep0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 	return (nni_getopt_int(s->ttl, buf, szp));
 }
 
 static nni_msg *
-rep_sock_filter(void *arg, nni_msg *msg)
+rep0_sock_filter(void *arg, nni_msg *msg)
 {
-	rep_sock *s = arg;
-	char *    header;
-	size_t    len;
+	rep0_sock *s = arg;
+	char *     header;
+	size_t     len;
 
 	nni_mtx_lock(&s->lk);
 	if (s->raw) {
@@ -408,11 +417,11 @@ rep_sock_filter(void *arg, nni_msg *msg)
 }
 
 static void
-rep_sock_send(void *arg, nni_aio *aio)
+rep0_sock_send(void *arg, nni_aio *aio)
 {
-	rep_sock *s = arg;
-	int       rv;
-	nni_msg * msg;
+	rep0_sock *s = arg;
+	int        rv;
+	nni_msg *  msg;
 
 	nni_mtx_lock(&s->lk);
 	if (s->raw) {
@@ -448,59 +457,59 @@ rep_sock_send(void *arg, nni_aio *aio)
 }
 
 static void
-rep_sock_recv(void *arg, nni_aio *aio)
+rep0_sock_recv(void *arg, nni_aio *aio)
 {
-	rep_sock *s = arg;
+	rep0_sock *s = arg;
 
 	nni_msgq_aio_get(s->urq, aio);
 }
 
 // This is the global protocol structure -- our linkage to the core.
 // This should be the only global non-static symbol in this file.
-static nni_proto_pipe_ops rep_pipe_ops = {
-	.pipe_init  = rep_pipe_init,
-	.pipe_fini  = rep_pipe_fini,
-	.pipe_start = rep_pipe_start,
-	.pipe_stop  = rep_pipe_stop,
+static nni_proto_pipe_ops rep0_pipe_ops = {
+	.pipe_init  = rep0_pipe_init,
+	.pipe_fini  = rep0_pipe_fini,
+	.pipe_start = rep0_pipe_start,
+	.pipe_stop  = rep0_pipe_stop,
 };
 
-static nni_proto_sock_option rep_sock_options[] = {
+static nni_proto_sock_option rep0_sock_options[] = {
 	{
 	    .pso_name   = NNG_OPT_RAW,
-	    .pso_getopt = rep_sock_getopt_raw,
-	    .pso_setopt = rep_sock_setopt_raw,
+	    .pso_getopt = rep0_sock_getopt_raw,
+	    .pso_setopt = rep0_sock_setopt_raw,
 	},
 	{
 	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_getopt = rep_sock_getopt_maxttl,
-	    .pso_setopt = rep_sock_setopt_maxttl,
+	    .pso_getopt = rep0_sock_getopt_maxttl,
+	    .pso_setopt = rep0_sock_setopt_maxttl,
 	},
 	// terminate list
 	{ NULL, NULL, NULL },
 };
 
-static nni_proto_sock_ops rep_sock_ops = {
-	.sock_init    = rep_sock_init,
-	.sock_fini    = rep_sock_fini,
-	.sock_open    = rep_sock_open,
-	.sock_close   = rep_sock_close,
-	.sock_options = rep_sock_options,
-	.sock_filter  = rep_sock_filter,
-	.sock_send    = rep_sock_send,
-	.sock_recv    = rep_sock_recv,
+static nni_proto_sock_ops rep0_sock_ops = {
+	.sock_init    = rep0_sock_init,
+	.sock_fini    = rep0_sock_fini,
+	.sock_open    = rep0_sock_open,
+	.sock_close   = rep0_sock_close,
+	.sock_options = rep0_sock_options,
+	.sock_filter  = rep0_sock_filter,
+	.sock_send    = rep0_sock_send,
+	.sock_recv    = rep0_sock_recv,
 };
 
-static nni_proto nni_rep_proto = {
+static nni_proto rep0_proto = {
 	.proto_version  = NNI_PROTOCOL_VERSION,
 	.proto_self     = { NNI_PROTO_REP_V0, "rep" },
 	.proto_peer     = { NNI_PROTO_REQ_V0, "req" },
 	.proto_flags    = NNI_PROTO_FLAG_SNDRCV,
-	.proto_sock_ops = &rep_sock_ops,
-	.proto_pipe_ops = &rep_pipe_ops,
+	.proto_sock_ops = &rep0_sock_ops,
+	.proto_pipe_ops = &rep0_pipe_ops,
 };
 
 int
 nng_rep0_open(nng_socket *sidp)
 {
-	return (nni_proto_open(sidp, &nni_rep_proto));
+	return (nni_proto_open(sidp, &rep0_proto));
 }

--- a/src/protocol/reqrep0/rep.h
+++ b/src/protocol/reqrep0/rep.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_REQREP0_REP_H
+#define NNG_PROTOCOL_REQREP0_REP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_rep0_open(nng_socket *);
+
+#ifndef nng_rep_open
+#define nng_rep_open nng_rep0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_REQREP0_REP_H

--- a/src/protocol/reqrep0/req.h
+++ b/src/protocol/reqrep0/req.h
@@ -1,0 +1,30 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_REQREP0_REQ_H
+#define NNG_PROTOCOL_REQREP0_REQ_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_req0_open(nng_socket *);
+
+#ifndef nng_req_open
+#define nng_req_open nng_req0_open
+#endif
+
+#define NNG_OPT_REQ_RESENDTIME "req:resend-time"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_REQREP0_REQ_H

--- a/src/protocol/survey0/CMakeLists.txt
+++ b/src/protocol/survey0/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+#  Req/Rep protocol
+
+if (NNG_PROTO_SURVEYOR0)
+    set(SURV0_SOURCES protocol/survey0/survey.c protocol/survey0/survey.h)
+    install(FILES survey.h DESTINATION include/nng/protocol/survey0)
+endif()
+
+if (NNG_PROTO_RESPONDENT0)
+    set(RESP0_SOURCES protocol/survey0/respond.c protocol/survey0/respond.h)
+    install(FILES respond.h DESTINATION include/nng/protocol/survey0)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${SURV0_SOURCES} ${RESP0_SOURCES} PARENT_SCOPE)

--- a/src/protocol/survey0/respond.h
+++ b/src/protocol/survey0/respond.h
@@ -1,0 +1,28 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_SURVEY0_RESPOND_H
+#define NNG_PROTOCOL_SURVEY0_RESPOND_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_respondent0_open(nng_socket *);
+
+#ifndef nng_respondent_open
+#define nng_respondent_open nng_respondent0_open
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_SURVEY0_RESPOND_H

--- a/src/protocol/survey0/survey.h
+++ b/src/protocol/survey0/survey.h
@@ -1,0 +1,30 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_PROTOCOL_SURVEY0_SURVEY_H
+#define NNG_PROTOCOL_SURVEY0_SURVEY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+NNG_DECL int nng_surveyor0_open(nng_socket *);
+
+#ifndef nng_surveyor_open
+#define nng_surveyor_open nng_surveyor0_open
+#endif
+
+#define NNG_OPT_SURVEYOR_SURVEYTIME "surveyor:survey-time"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_PROTOCOL_SURVEY0_SURVEY_H

--- a/src/transport/inproc/CMakeLists.txt
+++ b/src/transport/inproc/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+# inproc protocol
+
+if (NNG_TRANSPORT_INPROC)
+    set(INPROC_SOURCES transport/inproc/inproc.c transport/inproc/inproc.h)
+    install(FILES inproc.h DESTINATION include/nng/transport/inproc)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${INPROC_SOURCES} PARENT_SCOPE)

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -475,9 +475,8 @@ struct nni_tran nni_inproc_tran = {
 	.tran_fini    = nni_inproc_fini,
 };
 
-
 int
 nng_inproc_register(void)
 {
-        return (nni_tran_register(&nni_inproc_tran));
+	return (nni_tran_register(&nni_inproc_tran));
 }

--- a/src/transport/ipc/CMakeLists.txt
+++ b/src/transport/ipc/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+# ipc protocol
+
+if (NNG_TRANSPORT_IPC)
+    set(IPC_SOURCES transport/ipc/ipc.c transport/ipc/ipc.h)
+    install(FILES ipc.h DESTINATION include/nng/transport/ipc)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${IPC_SOURCES} PARENT_SCOPE)

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -704,9 +704,7 @@ static nni_tran_ep nni_ipc_ep_ops = {
 	.ep_options = nni_ipc_ep_options,
 };
 
-// This is the IPC transport linkage, and should be the only global
-// symbol in this entire file.
-struct nni_tran nni_ipc_tran = {
+static nni_tran nni_ipc_tran = {
 	.tran_version = NNI_TRANSPORT_VERSION,
 	.tran_scheme  = "ipc",
 	.tran_ep      = &nni_ipc_ep_ops,
@@ -714,3 +712,9 @@ struct nni_tran nni_ipc_tran = {
 	.tran_init    = nni_ipc_tran_init,
 	.tran_fini    = nni_ipc_tran_fini,
 };
+
+int
+nng_ipc_register(void)
+{
+	return (nni_tran_register(&nni_ipc_tran));
+}

--- a/src/transport/ipc/ipc.h
+++ b/src/transport/ipc/ipc.h
@@ -1,0 +1,19 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_TRANSPORT_IPC_IPC_H
+#define NNG_TRANSPORT_IPC_IPC_H
+
+// ipc transport.  This is used for inter-process communication on
+// the same host computer.
+
+extern int nng_ipc_register(void);
+
+#endif // NNG_TRANSPORT_IPC_IPC_H

--- a/src/transport/tcp/CMakeLists.txt
+++ b/src/transport/tcp/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+# TCP protocol
+
+if (NNG_TRANSPORT_TCP)
+    set(TCP_SOURCES transport/tcp/tcp.c transport/tcp/tcp.h)
+    install(FILES tcp.h DESTINATION include/nng/transport/tcp)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${TCP_SOURCES} PARENT_SCOPE)

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -854,9 +854,7 @@ static nni_tran_ep nni_tcp_ep_ops = {
 	.ep_options = nni_tcp_ep_options,
 };
 
-// This is the TCP transport linkage, and should be the only global
-// symbol in this entire file.
-struct nni_tran nni_tcp_tran = {
+static nni_tran nni_tcp_tran = {
 	.tran_version = NNI_TRANSPORT_VERSION,
 	.tran_scheme  = "tcp",
 	.tran_ep      = &nni_tcp_ep_ops,
@@ -864,3 +862,9 @@ struct nni_tran nni_tcp_tran = {
 	.tran_init    = nni_tcp_tran_init,
 	.tran_fini    = nni_tcp_tran_fini,
 };
+
+int
+nng_tcp_register(void)
+{
+	return (nni_tran_register(&nni_tcp_tran));
+}

--- a/src/transport/tcp/tcp.h
+++ b/src/transport/tcp/tcp.h
@@ -1,0 +1,18 @@
+//
+// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_TRANSPORT_TCP_TCP_H
+#define NNG_TRANSPORT_TCP_TCP_H
+
+// TCP transport.  This is used for communication over TCP/IP.
+
+extern int nng_tcp_register(void);
+
+#endif // NNG_TRANSPORT_TCP_TCP_H

--- a/src/transport/zerotier/CMakeLists.txt
+++ b/src/transport/zerotier/CMakeLists.txt
@@ -1,0 +1,50 @@
+#
+# Copyright 2017 Garrett D'Amore <garrett@damore.org>
+# Copyright 2017 Capitar IT Group BV <info@capitar.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+#
+
+# ZeroTier protocol
+
+set (NNG_TRANSPORT_ZEROTIER_SOURCE "" CACHE PATH "Location of ZeroTier source tree.")
+
+if (NNG_TRANSPORT_ZEROTIER)
+
+    # We use the libzerotiercore.a library, which is unfortunately a C++ object
+    # even though it exposes only public C symbols.  It would be extremely
+    # helpful if libzerotiercore didn't make us carry the whole C++ runtime
+    # behind us.  The user must specify the location of the ZeroTier source
+    # tree (dev branch for now, and already compiled please) by setting the
+    # NNG_ZEROTIER_SOURCE macro.
+    # NB: This needs to be the zerotierone tree, not the libzt library.
+    # This is because we don't access the API, but instead use the low
+    # level zerotiercore functionality directly.
+    # NB: As we wind up linking libzerotiercore.a into the application,
+    # this means that your application will *also* need to either be licensed
+    # under the GPLv3, or you will need to have a commercial license from
+    # ZeroTier permitting its use elsewhere.
+    
+    enable_language(CXX)
+    find_library(NNG_LIBZTCORE zerotiercore PATHS ${NNG_TRANSPORT_ZEROTIER_SOURCE})
+    if (NNG_LIBZTCORE)
+        set(CMAKE_REQUIRED_INCLUDES ${NNG_TRANSPORT_ZEROTIER_SOURCE}/include)
+        message(STATUS "C++ ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES}")
+        set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${NNG_LIBZTCORE} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES})
+        set(NNG_REQUIRED_LIBRARIES ${NNG_REQUIRED_LIBRARIES} ${NNG_LIBZTCORE} ${CMAKE_CXX_IMPLICIT_LINK_LIBRARIES} PARENT_SCOPE)
+        set(NNG_REQUIRED_INCLUDES ${NNG_REQUIRED_INCLUDES} ${NNG_TRANSPORT_ZEROTIER_SOURCE}/include PARENT_SCOPE)
+        nng_check_sym(ZT_Node_join ZeroTierOne.h HAVE_ZTCORE)
+    endif()
+    if (NOT HAVE_ZTCORE)
+        message (FATAL_ERROR "Cannot find ZeroTier components")
+    endif()
+    message(STATUS "Found ZeroTier at ${NNG_LIBZTCORE}")
+
+    set(ZT_SOURCES transport/zerotier/zerotier.c transport/zerotier/zerotier.h)
+    install(FILES zerotier.h DESTINATION include/nng/transport/zerotier)
+endif()
+
+set(NNG_SOURCES ${NNG_SOURCES} ${ZT_SOURCES} PARENT_SCOPE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,20 +61,37 @@ if (NNG_TESTS)
         math (EXPR TEST_PORT "${TEST_PORT}+20")
     endmacro (add_nng_test)
 
-    macro (add_nng_compat_test NAME TIMEOUT)
-        list (APPEND all_tests ${NAME})
-        add_executable (${NAME} ${NAME}.c)
-        target_link_libraries (${NAME} ${PROJECT_NAME}_static)
-        target_link_libraries (${NAME} ${NNG_REQUIRED_LIBRARIES})
-        target_compile_definitions(${NAME} PUBLIC -DNNG_STATIC_LIB)
-        if (CMAKE_THREAD_LIBS_INIT)
-            target_link_libraries (${NAME} "${CMAKE_THREAD_LIBS_INIT}")
-        endif()
+    # Compatibility tests are only added if all of the legacy protocols
+    # are present.  It's not worth trying to figure out which of these
+    # should work and which shouldn't.
+    if (NNG_PROTO_BUS0 AND
+        NNG_PROTO_PAIR0 AND
+        NNG_PROTO_REQ0 AND
+        NNG_PROTO_REP0 AND
+        NNG_PROTO_PUB0 AND
+        NNG_PROTO_SUB0 AND
+        NNG_PROTO_PUSH0 AND
+        NNG_PROTO_PULL0)
 
-        add_test (NAME ${NAME} COMMAND ${NAME} ${TEST_PORT})
-        set_tests_properties (${NAME} PROPERTIES TIMEOUT ${TIMEOUT})
-        math (EXPR TEST_PORT "${TEST_PORT}+10")
-    endmacro (add_nng_compat_test)
+        macro (add_nng_compat_test NAME TIMEOUT)
+            list (APPEND all_tests ${NAME})
+            add_executable (${NAME} ${NAME}.c)
+            target_link_libraries (${NAME} ${PROJECT_NAME}_static)
+            target_link_libraries (${NAME} ${NNG_REQUIRED_LIBRARIES})
+            target_compile_definitions(${NAME} PUBLIC -DNNG_STATIC_LIB)
+            if (CMAKE_THREAD_LIBS_INIT)
+                target_link_libraries (${NAME} "${CMAKE_THREAD_LIBS_INIT}")
+            endif()
+
+            add_test (NAME ${NAME} COMMAND ${NAME} ${TEST_PORT})
+            set_tests_properties (${NAME} PROPERTIES TIMEOUT ${TIMEOUT})
+            math (EXPR TEST_PORT "${TEST_PORT}+10")
+        endmacro (add_nng_compat_test)
+    else ()
+        macro (add_nng_compat_test NAME TIMEOUT)
+        endmacro (add_nng_compat_test)
+        message (STATUS "Compatibility tests disabled (unconfigured legacy protocols)")
+    endif ()
 
     macro (add_nng_cpp_test NAME TIMEOUT)
         if (NOT NNG_ENABLE_COVERAGE)
@@ -130,11 +147,13 @@ add_nng_test(device 5)
 add_nng_test(errors 2)
 add_nng_test(pair1 5)
 add_nng_test(udp 5)
-if (NNG_HAVE_ZEROTIER)
-    add_nng_test(zt 60)
-endif()
+add_nng_test(zt 60)
 
 # compatbility tests
+# We only support these if ALL the legacy protocols are supported.  This
+# is because we don't want to make modifications to partially enable some
+# of these tests.  Folks minimizing the library probably don't care too
+# much about these anyway.
 add_nng_compat_test(compat_block 5)
 add_nng_compat_test(compat_bug777 5)
 add_nng_compat_test(compat_bus 5)

--- a/tests/aio.c
+++ b/tests/aio.c
@@ -11,6 +11,10 @@
 #include "convey.h"
 #include "nng.h"
 
+#include "protocol/pair1/pair.h"
+
+#include "stubs.h"
+
 #include <string.h>
 
 #define APPENDSTR(m, s) nng_msg_append(m, s, strlen(s))

--- a/tests/bus.c
+++ b/tests/bus.c
@@ -11,6 +11,10 @@
 #include "convey.h"
 #include "nng.h"
 
+#include "protocol/bus0/bus.h"
+
+#include "stubs.h"
+
 #include <string.h>
 
 #define APPENDSTR(m, s) nng_msg_append(m, s, strlen(s))

--- a/tests/cplusplus_pair.cc
+++ b/tests/cplusplus_pair.cc
@@ -8,59 +8,68 @@
 //
 
 #include "nng.h"
+#include "protocol/pair1/pair.h"
 
 #include <cstring>
+#include <iostream>
 
 #define SOCKET_ADDRESS "inproc://c++"
 
 int
 main(int argc, char **argv)
 {
-    nng_socket s1;
-    nng_socket s2;
-    int rv;
-    size_t sz;
-    char buf[8];
 
-    if ((rv = nng_pair0_open(&s1)) != 0) {
-	throw nng_strerror(rv);
-    }
-    if ((rv = nng_pair0_open(&s2)) != 0) {
-	throw nng_strerror(rv);
-    }
-    if ((rv = nng_listen(s1, SOCKET_ADDRESS, NULL, 0)) != 0) {
-	throw nng_strerror(rv);
-    }
-    if ((rv = nng_dial(s2, SOCKET_ADDRESS, NULL, 0)) != 0) {
-	throw nng_strerror(rv);
-    }
-    if ((rv = nng_send(s2, (void *)"ABC", 4, 0)) != 0) {
-	throw nng_strerror(rv);
-    }
-    sz = sizeof (buf);
-    if ((rv = nng_recv(s1, buf, &sz, 0)) != 0) {
-        throw nng_strerror(rv);
-    }
-    if ((sz != 4) || (memcmp(buf, "ABC", 4) != 0)) {
-        throw "Contents did not match";
-    }
-    if ((rv = nng_send(s1, (void *)"DEF", 4, 0)) != 0) {
-	throw nng_strerror(rv);
-    }
-    sz = sizeof (buf);
-    if ((rv = nng_recv(s2, buf, &sz, 0)) != 0) {
-        throw nng_strerror(rv);
-    }
-    if ((sz != 4) || (memcmp(buf, "DEF", 4) != 0)) {
-        throw "Contents did not match";
-    }
-    if ((rv = nng_close(s1)) != 0) {
-        throw nng_strerror(rv);
-    }
-    if ((rv = nng_close(s2)) != 0) {
-        throw nng_strerror(rv);
-    }
+#if defined(NNG_HAVE_PAIR1)
 
-    return (0);
+	nng_socket s1;
+	nng_socket s2;
+	int        rv;
+	size_t     sz;
+	char       buf[8];
+
+	if ((rv = nng_pair1_open(&s1)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((rv = nng_pair1_open(&s2)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((rv = nng_listen(s1, SOCKET_ADDRESS, NULL, 0)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((rv = nng_dial(s2, SOCKET_ADDRESS, NULL, 0)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((rv = nng_send(s2, (void *) "ABC", 4, 0)) != 0) {
+		throw nng_strerror(rv);
+	}
+	sz = sizeof(buf);
+	if ((rv = nng_recv(s1, buf, &sz, 0)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((sz != 4) || (memcmp(buf, "ABC", 4) != 0)) {
+		throw "Contents did not match";
+	}
+	if ((rv = nng_send(s1, (void *) "DEF", 4, 0)) != 0) {
+		throw nng_strerror(rv);
+	}
+	sz = sizeof(buf);
+	if ((rv = nng_recv(s2, buf, &sz, 0)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((sz != 4) || (memcmp(buf, "DEF", 4) != 0)) {
+		throw "Contents did not match";
+	}
+	if ((rv = nng_close(s1)) != 0) {
+		throw nng_strerror(rv);
+	}
+	if ((rv = nng_close(s2)) != 0) {
+		throw nng_strerror(rv);
+	}
+
+	std::cout << "Pass." << std::endl;
+#else
+	std::cout << "Skipped (protocol unconfigured)." << std::endl;
+#endif
+
+	return (0);
 }
-

--- a/tests/device.c
+++ b/tests/device.c
@@ -10,6 +10,8 @@
 
 #include "convey.h"
 #include "nng.h"
+#include "protocol/pair1/pair.h"
+#include "stubs.h"
 
 #include <string.h>
 
@@ -68,8 +70,8 @@ Main({
 			So(nng_listen(dev1, addr1, NULL, 0) == 0);
 			So(nng_listen(dev2, addr2, NULL, 0) == 0);
 
-			So(nng_pair_open(&end1) == 0);
-			So(nng_pair_open(&end2) == 0);
+			So(nng_pair1_open(&end1) == 0);
+			So(nng_pair1_open(&end2) == 0);
 
 			So(nng_dial(end1, addr1, NULL, 0) == 0);
 			So(nng_dial(end2, addr2, NULL, 0) == 0);

--- a/tests/pair1.c
+++ b/tests/pair1.c
@@ -10,7 +10,10 @@
 
 #include "convey.h"
 #include "nng.h"
+#include "protocol/pair1/pair.h"
 #include "trantest.h"
+
+#include "stubs.h"
 
 #include <string.h>
 

--- a/tests/pipeline.c
+++ b/tests/pipeline.c
@@ -10,6 +10,10 @@
 
 #include "convey.h"
 #include "nng.h"
+#include "protocol/pipeline0/pull.h"
+#include "protocol/pipeline0/push.h"
+#include "stubs.h"
+
 #include <string.h>
 
 #define APPENDSTR(m, s) nng_msg_append(m, s, strlen(s))

--- a/tests/pollfd.c
+++ b/tests/pollfd.c
@@ -8,9 +8,6 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "convey.h"
-#include "nng.h"
-
 #include <string.h>
 
 #ifndef _WIN32
@@ -32,14 +29,21 @@
 
 #endif
 
+#include "convey.h"
+#include "nng.h"
+#include "protocol/pair1/pair.h"
+#include "protocol/pipeline0/pull.h"
+#include "protocol/pipeline0/push.h"
+#include "stubs.h"
+
 TestMain("Poll FDs", {
 
 	Convey("Given a connected pair of sockets", {
 		nng_socket s1;
 		nng_socket s2;
 
-		So(nng_pair_open(&s1) == 0);
-		So(nng_pair_open(&s2) == 0);
+		So(nng_pair1_open(&s1) == 0);
+		So(nng_pair1_open(&s2) == 0);
 		Reset({
 			nng_close(s1);
 			nng_close(s2);
@@ -106,26 +110,25 @@ TestMain("Poll FDs", {
 			So(nng_getopt(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
 			So(sz == sizeof(fd));
 		});
-		Convey("We cannot get a send FD for PULL", {
-			nng_socket s3;
-			int        fd;
-			size_t     sz;
-			So(nng_pull_open(&s3) == 0);
-			Reset({ nng_close(s3); });
-			sz = sizeof(fd);
-			So(nng_getopt(s3, NNG_OPT_SENDFD, &fd, &sz) ==
-			    NNG_ENOTSUP);
-		});
+	});
 
-		Convey("We cannot get a recv FD for PUSH", {
-			nng_socket s3;
-			int        fd;
-			size_t     sz;
-			So(nng_push_open(&s3) == 0);
-			Reset({ nng_close(s3); });
-			sz = sizeof(fd);
-			So(nng_getopt(s3, NNG_OPT_RECVFD, &fd, &sz) ==
-			    NNG_ENOTSUP);
-		});
+	Convey("We cannot get a send FD for PULL", {
+		nng_socket s3;
+		int        fd;
+		size_t     sz;
+		So(nng_pull0_open(&s3) == 0);
+		Reset({ nng_close(s3); });
+		sz = sizeof(fd);
+		So(nng_getopt(s3, NNG_OPT_SENDFD, &fd, &sz) == NNG_ENOTSUP);
+	});
+
+	Convey("We cannot get a recv FD for PUSH", {
+		nng_socket s3;
+		int        fd;
+		size_t     sz;
+		So(nng_push0_open(&s3) == 0);
+		Reset({ nng_close(s3); });
+		sz = sizeof(fd);
+		So(nng_getopt(s3, NNG_OPT_RECVFD, &fd, &sz) == NNG_ENOTSUP);
 	});
 })

--- a/tests/reconnect.c
+++ b/tests/reconnect.c
@@ -10,6 +10,10 @@
 
 #include "convey.h"
 #include "nng.h"
+#include "protocol/pipeline0/pull.h"
+#include "protocol/pipeline0/push.h"
+#include "stubs.h"
+
 #include <string.h>
 
 #define APPENDSTR(m, s) nng_msg_append(m, s, strlen(s))

--- a/tests/reqrep.c
+++ b/tests/reqrep.c
@@ -10,6 +10,9 @@
 
 #include "convey.h"
 #include "nng.h"
+#include "protocol/reqrep0/rep.h"
+#include "protocol/reqrep0/req.h"
+#include "stubs.h"
 
 #include <string.h>
 

--- a/tests/scalability.c
+++ b/tests/scalability.c
@@ -11,6 +11,10 @@
 #include "convey.h"
 #include "nng.h"
 
+#include "protocol/reqrep0/rep.h"
+#include "protocol/reqrep0/req.h"
+#include "stubs.h"
+
 #include <string.h>
 
 static int nclients = 200;

--- a/tests/sock.c
+++ b/tests/sock.c
@@ -12,6 +12,9 @@
 #include "nng.h"
 #include "trantest.h"
 
+#include "protocol/pubsub0/sub.h"
+
+#include "protocol/pair1/pair.h"
 #include "stubs.h"
 
 #include <string.h>

--- a/tests/stubs.h
+++ b/tests/stubs.h
@@ -44,4 +44,51 @@ getms(void)
 #endif
 }
 
+int
+nosocket(nng_socket *s)
+{
+	ConveySkip("Protocol unconfigured");
+	return (NNG_ENOTSUP);
+}
+
+#ifndef NNG_HAVE_REQ0
+#define nng_req0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_REP0
+#define nng_rep0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_PUB0
+#define nng_pub0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_SUB0
+#define nng_sub0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_PAIR0
+#define nng_pair0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_PAIR1
+#define nng_pair1_open nosocket
+#endif
+
+#ifndef NNG_HAVE_PUSH0
+#define nng_push0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_PULL0
+#define nng_pull0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_SURVEYOR0
+#define nng_surveyor0_open nosocket
+#endif
+
+#ifndef NNG_HAVE_RESPONDENT0
+#define nng_respondent0_open nosocket
+#endif
+
 #endif // STUBS_H

--- a/tests/survey.c
+++ b/tests/survey.c
@@ -9,7 +9,11 @@
 //
 
 #include "convey.h"
+
 #include "nng.h"
+#include "protocol/survey0/respond.h"
+#include "protocol/survey0/survey.h"
+#include "stubs.h"
 
 #include <string.h>
 

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -9,8 +9,11 @@
 //
 
 #include "convey.h"
+#include "nng.h"
+#include "protocol/pair1/pair.h"
 #include "trantest.h"
 
+#include "stubs.h"
 // TCP tests.
 
 #ifndef _WIN32

--- a/tests/tcp6.c
+++ b/tests/tcp6.c
@@ -13,6 +13,9 @@
 
 #include "core/nng_impl.h"
 // TCP tests for IPv6.
+#include "protocol/pair1/pair.h"
+
+#include "stubs.h"
 
 static int
 has_v6(void)

--- a/tests/zt.c
+++ b/tests/zt.c
@@ -9,9 +9,12 @@
 //
 
 #include "convey.h"
+#include "nng.h"
+#include "protocol/pair0/pair.h"
+#include "transport/zerotier/zerotier.h"
 #include "trantest.h"
 
-#include "transport/zerotier/zerotier.h"
+#include "stubs.h"
 
 // zerotier tests.
 
@@ -34,6 +37,10 @@ mkdir(const char *path, int mode)
 #include <sys/stat.h>
 #include <unistd.h>
 #endif // WIN32
+
+#ifndef NNG_HAVE_ZEROTIER
+#define nng_zt_network_status_ok 0
+#endif
 
 static int
 check_props(nng_msg *msg, nng_listener l, nng_dialer d)
@@ -197,6 +204,8 @@ TestMain("ZeroTier Transport", {
 		char         addr[NNG_MAXADDRLEN];
 		int          rv;
 
+		So(nng_zt_register() == 0);
+
 		snprintf(addr, sizeof(addr), "zt://" NWID ":%u", port);
 
 		So(nng_pair_open(&s) == 0);
@@ -240,6 +249,8 @@ TestMain("ZeroTier Transport", {
 		// uint64_t   node = 0xb000072fa6ull; // my personal host
 		uint64_t node = 0x2d2f619cccull; // my personal host
 
+		So(nng_zt_register() == 0);
+
 		snprintf(addr, sizeof(addr), "zt://" NWID "/%llx:%u",
 		    (unsigned long long) node, port);
 
@@ -257,6 +268,8 @@ TestMain("ZeroTier Transport", {
 		int          rv;
 		uint64_t     node1 = 0;
 		uint64_t     node2 = 0;
+
+		So(nng_zt_register() == 0);
 
 		snprintf(addr, sizeof(addr), "zt://" NWID ":%u", port);
 
@@ -306,6 +319,7 @@ TestMain("ZeroTier Transport", {
 
 		port = 9944;
 		// uint64_t   node = 0xb000072fa6ull; // my personal host
+		So(nng_zt_register() == 0);
 
 		snprintf(addr1, sizeof(addr1), "zt://" NWID ":%u", port);
 


### PR DESCRIPTION
Will rebase and squash these before commit.

This moves to fully modularized protocols and transports.  We also eliminate the global
constants associated with protocol numbers (leaving a comment behind to act as a registry.)

The test suite is modified to properly cope with any of these things being added or removed, treating their absence as "skips" of the associated tests.

There are some new man pages here too.