### PR TITLE
fixes #171 Refactor aio to use generic data fields

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -78,8 +78,6 @@ extern void *nni_aio_get_output(nni_aio *, int);
 // XXX: These should be refactored in terms of generic inputs and outputs.
 extern void     nni_aio_set_msg(nni_aio *, nni_msg *);
 extern nni_msg *nni_aio_get_msg(nni_aio *);
-extern void     nni_aio_set_pipe(nni_aio *, void *);
-extern void *   nni_aio_get_pipe(nni_aio *);
 
 // nni_aio_set_synch sets a synchronous completion flag on the AIO.
 // When this is set, the next time the AIO is completed, the callback
@@ -126,7 +124,6 @@ extern int  nni_aio_list_active(nni_aio *);
 // nni_aio_finish is called by the provider when an operation is complete.
 extern void nni_aio_finish(nni_aio *, int, size_t);
 extern void nni_aio_finish_error(nni_aio *, int);
-extern void nni_aio_finish_pipe(nni_aio *, void *);
 extern void nni_aio_finish_msg(nni_aio *, nni_msg *);
 
 // nni_aio_abort is used to abort an operation.  Any pending I/O or

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -364,7 +364,7 @@ nni_ep_con_cb(void *arg)
 	int      rv;
 
 	if ((rv = nni_aio_result(aio)) == 0) {
-		rv = nni_pipe_create(ep, nni_aio_get_pipe(aio));
+		rv = nni_pipe_create(ep, nni_aio_get_output(aio, 0));
 	}
 	nni_mtx_lock(&ep->ep_mtx);
 	switch (rv) {
@@ -448,7 +448,7 @@ nni_ep_dial(nni_ep *ep, int flags)
 
 	// As we're synchronous, we also have to handle the completion.
 	if (((rv = nni_aio_result(aio)) != 0) ||
-	    ((rv = nni_pipe_create(ep, nni_aio_get_pipe(aio))) != 0)) {
+	    ((rv = nni_pipe_create(ep, nni_aio_get_output(aio, 0))) != 0)) {
 		nni_mtx_lock(&ep->ep_mtx);
 		ep->ep_started = 0;
 		nni_mtx_unlock(&ep->ep_mtx);
@@ -464,8 +464,8 @@ nni_ep_acc_cb(void *arg)
 	int      rv;
 
 	if ((rv = nni_aio_result(aio)) == 0) {
-		NNI_ASSERT(nni_aio_get_pipe(aio) != NULL);
-		rv = nni_pipe_create(ep, nni_aio_get_pipe(aio));
+		NNI_ASSERT(nni_aio_get_output(aio, 0) != NULL);
+		rv = nni_pipe_create(ep, nni_aio_get_output(aio, 0));
 	}
 
 	nni_mtx_lock(&ep->ep_mtx);
@@ -503,7 +503,6 @@ nni_ep_acc_start(nni_ep *ep)
 	if (ep->ep_closing) {
 		return;
 	}
-	nni_aio_set_pipe(aio, NULL);
 	ep->ep_ops.ep_accept(ep->ep_data, aio);
 }
 

--- a/src/core/url.c
+++ b/src/core/url.c
@@ -284,7 +284,7 @@ nni_url_parse(nni_url **urlp, const char *raw)
 		rv = NNG_ENOMEM;
 		goto error;
 	}
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		url->u_scheme[i] = tolower(s[i]);
 	}
 	url->u_scheme[len] = '\0';
@@ -334,7 +334,7 @@ nni_url_parse(nni_url **urlp, const char *raw)
 	}
 	// Copy the host portion, but make it lower case (hostnames are
 	// case insensitive).
-	for (int i = 0; i < len; i++) {
+	for (size_t i = 0; i < len; i++) {
 		url->u_host[i] = tolower(s[i]);
 	}
 	url->u_host[len] = '\0';

--- a/src/nng.c
+++ b/src/nng.c
@@ -1140,7 +1140,7 @@ void
 nng_aio_finish(nng_aio *aio, int rv)
 {
 	// Preserve the count.
-	return (nni_aio_finish(aio, rv, nni_aio_count(aio)));
+	nni_aio_finish(aio, rv, nni_aio_count(aio));
 }
 
 #if 0

--- a/src/platform/posix/posix_epdesc.c
+++ b/src/platform/posix/posix_epdesc.c
@@ -74,7 +74,8 @@ nni_posix_epdesc_finish(nni_aio *aio, int rv, int newfd)
 	if (rv != 0) {
 		nni_aio_finish_error(aio, rv);
 	} else {
-		nni_aio_finish_pipe(aio, pd);
+		nni_aio_set_output(aio, 0, pd);
+		nni_aio_finish(aio, 0, 0);
 	}
 }
 
@@ -317,7 +318,6 @@ nni_posix_epdesc_accept(nni_posix_epdesc *ed, nni_aio *aio)
 	// connection is ready for us.  There isn't anything else for us to
 	// do really, as that will have been done in listen.
 	nni_mtx_lock(&ed->mtx);
-	nni_aio_set_pipe(aio, NULL);
 	// If we can't start, it means that the AIO was stopped.
 	if ((rv = nni_aio_start(aio, nni_posix_epdesc_cancel, ed)) != 0) {
 		nni_mtx_unlock(&ed->mtx);
@@ -343,7 +343,6 @@ nni_posix_epdesc_connect(nni_posix_epdesc *ed, nni_aio *aio)
 	int fd;
 
 	nni_mtx_lock(&ed->mtx);
-	nni_aio_set_pipe(aio, NULL);
 	// If we can't start, it means that the AIO was stopped.
 	if ((rv = nni_aio_start(aio, nni_posix_epdesc_cancel, ed)) != 0) {
 		nni_mtx_unlock(&ed->mtx);

--- a/src/platform/windows/win_ipc.c
+++ b/src/platform/windows/win_ipc.c
@@ -321,7 +321,8 @@ nni_win_ipc_acc_finish(nni_win_event *evt, nni_aio *aio)
 		return;
 	}
 
-	nni_aio_finish_pipe(aio, pipe);
+	nni_aio_set_output(aio, 0, pipe);
+	nni_aio_finish(aio, 0, 0);
 }
 
 static void
@@ -448,7 +449,8 @@ nni_win_ipc_conn_thr(void *arg)
 			    ((rv = nni_win_iocp_register(p)) != 0)) {
 				goto fail;
 			}
-			nni_aio_finish_pipe(aio, pipe);
+			nni_aio_set_output(aio, 0, pipe);
+			nni_aio_finish(aio, 0, 0);
 			continue;
 
 		fail:

--- a/src/platform/windows/win_tcp.c
+++ b/src/platform/windows/win_tcp.c
@@ -105,7 +105,7 @@ nni_win_tcp_pipe_start(nni_win_event *evt, nni_aio *aio)
 	DWORD              niov;
 	DWORD              flags;
 	nni_plat_tcp_pipe *pipe = evt->ptr;
-	int                i;
+	unsigned           i;
 	unsigned           naiov;
 	nni_iov *          aiov;
 	WSABUF *           iov;
@@ -469,7 +469,8 @@ nni_win_tcp_acc_finish(nni_win_event *evt, nni_aio *aio)
 	memcpy(&pipe->sockname, sa1, len1);
 	memcpy(&pipe->peername, sa2, len2);
 
-	nni_aio_finish_pipe(aio, pipe);
+	nni_aio_set_output(aio, 0, pipe);
+	nni_aio_finish(aio, 0, 0);
 }
 
 static int
@@ -512,7 +513,6 @@ nni_win_tcp_acc_start(nni_win_event *evt, nni_aio *aio)
 void
 nni_plat_tcp_ep_accept(nni_plat_tcp_ep *ep, nni_aio *aio)
 {
-	nni_aio_set_pipe(aio, NULL);
 	nni_win_event_submit(&ep->acc_ev, aio);
 }
 
@@ -562,7 +562,8 @@ nni_win_tcp_con_finish(nni_win_event *evt, nni_aio *aio)
 	len = sizeof(pipe->sockname);
 	(void) getsockname(s, (SOCKADDR *) &pipe->sockname, &len);
 
-	nni_aio_finish_pipe(aio, pipe);
+	nni_aio_set_output(aio, 0, pipe);
+	nni_aio_finish(aio, 0, 0);
 }
 
 static int
@@ -632,7 +633,6 @@ nni_win_tcp_con_start(nni_win_event *evt, nni_aio *aio)
 extern void
 nni_plat_tcp_ep_connect(nni_plat_tcp_ep *ep, nni_aio *aio)
 {
-	nni_aio_set_pipe(aio, NULL);
 	nni_win_event_submit(&ep->con_ev, aio);
 }
 

--- a/src/supplemental/http/http_client.c
+++ b/src/supplemental/http/http_client.c
@@ -44,7 +44,7 @@ http_conn_done(void *arg)
 
 	nni_mtx_lock(&c->mtx);
 	rv = nni_aio_result(c->connaio);
-	p  = rv == 0 ? nni_aio_get_pipe(c->connaio) : NULL;
+	p  = rv == 0 ? nni_aio_get_output(c->connaio, 0) : NULL;
 	if ((aio = nni_list_first(&c->aios)) == NULL) {
 		if (p != NULL) {
 			nni_plat_tcp_pipe_fini(p);

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -737,7 +737,7 @@ void
 nng_http_client_connect(nng_http_client *cli, nng_aio *aio)
 {
 #ifdef NNG_SUPP_HTTP
-	return (nni_http_client_connect(cli, aio));
+	nni_http_client_connect(cli, aio);
 #else
 	NNI_ARG_UNUSED(cli);
 	if (nni_aio_start(aio, NULL, NULL)) {

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -719,7 +719,7 @@ http_server_acccb(void *arg)
 		nni_mtx_unlock(&s->mtx);
 		return;
 	}
-	tcp = nni_aio_get_pipe(aio);
+	tcp = nni_aio_get_output(aio, 0);
 	if (s->closed) {
 		// If we're closing, then reject this one.
 		nni_plat_tcp_pipe_fini(tcp);

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -1174,7 +1174,8 @@ ws_http_cb_listener(nni_ws *ws, nni_aio *aio)
 	ws->ready = true;
 	if ((aio = nni_list_first(&l->aios)) != NULL) {
 		nni_list_remove(&l->aios, aio);
-		nni_aio_finish_pipe(aio, ws);
+		nni_aio_set_output(aio, 0, ws);
+		nni_aio_finish(aio, 0, 0);
 	} else {
 		nni_list_append(&l->pend, ws);
 	}
@@ -1269,7 +1270,8 @@ ws_http_cb_dialer(nni_ws *ws, nni_aio *aio)
 	nni_list_remove(&d->wspend, ws);
 	ws->ready   = true;
 	ws->useraio = NULL;
-	nni_aio_finish_pipe(uaio, ws);
+	nni_aio_set_output(uaio, 0, ws);
+	nni_aio_finish(uaio, 0, 0);
 	nni_mtx_unlock(&d->mtx);
 	return;
 err:
@@ -1621,7 +1623,8 @@ nni_ws_listener_accept(nni_ws_listener *l, nni_aio *aio)
 	}
 	if ((ws = nni_list_first(&l->pend)) != NULL) {
 		nni_list_remove(&l->pend, ws);
-		nni_aio_finish_pipe(aio, ws);
+		nni_aio_set_output(aio, 0, ws);
+		nni_aio_finish(aio, 0, 0);
 	} else {
 		nni_list_append(&l->aios, aio);
 	}

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -579,20 +579,20 @@ nni_ipc_ep_finish(nni_ipc_ep *ep)
 	if ((rv = nni_aio_result(ep->aio)) != 0) {
 		goto done;
 	}
-	NNI_ASSERT(nni_aio_get_pipe(ep->aio) != NULL);
+	NNI_ASSERT(nni_aio_get_output(ep->aio, 0) != NULL);
 
 	// Attempt to allocate the parent pipe.  If this fails we'll
 	// drop the connection (ENOMEM probably).
-	rv = nni_ipc_pipe_init(&pipe, ep, nni_aio_get_pipe(ep->aio));
+	rv = nni_ipc_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
 
 done:
-	nni_aio_set_pipe(ep->aio, NULL);
 	aio          = ep->user_aio;
 	ep->user_aio = NULL;
 
 	if ((aio != NULL) && (rv == 0)) {
 		NNI_ASSERT(pipe != NULL);
-		nni_aio_finish_pipe(aio, pipe);
+		nni_aio_set_output(aio, 0, pipe);
+		nni_aio_finish(aio, 0, 0);
 		return;
 	}
 

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -631,19 +631,19 @@ nni_tcp_ep_finish(nni_tcp_ep *ep)
 	if ((rv = nni_aio_result(ep->aio)) != 0) {
 		goto done;
 	}
-	NNI_ASSERT(nni_aio_get_pipe(ep->aio) != NULL);
+	NNI_ASSERT(nni_aio_get_output(ep->aio, 0) != NULL);
 
 	// Attempt to allocate the parent pipe.  If this fails we'll
 	// drop the connection (ENOMEM probably).
-	rv = nni_tcp_pipe_init(&pipe, ep, nni_aio_get_pipe(ep->aio));
+	rv = nni_tcp_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
 
 done:
-	nni_aio_set_pipe(ep->aio, NULL);
 	aio          = ep->user_aio;
 	ep->user_aio = NULL;
 
 	if ((aio != NULL) && (rv == 0)) {
-		nni_aio_finish_pipe(aio, pipe);
+		nni_aio_set_output(aio, 0, pipe);
+		nni_aio_finish(aio, 0, 0);
 		return;
 	}
 	if (pipe != NULL) {

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -653,19 +653,19 @@ nni_tls_ep_finish(nni_tls_ep *ep)
 	if ((rv = nni_aio_result(ep->aio)) != 0) {
 		goto done;
 	}
-	NNI_ASSERT(nni_aio_get_pipe(ep->aio) != NULL);
+	NNI_ASSERT(nni_aio_get_output(ep->aio, 0) != NULL);
 
 	// Attempt to allocate the parent pipe.  If this fails we'll
 	// drop the connection (ENOMEM probably).
-	rv = nni_tls_pipe_init(&pipe, ep, nni_aio_get_pipe(ep->aio));
+	rv = nni_tls_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
 
 done:
-	nni_aio_set_pipe(ep->aio, NULL);
 	aio          = ep->user_aio;
 	ep->user_aio = NULL;
 
 	if ((aio != NULL) && (rv == 0)) {
-		nni_aio_finish_pipe(aio, pipe);
+		nni_aio_set_output(aio, 0, pipe);
+		nni_aio_finish(aio, 0, 0);
 		return;
 	}
 	if (pipe != NULL) {

--- a/tests/httpserver.c
+++ b/tests/httpserver.c
@@ -200,7 +200,7 @@ TestMain("HTTP Server", {
 			nng_aio_wait(aio);
 
 			So(nng_aio_result(aio) == 0);
-			h = nni_aio_get_output(aio, 0);
+			h = nng_aio_get_output(aio, 0);
 			So(h != NULL);
 			So(nng_http_req_alloc(&req, url) == 0);
 			So(nng_http_res_alloc(&res) == 0);

--- a/tests/resolv.c
+++ b/tests/resolv.c
@@ -52,20 +52,20 @@ ip6tostr(void *addr)
 // the normal assumptions on Linux do *not* hold true.
 #if 0
 	    Convey("Localhost IPv6 resolves", {
-		    nni_aio aio;
-		    memset(&aio, 0, sizeof (aio));
+		    nng_aio *aio;
 		    const char *str;
-		    nni_aio_init(&aio, NULL, NULL);
+		    nng_sockaddr sa;
+		    So(nng_aio_alloc(&aio, NULL, NULL) == 0);
+		    So(nng_aio_set_input(aio, 0, &sa) == 0);
 		    nni_plat_tcp_resolv("localhost", "80", NNG_AF_INET6, 1,
-		    &aio);
-		    nni_aio_wait(&aio);
-		    So(nni_aio_result(&aio) == 0);
-		    So(aio.a_naddrs == 1);
-		    So(aio.a_addrs[0].s_un.s_in6.sa_family == NNG_AF_INET6);
-		    So(aio.a_addrs[0].s_un.s_in6.sa_port == ntohs(80));
-		    str = ip6tostr(&aio.a_addrs[0].s_un.s_in6.sa_addr);
+		    aio);
+		    nng_aio_wait(aio);
+		    So(nng_aio_result(aio) == 0);
+		    So(sa.s_un.s_in6.sa_family == NNG_AF_INET6);
+		    So(sa.s_un.s_in6.sa_port == ntohs(80));
+		    str = ip6tostr(&sa.s_un.s_in6.sa_addr);
 		    So(strcmp(str, "::1") == 0);
-		    nni_aio_fini(&aio);
+		    nng_aio_free(aio);
 	    }
 #endif
 


### PR DESCRIPTION
This addresses the use of the pipe special field, and eliminates it.
The message APIs (recvmsg, sendmsg) need to be updated as well still,
but I want to handle that as part of a separate issue.