### PR TITLE
fixes #219 transports should take URL structure instead of string add…

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -43,6 +43,7 @@ typedef struct nni_tran_ep          nni_tran_ep;
 typedef struct nni_tran_ep_option   nni_tran_ep_option;
 typedef struct nni_tran_pipe        nni_tran_pipe;
 typedef struct nni_tran_pipe_option nni_tran_pipe_option;
+typedef struct nni_url              nni_url;
 
 typedef struct nni_proto_sock_ops    nni_proto_sock_ops;
 typedef struct nni_proto_pipe_ops    nni_proto_pipe_ops;

--- a/src/core/endpt.h
+++ b/src/core/endpt.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -30,9 +30,8 @@ extern void      nni_ep_list_init(nni_list *);
 extern int       nni_ep_setopt(nni_ep *, const char *, const void *, size_t);
 extern int       nni_ep_getopt(nni_ep *, const char *, void *, size_t *);
 extern int nni_ep_pipe_add(nni_ep *ep, nni_pipe *);
-extern void        nni_ep_pipe_remove(nni_ep *, nni_pipe *);
-extern const char *nni_ep_url(nni_ep *);
-extern int         nni_ep_mode(nni_ep *);
+extern void nni_ep_pipe_remove(nni_ep *, nni_pipe *);
+extern int  nni_ep_mode(nni_ep *);
 
 // Endpoint modes.  Currently used by transports.  Remove this when we make
 // transport dialers and listeners explicit.

--- a/src/core/nng_impl.h
+++ b/src/core/nng_impl.h
@@ -44,10 +44,13 @@
 #include "core/taskq.h"
 #include "core/thread.h"
 #include "core/timer.h"
-#include "core/transport.h"
 #include "core/url.h"
 
+// transport needs to come after url
+#include "core/transport.h"
+
 // These have to come after the others - particularly transport.h
+
 #include "core/endpt.h"
 #include "core/pipe.h"
 #include "core/socket.h"

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -29,7 +29,6 @@ struct nni_pipe {
 	int           p_reap;
 	int           p_stop;
 	int           p_refcnt;
-	const char *  p_url;
 	nni_mtx       p_mtx;
 	nni_cv        p_cv;
 	nni_list_node p_reap_node;
@@ -268,7 +267,6 @@ nni_pipe_create(nni_ep *ep, void *tdata)
 	p->p_proto_data = NULL;
 	p->p_ep         = ep;
 	p->p_sock       = sock;
-	p->p_url        = nni_ep_url(ep);
 
 	NNI_LIST_NODE_INIT(&p->p_reap_node);
 	NNI_LIST_NODE_INIT(&p->p_sock_node);

--- a/src/core/transport.h
+++ b/src/core/transport.h
@@ -76,7 +76,7 @@ struct nni_tran_ep_option {
 struct nni_tran_ep {
 	// ep_init creates a vanilla endpoint. The value created is
 	// used for the first argument for all other endpoint functions.
-	int (*ep_init)(void **, const char *, nni_sock *, int);
+	int (*ep_init)(void **, nni_url *, nni_sock *, int);
 
 	// ep_fini frees the resources associated with the endpoint.
 	// The endpoint will already have been closed.
@@ -164,7 +164,7 @@ struct nni_tran_pipe {
 
 // These APIs are used by the framework internally, and not for use by
 // transport implementations.
-extern nni_tran *nni_tran_find(const char *);
+extern nni_tran *nni_tran_find(nni_url *);
 extern int       nni_tran_chkopt(const char *, const void *, size_t);
 extern int       nni_tran_sys_init(void);
 extern void      nni_tran_sys_fini(void);

--- a/src/core/url.c
+++ b/src/core/url.c
@@ -454,3 +454,30 @@ nni_url_free(nni_url *url)
 	nni_strfree(url->u_rawpath);
 	NNI_FREE_STRUCT(url);
 }
+
+int
+nni_url_clone(nni_url **dstp, const nni_url *src)
+{
+	nni_url *dst;
+
+	if ((dst = NNI_ALLOC_STRUCT(dst)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+#define URL_COPYSTR(d, s) ((s != NULL) && ((d = nni_strdup(s)) == NULL))
+	if (URL_COPYSTR(dst->u_rawurl, src->u_rawurl) ||
+	    URL_COPYSTR(dst->u_scheme, src->u_scheme) ||
+	    URL_COPYSTR(dst->u_userinfo, src->u_userinfo) ||
+	    URL_COPYSTR(dst->u_host, src->u_host) ||
+	    URL_COPYSTR(dst->u_hostname, src->u_hostname) ||
+	    URL_COPYSTR(dst->u_port, src->u_port) ||
+	    URL_COPYSTR(dst->u_rawpath, src->u_rawpath) ||
+	    URL_COPYSTR(dst->u_path, src->u_path) ||
+	    URL_COPYSTR(dst->u_query, src->u_query) ||
+	    URL_COPYSTR(dst->u_fragment, src->u_fragment)) {
+		nni_url_free(dst);
+		return (NNG_ENOMEM);
+	}
+#undef URL_COPYSTR
+	*dstp = dst;
+	return (0);
+}

--- a/src/core/url.h
+++ b/src/core/url.h
@@ -11,8 +11,6 @@
 #ifndef CORE_URL_H
 #define CORE_URL_H
 
-typedef struct nni_url nni_url;
-
 struct nni_url {
 	char *u_rawurl;   // never NULL
 	char *u_scheme;   // never NULL
@@ -28,5 +26,6 @@ struct nni_url {
 
 extern int nni_url_parse(nni_url **, const char *path);
 extern void nni_url_free(nni_url *);
+extern int  nni_url_clone(nni_url **, const nni_url *);
 
 #endif // CORE_URL_H

--- a/src/supplemental/http/http.h
+++ b/src/supplemental/http/http.h
@@ -174,7 +174,7 @@ typedef struct nni_http_handler nni_http_handler;
 // a restricted binding is required, we recommend using a URL consisting
 // of an empty host name, such as http://  or https://  -- this would
 // convert to binding to the default port on all interfaces on the host.
-extern int nni_http_server_init(nni_http_server **, const char *);
+extern int nni_http_server_init(nni_http_server **, nni_url *);
 
 // nni_http_server_fini drops the reference count on the server, and
 // if this was the last reference, closes down the server and frees
@@ -325,8 +325,7 @@ extern void *nni_http_handler_get_data(nni_http_handler *, unsigned);
 
 typedef struct nni_http_client nni_http_client;
 
-// https vs. http; would also allow us to defer DNS lookups til later.
-extern int  nni_http_client_init(nni_http_client **, const char *);
+extern int  nni_http_client_init(nni_http_client **, nni_url *);
 extern void nni_http_client_fini(nni_http_client *);
 
 // nni_http_client_set_tls sets the TLS configuration.  This wipes out

--- a/src/supplemental/websocket/websocket.h
+++ b/src/supplemental/websocket/websocket.h
@@ -29,7 +29,7 @@ typedef int (*nni_ws_listen_hook)(void *, nni_http_req *, nni_http_res *);
 // on INADDR_ANY port 80, with path "/".  For connect side, INADDR_ANY
 // makes no sense.  (TBD: return NNG_EADDRINVAL, or try loopback?)
 
-extern int  nni_ws_listener_init(nni_ws_listener **, const char *);
+extern int  nni_ws_listener_init(nni_ws_listener **, nni_url *);
 extern void nni_ws_listener_fini(nni_ws_listener *);
 extern void nni_ws_listener_close(nni_ws_listener *);
 extern int  nni_ws_listener_proto(nni_ws_listener *, const char *);
@@ -40,7 +40,7 @@ extern void nni_ws_listener_hook(
 extern int nni_ws_listener_set_tls(nni_ws_listener *, nng_tls_config *);
 extern int nni_ws_listener_get_tls(nni_ws_listener *, nng_tls_config **s);
 
-extern int  nni_ws_dialer_init(nni_ws_dialer **, const char *);
+extern int  nni_ws_dialer_init(nni_ws_dialer **, nni_url *);
 extern void nni_ws_dialer_fini(nni_ws_dialer *);
 extern void nni_ws_dialer_close(nni_ws_dialer *);
 extern int  nni_ws_dialer_proto(nni_ws_dialer *, const char *);

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -47,7 +47,7 @@ struct nni_inproc_pair {
 };
 
 struct nni_inproc_ep {
-	char          addr[NNG_MAXADDRLEN + 1];
+	const char *  addr;
 	int           mode;
 	nni_list_node node;
 	uint16_t      proto;
@@ -190,13 +190,10 @@ nni_inproc_pipe_get_addr(void *arg, void *buf, size_t *szp)
 }
 
 static int
-nni_inproc_ep_init(void **epp, const char *url, nni_sock *sock, int mode)
+nni_inproc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 {
 	nni_inproc_ep *ep;
 
-	if (strlen(url) > NNG_MAXADDRLEN - 1) {
-		return (NNG_EINVAL);
-	}
 	if ((ep = NNI_ALLOC_STRUCT(ep)) == NULL) {
 		return (NNG_ENOMEM);
 	}
@@ -206,8 +203,8 @@ nni_inproc_ep_init(void **epp, const char *url, nni_sock *sock, int mode)
 	NNI_LIST_INIT(&ep->clients, nni_inproc_ep, node);
 	nni_aio_list_init(&ep->aios);
 
-	(void) snprintf(ep->addr, sizeof(ep->addr), "%s", url);
-	*epp = ep;
+	ep->addr = url->u_rawurl; // we match on the full URL.
+	*epp     = ep;
 	return (0);
 }
 

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -529,17 +529,16 @@ nni_ipc_ep_fini(void *arg)
 }
 
 static int
-nni_ipc_ep_init(void **epp, const char *url, nni_sock *sock, int mode)
+nni_ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 {
 	nni_ipc_ep *ep;
 	int         rv;
 	size_t      sz;
 
-	if (strncmp(url, "ipc://", strlen("ipc://")) != 0) {
-		return (NNG_EADDRINVAL);
+	if (((url->u_host != NULL) && (strlen(url->u_host) > 0)) ||
+	    (url->u_userinfo != NULL)) {
+		return (NNG_EINVAL);
 	}
-	url += strlen("ipc://");
-
 	if ((ep = NNI_ALLOC_STRUCT(ep)) == NULL) {
 		return (NNG_ENOMEM);
 	}
@@ -547,7 +546,7 @@ nni_ipc_ep_init(void **epp, const char *url, nni_sock *sock, int mode)
 	sz                           = sizeof(ep->sa.s_un.s_path.sa_path);
 	ep->sa.s_un.s_path.sa_family = NNG_AF_IPC;
 
-	if (nni_strlcpy(ep->sa.s_un.s_path.sa_path, url, sz) >= sz) {
+	if (nni_strlcpy(ep->sa.s_un.s_path.sa_path, url->u_path, sz) >= sz) {
 		NNI_FREE_STRUCT(ep);
 		return (NNG_EADDRINVAL);
 	}

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -537,16 +537,13 @@ nni_tls_ep_fini(void *arg)
 	if (ep->cfg) {
 		nni_tls_config_fini(ep->cfg);
 	}
-	if (ep->url) {
-		nni_url_free(ep->url);
-	}
 	nni_aio_fini(ep->aio);
 	nni_mtx_fini(&ep->mtx);
 	NNI_FREE_STRUCT(ep);
 }
 
 static int
-nni_tls_ep_init(void **epp, const char *addr, nni_sock *sock, int mode)
+nni_tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 {
 	nni_tls_ep *      ep;
 	int               rv;
@@ -557,26 +554,17 @@ nni_tls_ep_init(void **epp, const char *addr, nni_sock *sock, int mode)
 	int               passive;
 	nng_tls_mode      tlsmode;
 	nng_tls_auth_mode authmode;
-	nni_url *         url;
-
-	// Parse the URLs first.
-	if ((rv = nni_url_parse(&url, addr)) != 0) {
-		return (rv);
-	}
 
 	// Check for invalid URL components.
 	if ((strlen(url->u_path) != 0) && (strcmp(url->u_path, "/") != 0)) {
-		nni_url_free(url);
 		return (NNG_EADDRINVAL);
 	}
 	if ((url->u_fragment != NULL) || (url->u_userinfo != NULL) ||
 	    (url->u_query != NULL)) {
-		nni_url_free(url);
 		return (NNG_EADDRINVAL);
 	}
 
 	if ((rv = nni_aio_init(&aio, NULL, NULL)) != 0) {
-		nni_url_free(url);
 		return (rv);
 	}
 
@@ -598,7 +586,6 @@ nni_tls_ep_init(void **epp, const char *addr, nni_sock *sock, int mode)
 		lsa.s_un.s_family = NNG_AF_UNSPEC;
 		aio->a_addr       = &rsa;
 		if ((host == NULL) || (serv == NULL)) {
-			nni_url_free(url);
 			nni_aio_fini(aio);
 			return (NNG_EADDRINVAL);
 		}
@@ -615,14 +602,12 @@ nni_tls_ep_init(void **epp, const char *addr, nni_sock *sock, int mode)
 	nni_plat_tcp_resolv(host, serv, NNG_AF_UNSPEC, passive, aio);
 	nni_aio_wait(aio);
 	if ((rv = nni_aio_result(aio)) != 0) {
-		nni_url_free(url);
 		nni_aio_fini(aio);
 		return (rv);
 	}
 	nni_aio_fini(aio);
 
 	if ((ep = NNI_ALLOC_STRUCT(ep)) == NULL) {
-		nni_url_free(url);
 		return (NNG_ENOMEM);
 	}
 	nni_mtx_init(&ep->mtx);

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -30,8 +30,7 @@ typedef struct ws_hdr {
 } ws_hdr;
 
 struct ws_ep {
-	int              mode; // NNI_EP_MODE_DIAL or NNI_EP_MODE_LISTEN
-	char *           addr;
+	int              mode;   // NNI_EP_MODE_DIAL or NNI_EP_MODE_LISTEN
 	uint16_t         lproto; // local protocol
 	uint16_t         rproto; // remote protocol
 	size_t           rcvmax;
@@ -605,7 +604,6 @@ ws_ep_fini(void *arg)
 		nni_strfree(hdr->value);
 		NNI_FREE_STRUCT(hdr);
 	}
-	nni_strfree(ep->addr);
 	nni_strfree(ep->protoname);
 	nni_mtx_fini(&ep->mtx);
 	NNI_FREE_STRUCT(ep);
@@ -694,7 +692,7 @@ ws_ep_acc_cb(void *arg)
 }
 
 static int
-ws_ep_init(void **epp, const char *url, nni_sock *sock, int mode)
+ws_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 {
 	ws_ep *     ep;
 	const char *pname;
@@ -721,9 +719,6 @@ ws_ep_init(void **epp, const char *url, nni_sock *sock, int mode)
 		rv    = nni_ws_listener_init(&ep->listener, url);
 	}
 
-	if ((rv == 0) && ((ep->addr = nni_strdup(url)) == NULL)) {
-		rv = NNG_ENOMEM;
-	}
 	if ((rv != 0) ||
 	    ((rv = nni_aio_init(&ep->connaio, ws_ep_conn_cb, ep)) != 0) ||
 	    ((rv = nni_aio_init(&ep->accaio, ws_ep_acc_cb, ep)) != 0) ||

--- a/tests/httpclient.c
+++ b/tests/httpclient.c
@@ -34,11 +34,13 @@ TestMain("HTTP Client", {
 		nni_aio *        iaio;
 		nni_http_client *cli;
 		nni_http *       http;
+		nni_url *        url;
 
 		So(nng_aio_alloc(&aio, NULL, NULL) == 0);
 		iaio = (nni_aio *) aio;
 
-		So(nni_http_client_init(&cli, "http://httpbin.org") == 0);
+		So(nni_url_parse(&url, "http://httpbin.org") == 0);
+		So(nni_http_client_init(&cli, url) == 0);
 		nni_http_client_connect(cli, iaio);
 		nng_aio_wait(aio);
 		So(nng_aio_result(aio) == 0);
@@ -47,6 +49,7 @@ TestMain("HTTP Client", {
 			nni_http_client_fini(cli);
 			nni_http_fini(http);
 			nng_aio_free(aio);
+			nni_url_free(url);
 		});
 
 		Convey("We can initiate a message", {

--- a/tests/tls.c
+++ b/tests/tls.c
@@ -29,47 +29,27 @@
 //
 // Generated using openssl:
 //
-// % openssl ecparam -name secp521r1 -noout -genkey -out key.key
-// % openssl req -new -key key.key -out cert.csr
-// % openssl x509 -req -in cert.csr -days 36500 -out cert.crt -signkey key.key
+// % openssl rsa -genkey -out key.key
+// % openssl req -new -key key.key -out cert.csr -sha256
+// % openssl x509 -req -in cert.csr -days 36500 -out cert.crt
+//    -signkey key.key -sha256
 //
 // Relevant metadata:
 //
 // Certificate:
-//     Data:
+//    Data:
 //        Version: 1 (0x0)
-//        Serial Number: 9808857926806240008 (0x882010509b8f7b08)
-//    Signature Algorithm: ecdsa-with-SHA1
-//        Issuer: C=US, ST=CA, L=San Diego, O=nanomsg, CN=127.0.0.1
+//        Serial Number: 17127835813110005400 (0xedb24becc3a2be98)
+//    Signature Algorithm: sha256WithRSAEncryption
+//        Issuer: C=US, ST=CA, L=San Diego, O=nanomsg.org, CN=localhost
 //        Validity
-//            Not Before: Nov 17 20:08:06 2017 GMT
-//            Not After : Oct 24 20:08:06 2117 GMT
-//        Subject: C=US, ST=CA, L=San Diego, O=nanomsg, CN=127.0.0.1
+//            Not Before: Jan 11 22:34:35 2018 GMT
+//            Not After : Dec 18 22:34:35 2117 GMT
+//        Subject: C=US, ST=CA, L=San Diego, O=nanomsg.org, CN=localhost
+//        Subject Public Key Info:
+//            Public Key Algorithm: rsaEncryption
+//                Public-Key: (2048 bit)
 //
-static const char eccert[] =
-    "-----BEGIN CERTIFICATE-----\n"
-    "MIICIjCCAYMCCQDaC9ARg31kIjAKBggqhkjOPQQDAjBUMQswCQYDVQQGEwJVUzEL\n"
-    "MAkGA1UECAwCQ0ExEjAQBgNVBAcMCVNhbiBEaWVnbzEQMA4GA1UECgwHbmFub21z\n"
-    "ZzESMBAGA1UEAwwJMTI3LjAuMC4xMCAXDTE3MTExNzIwMjczMloYDzIxMTcxMDI0\n"
-    "MjAyNzMyWjBUMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0ExEjAQBgNVBAcMCVNh\n"
-    "biBEaWVnbzEQMA4GA1UECgwHbmFub21zZzESMBAGA1UEAwwJMTI3LjAuMC4xMIGb\n"
-    "MBAGByqGSM49AgEGBSuBBAAjA4GGAAQAN7vDK6GEiSguMsOuhfOvGyiVc37Sog0b\n"
-    "UkpaiS6+SagTmXFSN1Rgh9isxKFYJvcCtAko3v0I8rAVQucdhf5B3hEBMQlbBIuM\n"
-    "rMKT6ZQJ+eiwyb4O3Scgd7DoL3tc/kOqijwB/5hJ4sZdquDKP5DDFe5fAf4MNtzY\n"
-    "4C+iApWlKq/LoXkwCgYIKoZIzj0EAwIDgYwAMIGIAkIBOuJAWmNSdd6Ovmr6Ebg3\n"
-    "UF9ZrsNwARd9BfYbBk5OQhUOjCLB6d8aLi49WOm1WoRvOS5PaVvmvSfNhaw8b5nV\n"
-    "hnYCQgC+EmJ6C3bEcZrndhfbqvCaOGkc7/SrKhC6fS7mJW4wL90QUV9WjQ2Ll6X5\n"
-    "PxkSj7s0SvD6T8j7rju5LDgkdZc35A==\n"
-    "-----END CERTIFICATE-----\n";
-
-static const char eckey[] =
-    "-----BEGIN EC PRIVATE KEY-----\n"
-    "MIHcAgEBBEIB20OHMntU2UJW2yuQn2f+bLsuhTT5KRGorcocnqxatWLvxuF1cfUA\n"
-    "TjQxRRS6BIUvFt1fMIklp9qedJF00JHy4qWgBwYFK4EEACOhgYkDgYYABAA3u8Mr\n"
-    "oYSJKC4yw66F868bKJVzftKiDRtSSlqJLr5JqBOZcVI3VGCH2KzEoVgm9wK0CSje\n"
-    "/QjysBVC5x2F/kHeEQExCVsEi4yswpPplAn56LDJvg7dJyB3sOgve1z+Q6qKPAH/\n"
-    "mEnixl2q4Mo/kMMV7l8B/gw23NjgL6IClaUqr8uheQ==\n"
-    "-----END EC PRIVATE KEY-----\n";
 
 static const char cert[] =
     "-----BEGIN CERTIFICATE-----\n"
@@ -92,6 +72,7 @@ static const char cert[] =
     "dFMXOO1rleU0lWAJcXWOWHH3er0fivu2ISL8fRjjikYvhRGxtkwC0kPDa2Ntzgd3\n"
     "Hsg=\n"
     "-----END CERTIFICATE-----\n";
+
 static const char key[] =
     "-----BEGIN RSA PRIVATE KEY-----\n"
     "MIIEpQIBAAKCAQEAzL6B3RJ3zoZhtz04+mAuas+jeYYJnMH+BGZKK+PkdUOYQziq\n"
@@ -377,6 +358,7 @@ TestMain("TLS Transport", {
 		nng_msg *    msg;
 		nng_pipe     p;
 		int          v;
+		nng_dialer   d;
 
 		So(nng_pair_open(&s1) == 0);
 		So(nng_pair_open(&s2) == 0);
@@ -392,11 +374,14 @@ TestMain("TLS Transport", {
 
 		// reset port back one
 		trantest_prev_address(addr, "tls+tcp://127.0.0.1:%u");
-		So(nng_setopt_int(s2, NNG_OPT_TLS_AUTH_MODE,
-		       NNG_TLS_AUTH_MODE_OPTIONAL) == 0);
 		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
-		So(nng_dial(s2, addr, NULL, 0) == 0);
-		nng_msleep(100);
+		So(nng_dialer_create(&d, s2, addr) == 0);
+		So(init_dialer_tls_file(NULL, d) == 0);
+		So(nng_dialer_setopt_int(d, NNG_OPT_TLS_AUTH_MODE,
+		       NNG_TLS_AUTH_MODE_OPTIONAL) == 0);
+		So(nng_dialer_setopt_string(
+		       d, NNG_OPT_TLS_SERVER_NAME, "example.com") == 0);
+		So(nng_dialer_start(d, 0) == 0);
 
 		So(nng_send(s1, "hello", 6, 0) == 0);
 		So(nng_recvmsg(s2, &msg, 0) == 0);

--- a/tests/trantest.h
+++ b/tests/trantest.h
@@ -137,7 +137,10 @@ trantest_init(trantest *tt, const char *addr)
 	So(nng_req_open(&tt->reqsock) == 0);
 	So(nng_rep_open(&tt->repsock) == 0);
 
-	tt->tran = nni_tran_find(addr);
+	nni_url *url;
+	So(nni_url_parse(&url, tt->addr) == 0);
+	tt->tran = nni_tran_find(url);
+	nni_url_free(url);
 	So(tt->tran != NULL);
 #else
 	ConveySkip("Missing REQ or REP protocols");

--- a/tests/wssfile.c
+++ b/tests/wssfile.c
@@ -295,6 +295,7 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 		nng_socket   s1;
 		nng_socket   s2;
 		nng_listener l;
+		nng_dialer   d;
 		char         addr[NNG_MAXADDRLEN];
 		nng_msg *    msg;
 		nng_pipe     p;
@@ -314,10 +315,20 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 
 		// reset port back one
 		trantest_prev_address(addr, "wss://127.0.0.1:%u/test");
+		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
+		So(nng_dialer_create(&d, s2, addr) == 0);
+		So(init_dialer_wss_file(NULL, d) == 0);
+		So(nng_dialer_setopt_int(d, NNG_OPT_TLS_AUTH_MODE,
+		       NNG_TLS_AUTH_MODE_OPTIONAL) == 0);
+		So(nng_dialer_setopt_string(
+		       d, NNG_OPT_TLS_SERVER_NAME, "example.com") == 0);
+		So(nng_dialer_start(d, 0) == 0);
+#if 0
 		So(nng_setopt_int(s2, NNG_OPT_TLS_AUTH_MODE,
 		       NNG_TLS_AUTH_MODE_OPTIONAL) == 0);
 		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
 		So(nng_dial(s2, addr, NULL, 0) == 0);
+#endif
 		nng_msleep(100);
 
 		So(nng_send(s1, "hello", 6, 0) == 0);


### PR DESCRIPTION
…ress

This eliminates a bunch of redundant URL parsing, using the common
URL logic we already have in place.

While here I fixed a problem with the TLS and WSS test suites that
was failing on older Ubuntu -- apparently older versions of mbedTLS
were unhappy if selecting OPTIONAL verification without a validate
certificate chain.