### PR TITLE
Fix leaks on send.

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -308,6 +308,7 @@ nni_aio_finish_impl(
 	NNI_ASSERT(aio->a_pend == 0); // provider only calls us *once*
 
 	nni_list_node_remove(&aio->a_expire_node);
+
 	aio->a_pend        = 1;
 	aio->a_result      = result;
 	aio->a_count       = count;

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -252,6 +252,7 @@ nni_ipc_pipe_send_cb(void *arg)
 	msg = nni_aio_get_msg(aio);
 	n   = nni_msg_len(msg);
 	nni_aio_set_msg(aio, NULL);
+	nni_msg_free(msg);
 	nni_aio_finish(aio, 0, n);
 }
 

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -251,6 +251,7 @@ nni_tcp_pipe_send_cb(void *arg)
 	msg = nni_aio_get_msg(aio);
 	n   = nni_msg_len(msg);
 	nni_aio_set_msg(aio, NULL);
+	nni_msg_free(msg);
 	nni_aio_finish(aio, 0, n);
 }
 

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Staysail Systems, Inc. <info@staysail.tech>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -261,6 +261,7 @@ nni_tls_pipe_send_cb(void *arg)
 	msg = nni_aio_get_msg(aio);
 	n   = nni_msg_len(msg);
 	nni_aio_set_msg(aio, NULL);
+	nni_msg_free(msg);
 	nni_aio_finish(aio, 0, n);
 }
 

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -119,6 +119,8 @@ ws_pipe_recv_cancel(nni_aio *aio, int rv)
 		return;
 	}
 	nni_aio_cancel(p->rxaio, rv);
+	p->user_rxaio = NULL;
+	nni_aio_finish_error(aio, rv);
 	nni_mtx_unlock(&p->mtx);
 }
 
@@ -147,9 +149,9 @@ ws_pipe_send_cancel(nni_aio *aio, int rv)
 		nni_mtx_unlock(&p->mtx);
 		return;
 	}
-	// This aborts the upper send, which will call back with an error
-	// when it is done.
+	p->user_txaio = NULL;
 	nni_aio_cancel(p->txaio, rv);
+	nni_aio_finish_error(aio, rv);
 	nni_mtx_unlock(&p->mtx);
 }
 


### PR DESCRIPTION
I'm pretty sure I need to go back and review the handling of
send messages for websocket too.  We still have a receive leak
in websocket and leaks caused by the new URL parsing code which
needs to be refactored.