### PR TITLE
fixes #234 Investigate enabling more verbose compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,23 +240,31 @@ endif()
 
 #  Platform checks.
 
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+	set(NNG_WARN_FLAGS "-Wall -Wextra")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    set(NNG_WARN_FLAGS "-Wall -Wextra")
+elseif (CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+    set(NNG_WARN_FLAGS "-Wall -Wextra")
+endif()
+
 if (NNG_ENABLE_COVERAGE)
     # NB: This only works for GCC and Clang 3.0 and newer.  If your stuff
     # is older than that, you will need to find something newer.  For
     # correct reporting, we always turn off all optimizations.
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-        set(CMAKE_C_FLAGS "-g -O0 --coverage")
-        set(CMAKE_CXX_FLAGS "-g -O0 --coverage")
+	    set(NNG_COVERAGE_FLAGS "-g -O0 --coverage")
     elseif (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-        set(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-        set(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-    elseif (CMAKE_COMPILER_ID STREQUAL "AppleClang")
-        set(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-        set(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+    	set(NNG_COVERAGE_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+    elseif (CMAKE_C_COMPILER_ID STREQUAL "AppleClang")
+    	set(NNG_COVERAGE_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
     else()
         message(FATAL_ERROR "Unable to enable coverage for your compiler.")
     endif()
 endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NNG_WARN_FLAGS} ${NNG_COVERAGE_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${NNG_WARN_FLAGS} ${NNG_COVERAGE_FLAGS}")
 
 find_package (Threads REQUIRED)
 

--- a/README.adoc
+++ b/README.adoc
@@ -4,6 +4,7 @@ image:https://img.shields.io/badge/license-MIT-blue.svg[MIT License]
 image:https://img.shields.io/circleci/project/github/nanomsg/nng.svg?label=[Linux Status,link="https://circleci.com/gh/nanomsg/nng"]
 image:https://img.shields.io/appveyor/ci/nanomsg/nng/master.svg?label=windows[Windows Status,link="https://ci.appveyor.com/project/nanomsg/nng"]
 image:https://codecov.io/gh/nanomsg/nng/branch/master/graph/badge.svg?label=coverage[Coverage,link="https://codecov.io/gh/nanomsg/nng"]
+image:https://api.codacy.com/project/badge/Grade/f241cba192974787b66f7e4368777ebf["Codacy code quality", link="https://www.codacy.com/app/gdamore/nng?utm_source=github.com&utm_medium=referral&utm_content=nanomsg/nng&utm_campaign=Badge_Grade"]
 
 This repository represents a work in progress rewrite of the SP protocol
 library called "libnanomsg".  This is pre-release, but at this point you

--- a/demo/http_client/http_client.c
+++ b/demo/http_client/http_client.c
@@ -31,11 +31,11 @@
 // % export CC="cc"
 // % ${CC} ${CPPFLAGS} http_client.c -o http_client ${LDFLAGS}
 // % ./http_client http://httpbin.org/ip
-// 
+//
 
+#include <nng/nng.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <nng/nng.h>
 
 void
 fatal(int rv)
@@ -48,16 +48,16 @@ int
 main(int argc, char **argv)
 {
 	nng_http_client *client;
-	nng_http_conn *conn;
-	nng_url *url;
-	nng_aio *aio;	
-	nng_http_req *req;
-	nng_http_res *res;
-	const char *hdr;
-	int rv;
-	int len;
-	void *data;
-	nng_iov iov;
+	nng_http_conn *  conn;
+	nng_url *        url;
+	nng_aio *        aio;
+	nng_http_req *   req;
+	nng_http_res *   res;
+	const char *     hdr;
+	int              rv;
+	int              len;
+	void *           data;
+	nng_iov          iov;
 
 	if (argc < 2) {
 		fprintf(stderr, "No URL supplied!\n");
@@ -116,12 +116,12 @@ main(int argc, char **argv)
 		exit(1);
 	}
 
+	len = atoi(hdr);
 	if (len == 0) {
 		return (0);
 	}
 
 	// Allocate a buffer to receive the body data.
-	len = atoi(hdr);
 	data = malloc(len);
 
 	// Set up a single iov to point to the buffer.

--- a/perf/perf.c
+++ b/perf/perf.c
@@ -33,17 +33,18 @@
 static void die(const char *, ...);
 
 static int
-nng_pair_open(nng_socket *rv)
+nng_pair_open(nng_socket *arg)
 {
+	(void) arg;
 	die("No pair protocol enabled in this build!");
 	return (NNG_ENOTSUP);
 }
 #endif // NNG_ENABLE_PAIR
 
-static void latency_client(const char *, int, int);
-static void latency_server(const char *, int, int);
-static void throughput_client(const char *, int, int);
-static void throughput_server(const char *, int, int);
+static void latency_client(const char *, size_t, int);
+static void latency_server(const char *, size_t, int);
+static void throughput_client(const char *, size_t, int);
+static void throughput_server(const char *, size_t, int);
 static void do_remote_lat(int argc, char **argv);
 static void do_local_lat(int argc, char **argv);
 static void do_remote_thr(int argc, char **argv);
@@ -209,7 +210,7 @@ struct inproc_args {
 	int         count;
 	int         msgsize;
 	const char *addr;
-	void (*func)(const char *, int, int);
+	void (*func)(const char *, size_t, int);
 };
 
 static void
@@ -275,7 +276,7 @@ do_inproc_thr(int argc, char **argv)
 }
 
 void
-latency_client(const char *addr, int msgsize, int trips)
+latency_client(const char *addr, size_t msgsize, int trips)
 {
 	nng_socket s;
 	nng_msg *  msg;
@@ -318,13 +319,13 @@ latency_client(const char *addr, int msgsize, int trips)
 	total   = (float) ((end - start)) / 1000;
 	latency = ((float) ((total * 1000000)) / (trips * 2));
 	printf("total time: %.3f [s]\n", total);
-	printf("message size: %d [B]\n", msgsize);
+	printf("message size: %d [B]\n", (int) msgsize);
 	printf("round trip count: %d\n", trips);
 	printf("average latency: %.3f [us]\n", latency);
 }
 
 void
-latency_server(const char *addr, int msgsize, int trips)
+latency_server(const char *addr, size_t msgsize, int trips)
 {
 	nng_socket s;
 	nng_msg *  msg;
@@ -366,7 +367,7 @@ latency_server(const char *addr, int msgsize, int trips)
 // API somewhere.
 
 void
-throughput_server(const char *addr, int msgsize, int count)
+throughput_server(const char *addr, size_t msgsize, int count)
 {
 	nng_socket s;
 	nng_msg *  msg;
@@ -413,14 +414,14 @@ throughput_server(const char *addr, int msgsize, int count)
 	msgpersec = (float) (count) / total;
 	mbps      = (float) (msgpersec * 8 * msgsize) / (1024 * 1024);
 	printf("total time: %.3f [s]\n", total);
-	printf("message size: %d [B]\n", msgsize);
+	printf("message size: %d [B]\n", (int) msgsize);
 	printf("message count: %d\n", count);
 	printf("throughput: %.f [msg/s]\n", msgpersec);
 	printf("throughput: %.3f [Mb/s]\n", mbps);
 }
 
 void
-throughput_client(const char *addr, int msgsize, int count)
+throughput_client(const char *addr, size_t msgsize, int count)
 {
 	nng_socket s;
 	nng_msg *  msg;

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -215,51 +215,51 @@ nni_aio_get_msg(nni_aio *aio)
 }
 
 void
-nni_aio_set_data(nni_aio *aio, int index, void *data)
+nni_aio_set_data(nni_aio *aio, unsigned index, void *data)
 {
-	if ((index >= 0) && (index < NNI_NUM_ELEMENTS(aio->a_user_data))) {
+	if (index < NNI_NUM_ELEMENTS(aio->a_user_data)) {
 		aio->a_user_data[index] = data;
 	}
 }
 
 void *
-nni_aio_get_data(nni_aio *aio, int index)
+nni_aio_get_data(nni_aio *aio, unsigned index)
 {
-	if ((index >= 0) && (index < NNI_NUM_ELEMENTS(aio->a_user_data))) {
+	if (index < NNI_NUM_ELEMENTS(aio->a_user_data)) {
 		return (aio->a_user_data[index]);
 	}
 	return (NULL);
 }
 
 void
-nni_aio_set_input(nni_aio *aio, int index, void *data)
+nni_aio_set_input(nni_aio *aio, unsigned index, void *data)
 {
-	if ((index >= 0) && (index < NNI_NUM_ELEMENTS(aio->a_inputs))) {
+	if (index < NNI_NUM_ELEMENTS(aio->a_inputs)) {
 		aio->a_inputs[index] = data;
 	}
 }
 
 void *
-nni_aio_get_input(nni_aio *aio, int index)
+nni_aio_get_input(nni_aio *aio, unsigned index)
 {
-	if ((index >= 0) && (index < NNI_NUM_ELEMENTS(aio->a_inputs))) {
+	if (index < NNI_NUM_ELEMENTS(aio->a_inputs)) {
 		return (aio->a_inputs[index]);
 	}
 	return (NULL);
 }
 
 void
-nni_aio_set_output(nni_aio *aio, int index, void *data)
+nni_aio_set_output(nni_aio *aio, unsigned index, void *data)
 {
-	if ((index >= 0) && (index < NNI_NUM_ELEMENTS(aio->a_outputs))) {
+	if (index < NNI_NUM_ELEMENTS(aio->a_outputs)) {
 		aio->a_outputs[index] = data;
 	}
 }
 
 void *
-nni_aio_get_output(nni_aio *aio, int index)
+nni_aio_get_output(nni_aio *aio, unsigned index)
 {
-	if ((index >= 0) && (index < NNI_NUM_ELEMENTS(aio->a_outputs))) {
+	if (index < NNI_NUM_ELEMENTS(aio->a_outputs)) {
 		return (aio->a_outputs[index]);
 	}
 	return (NULL);
@@ -315,7 +315,7 @@ nni_aio_start(nni_aio *aio, nni_aio_cancelfn cancelfn, void *data)
 	aio->a_prov_cancel = cancelfn;
 	aio->a_prov_data   = data;
 	aio->a_active      = 1;
-	for (int i = 0; i < NNI_NUM_ELEMENTS(aio->a_outputs); i++) {
+	for (unsigned i = 0; i < NNI_NUM_ELEMENTS(aio->a_outputs); i++) {
 		aio->a_outputs[i] = NULL;
 	}
 

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -52,28 +52,28 @@ extern void nni_aio_stop(nni_aio *);
 // consumer, initiating the I/O.  The intention is to be able to store
 // additional data for use when the operation callback is executed.
 // The index represents the "index" at which to store the data.  A maximum
-// of 4 elements can be stored with the (index >= 0 && index < 4).
-extern void nni_aio_set_data(nni_aio *, int, void *);
+// of 4 elements can be stored with the (index < 4).
+extern void nni_aio_set_data(nni_aio *, unsigned, void *);
 
 // nni_aio_get_data returns the user data that was previously stored
 // with nni_aio_set_data.
-extern void *nni_aio_get_data(nni_aio *, int);
+extern void *nni_aio_get_data(nni_aio *, unsigned);
 
 // nni_set_input sets input parameters on the AIO.  The semantic details
 // of this will be determined by the specific AIO operation.  AIOs can
 // carry up to 4 input parameters.
-extern void nni_aio_set_input(nni_aio *, int, void *);
+extern void nni_aio_set_input(nni_aio *, unsigned, void *);
 
 // nni_get_input returns the input value stored by nni_aio_set_input.
-extern void *nni_aio_get_input(nni_aio *, int);
+extern void *nni_aio_get_input(nni_aio *, unsigned);
 
 // nni_set_output sets output results on the AIO, allowing providers to
 // return results to consumers.  The semantic details are determined by
 // the AIO operation.  Up to 4 outputs can be carried on an AIO.
-extern void nni_aio_set_output(nni_aio *, int, void *);
+extern void nni_aio_set_output(nni_aio *, unsigned, void *);
 
 // nni_get_output returns an output previously stored on the AIO.
-extern void *nni_aio_get_output(nni_aio *, int);
+extern void *nni_aio_get_output(nni_aio *, unsigned);
 
 // XXX: These should be refactored in terms of generic inputs and outputs.
 extern void     nni_aio_set_msg(nni_aio *, nni_msg *);

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -27,7 +27,7 @@
 #endif
 
 // Returns the size of an array in elements. (Convenience.)
-#define NNI_NUM_ELEMENTS(x) (sizeof(x) / sizeof((x)[0]))
+#define NNI_NUM_ELEMENTS(x) ((unsigned) (sizeof(x) / sizeof((x)[0])))
 
 // These types are common but have names shared with user space.
 // Internal code should use these names when possible.

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -510,6 +510,7 @@ int
 nni_ep_listen(nni_ep *ep, int flags)
 {
 	int rv = 0;
+	NNI_ARG_UNUSED(flags);
 
 	nni_sock_reconntimes(ep->ep_sock, &ep->ep_inirtime, &ep->ep_maxrtime);
 	ep->ep_currtime = ep->ep_inirtime;

--- a/src/core/url.c
+++ b/src/core/url.c
@@ -127,8 +127,8 @@ url_canonify_uri(char **outp, const char *in)
 				out[dst++] = (char) c;
 			} else {
 				out[dst++] = '%';
-				out[dst++] = toupper(out[src + 1]);
-				out[dst++] = toupper(out[src + 2]);
+				out[dst++] = (char) toupper(out[src + 1]);
+				out[dst++] = (char) toupper(out[src + 2]);
 			}
 			src += 3;
 			continue;
@@ -152,7 +152,7 @@ url_canonify_uri(char **outp, const char *in)
 		if ((c == '?') || (c == '#')) {
 			skip = true;
 		}
-		out[dst++] = c;
+		out[dst++] = (char) c;
 		src++;
 	}
 	out[dst] = 0;
@@ -186,7 +186,7 @@ url_canonify_uri(char **outp, const char *in)
 			if ((c == '?') || (c == '#')) {
 				skip = true;
 			}
-			out[dst++] = c;
+			out[dst++] = (char) c;
 			src++;
 		}
 	}
@@ -285,7 +285,7 @@ nni_url_parse(nni_url **urlp, const char *raw)
 		goto error;
 	}
 	for (size_t i = 0; i < len; i++) {
-		url->u_scheme[i] = tolower(s[i]);
+		url->u_scheme[i] = (char) tolower(s[i]);
 	}
 	url->u_scheme[len] = '\0';
 
@@ -335,7 +335,7 @@ nni_url_parse(nni_url **urlp, const char *raw)
 	// Copy the host portion, but make it lower case (hostnames are
 	// case insensitive).
 	for (size_t i = 0; i < len; i++) {
-		url->u_host[i] = tolower(s[i]);
+		url->u_host[i] = (char) tolower(s[i]);
 	}
 	url->u_host[len] = '\0';
 	s += len;

--- a/src/platform/posix/posix_aio.h
+++ b/src/platform/posix/posix_aio.h
@@ -33,8 +33,8 @@ extern int  nni_posix_pipedesc_peername(nni_posix_pipedesc *, nni_sockaddr *);
 extern int  nni_posix_pipedesc_sockname(nni_posix_pipedesc *, nni_sockaddr *);
 
 extern int  nni_posix_epdesc_init(nni_posix_epdesc **);
-extern void nni_posix_epdesc_set_local(nni_posix_epdesc *, void *, int);
-extern void nni_posix_epdesc_set_remote(nni_posix_epdesc *, void *, int);
+extern void nni_posix_epdesc_set_local(nni_posix_epdesc *, void *, size_t);
+extern void nni_posix_epdesc_set_remote(nni_posix_epdesc *, void *, size_t);
 extern void nni_posix_epdesc_fini(nni_posix_epdesc *);
 extern void nni_posix_epdesc_close(nni_posix_epdesc *);
 extern void nni_posix_epdesc_connect(nni_posix_epdesc *, nni_aio *);

--- a/src/platform/posix/posix_epdesc.c
+++ b/src/platform/posix/posix_epdesc.c
@@ -434,9 +434,9 @@ nni_posix_epdesc_init(nni_posix_epdesc **edp)
 }
 
 void
-nni_posix_epdesc_set_local(nni_posix_epdesc *ed, void *sa, int len)
+nni_posix_epdesc_set_local(nni_posix_epdesc *ed, void *sa, size_t len)
 {
-	if ((len < 0) || (len > sizeof(struct sockaddr_storage))) {
+	if ((len < 1) || (len > sizeof(struct sockaddr_storage))) {
 		return;
 	}
 	nni_mtx_lock(&ed->mtx);
@@ -446,9 +446,9 @@ nni_posix_epdesc_set_local(nni_posix_epdesc *ed, void *sa, int len)
 }
 
 void
-nni_posix_epdesc_set_remote(nni_posix_epdesc *ed, void *sa, int len)
+nni_posix_epdesc_set_remote(nni_posix_epdesc *ed, void *sa, size_t len)
 {
-	if ((len < 0) || (len > sizeof(struct sockaddr_storage))) {
+	if ((len < 1) || (len > sizeof(struct sockaddr_storage))) {
 		return;
 	}
 	nni_mtx_lock(&ed->mtx);

--- a/src/platform/posix/posix_file.c
+++ b/src/platform/posix/posix_file.c
@@ -96,7 +96,7 @@ nni_plat_file_get(const char *name, void **datap, size_t *lenp)
 	FILE *      f;
 	struct stat st;
 	int         rv = 0;
-	int         len;
+	size_t      len;
 	void *      data;
 
 	if ((f = fopen(name, "rb")) == NULL) {
@@ -146,7 +146,6 @@ int
 nni_plat_file_type(const char *name, int *typep)
 {
 	struct stat sbuf;
-	int         rv;
 
 	if (stat(name, &sbuf) != 0) {
 		return (nni_plat_errno(errno));

--- a/src/platform/posix/posix_impl.h
+++ b/src/platform/posix/posix_impl.h
@@ -37,8 +37,8 @@
 
 #ifdef NNG_PLATFORM_POSIX_SOCKADDR
 #include <sys/socket.h>
-extern int nni_posix_sockaddr2nn(nni_sockaddr *, const void *);
-extern int nni_posix_nn2sockaddr(void *, const nni_sockaddr *);
+extern int    nni_posix_sockaddr2nn(nni_sockaddr *, const void *);
+extern size_t nni_posix_nn2sockaddr(void *, const nni_sockaddr *);
 #endif
 
 #ifdef NNG_PLATFORM_POSIX_DEBUG

--- a/src/platform/posix/posix_ipc.c
+++ b/src/platform/posix/posix_ipc.c
@@ -97,7 +97,6 @@ static int
 nni_plat_ipc_remove_stale(const char *path)
 {
 	int                fd;
-	int                rv;
 	struct sockaddr_un sun;
 	size_t             sz;
 

--- a/src/platform/posix/posix_pollq_poll.c
+++ b/src/platform/posix/posix_pollq_poll.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -353,6 +353,7 @@ static nni_posix_pollq nni_posix_global_pollq;
 nni_posix_pollq *
 nni_posix_pollq_get(int fd)
 {
+	NNI_ARG_UNUSED(fd);
 	// This is the point where we could choose a pollq based on FD.
 	return (&nni_posix_global_pollq);
 }

--- a/src/platform/posix/posix_rand.c
+++ b/src/platform/posix/posix_rand.c
@@ -1,5 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -42,7 +43,7 @@ void
 nni_plat_seed_prng(void *buf, size_t bufsz)
 {
 	struct nni_plat_prng_x x;
-	int                    i;
+	size_t                 i;
 
 	memset(buf, 0, bufsz);
 

--- a/src/platform/posix/posix_sockaddr.c
+++ b/src/platform/posix/posix_sockaddr.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -22,7 +22,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 
-int
+size_t
 nni_posix_nn2sockaddr(void *sa, const nni_sockaddr *na)
 {
 	struct sockaddr_in *     sin;
@@ -34,7 +34,7 @@ nni_posix_nn2sockaddr(void *sa, const nni_sockaddr *na)
 	size_t                   sz;
 
 	if ((sa == NULL) || (na == NULL)) {
-		return (-1);
+		return (0);
 	}
 	switch (na->s_un.s_family) {
 	case NNG_AF_INET:
@@ -65,12 +65,12 @@ nni_posix_nn2sockaddr(void *sa, const nni_sockaddr *na)
 		// Make sure that the path fits!
 		sz = sizeof(spath->sun_path);
 		if (nni_strlcpy(spath->sun_path, nspath->sa_path, sz) >= sz) {
-			return (-1);
+			return (0);
 		}
 		spath->sun_family = PF_UNIX;
 		return (sizeof(*spath));
 	}
-	return (-1);
+	return (0);
 }
 
 int

--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -265,8 +265,6 @@ nni_plat_cv_until_fallback(nni_cv *cv, struct timespec *ts)
 void
 nni_plat_mtx_lock(nni_plat_mtx *mtx)
 {
-	int rv;
-
 	if (!mtx->fallback) {
 		nni_pthread_mutex_lock(&mtx->mtx);
 
@@ -328,7 +326,6 @@ nni_plat_cv_wake(nni_plat_cv *cv)
 void
 nni_plat_cv_wake1(nni_plat_cv *cv)
 {
-	int rv;
 	if (cv->fallback) {
 		nni_plat_cv_wake1_fallback(cv);
 	} else {

--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -108,7 +108,6 @@ nni_posix_udp_dosend(nni_plat_udp *udp)
 {
 	nni_aio * aio;
 	nni_list *q = &udp->udp_sendq;
-	int       x = 0;
 
 	// While we're able to send, do so.
 	while ((aio = nni_list_first(q)) != NULL) {
@@ -119,7 +118,7 @@ nni_posix_udp_dosend(nni_plat_udp *udp)
 		int cnt = 0;
 
 		len = nni_posix_nn2sockaddr(&ss, nni_aio_get_input(aio, 0));
-		if (len < 0) {
+		if (len < 1) {
 			rv = NNG_EADDRINVAL;
 		} else {
 			struct msghdr hdr;
@@ -211,7 +210,7 @@ nni_plat_udp_open(nni_plat_udp **upp, nni_sockaddr *bindaddr)
 	struct sockaddr_storage sa;
 	int                     rv;
 
-	if ((salen = nni_posix_nn2sockaddr(&sa, bindaddr)) < 0) {
+	if ((salen = nni_posix_nn2sockaddr(&sa, bindaddr)) < 1) {
 		return (NNG_EADDRINVAL);
 	}
 
@@ -261,8 +260,6 @@ nni_plat_udp_open(nni_plat_udp **upp, nni_sockaddr *bindaddr)
 void
 nni_plat_udp_close(nni_plat_udp *udp)
 {
-	nni_aio *aio;
-
 	// We're no longer interested in events.
 	nni_posix_pollq_remove(&udp->udp_pitem);
 

--- a/src/platform/windows/win_ipc.c
+++ b/src/platform/windows/win_ipc.c
@@ -330,6 +330,7 @@ static int
 nni_win_ipc_acc_start(nni_win_event *evt, nni_aio *aio)
 {
 	nni_plat_ipc_ep *ep = evt->ptr;
+	NNI_ARG_UNUSED(aio);
 
 	if (!ConnectNamedPipe(ep->p, &evt->olpd)) {
 		int rv = GetLastError();

--- a/src/platform/windows/win_tcp.c
+++ b/src/platform/windows/win_tcp.c
@@ -265,6 +265,8 @@ nni_plat_tcp_ep_init(nni_plat_tcp_ep **epp, const nni_sockaddr *lsa,
 	GUID             guid2 = WSAID_ACCEPTEX;
 	GUID             guid3 = WSAID_GETACCEPTEXSOCKADDRS;
 
+	NNI_ARG_UNUSED(mode);
+
 	if ((ep = NNI_ALLOC_STRUCT(ep)) == NULL) {
 		return (NNG_ENOMEM);
 	}
@@ -481,6 +483,8 @@ nni_win_tcp_acc_start(nni_win_event *evt, nni_aio *aio)
 	SOCKET           acc_s;
 	DWORD            cnt;
 
+	NNI_ARG_UNUSED(aio);
+
 	acc_s = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
 	if (acc_s == INVALID_SOCKET) {
 		evt->status = nni_win_error(GetLastError());
@@ -575,6 +579,8 @@ nni_win_tcp_con_start(nni_win_event *evt, nni_aio *aio)
 	int              len;
 	int              rv;
 	int              family;
+
+	NNI_ARG_UNUSED(aio);
 
 	if (ep->loclen > 0) {
 		family = ep->locaddr.ss_family;

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -100,6 +100,7 @@ nni_plat_cv_until(nni_plat_cv *cv, nni_time until)
 void
 nni_plat_cv_fini(nni_plat_cv *cv)
 {
+	NNI_ARG_UNUSED(cv);
 }
 
 static unsigned int __stdcall nni_plat_thr_main(void *arg)

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -196,6 +196,7 @@ pull0_sock_getopt_raw(void *arg, void *buf, size_t *szp)
 static void
 pull0_sock_send(void *arg, nni_aio *aio)
 {
+	NNI_ARG_UNUSED(arg);
 	nni_aio_finish_error(aio, NNG_ENOTSUP);
 }
 

--- a/src/protocol/pipeline0/push.c
+++ b/src/protocol/pipeline0/push.c
@@ -221,6 +221,7 @@ push0_sock_send(void *arg, nni_aio *aio)
 static void
 push0_sock_recv(void *arg, nni_aio *aio)
 {
+	NNI_ARG_UNUSED(arg);
 	nni_aio_finish_error(aio, NNG_ENOTSUP);
 }
 

--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -290,6 +290,7 @@ pub0_sock_getopt_raw(void *arg, void *buf, size_t *szp)
 static void
 pub0_sock_recv(void *arg, nni_aio *aio)
 {
+	NNI_ARG_UNUSED(arg);
 	nni_aio_finish_error(aio, NNG_ENOTSUP);
 }
 

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -292,6 +292,7 @@ sub0_sock_getopt_raw(void *arg, void *buf, size_t *szp)
 static void
 sub0_sock_send(void *arg, nni_aio *aio)
 {
+	NNI_ARG_UNUSED(arg);
 	nni_aio_finish_error(aio, NNG_ENOTSUP);
 }
 

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -474,6 +474,11 @@ static nni_proto_sock_option surv0_sock_options[] = {
 	    .pso_getopt = surv0_sock_getopt_surveytime,
 	    .pso_setopt = surv0_sock_setopt_surveytime,
 	},
+	{
+	    .pso_name   = NNG_OPT_MAXTTL,
+	    .pso_getopt = surv0_sock_getopt_maxttl,
+	    .pso_setopt = surv0_sock_setopt_maxttl,
+	},
 	// terminate list
 	{ NULL, NULL, NULL },
 };

--- a/src/supplemental/base64/base64.c
+++ b/src/supplemental/base64/base64.c
@@ -107,7 +107,7 @@ nni_base64_encode(const uint8_t *in, size_t in_len, char *out, size_t out_len)
 	uint32_t v;
 	uint8_t  ch;
 
-	const uint8_t ENCODEMAP[64] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	const uint8_t ENCODEMAP[65] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 	                              "abcdefghijklmnopqrstuvwxyz"
 	                              "0123456789+/";
 

--- a/src/supplemental/http/http_client.c
+++ b/src/supplemental/http/http_client.c
@@ -197,6 +197,8 @@ nni_http_client_set_tls(nni_http_client *c, nng_tls_config *tls)
 	}
 	return (0);
 #else
+	NNI_ARG_UNUSED(c);
+	NNI_ARG_UNUSED(tls);
 	return (NNG_EINVAL);
 #endif
 }
@@ -214,6 +216,8 @@ nni_http_client_get_tls(nni_http_client *c, nng_tls_config **tlsp)
 	nni_mtx_unlock(&c->mtx);
 	return (0);
 #else
+	NNI_ARG_UNUSED(c);
+	NNI_ARG_UNUSED(tlsp);
 	return (NNG_ENOTSUP);
 #endif
 }

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -200,10 +200,10 @@ http_rd_buf(nni_http_conn *conn, nni_aio *aio)
 			conn->rd_get = conn->rd_put = 0;
 		}
 		if (rv == NNG_EAGAIN) {
-			nni_iov iov;
-			iov.iov_buf = conn->rd_buf + conn->rd_put;
-			iov.iov_len = conn->rd_bufsz - conn->rd_put;
-			nni_aio_set_iov(conn->rd_aio, 1, &iov);
+			nni_iov iov1;
+			iov1.iov_buf = conn->rd_buf + conn->rd_put;
+			iov1.iov_len = conn->rd_bufsz - conn->rd_put;
+			nni_aio_set_iov(conn->rd_aio, 1, &iov1);
 			nni_aio_set_data(conn->rd_aio, 1, aio);
 			conn->rd(conn->sock, conn->rd_aio);
 		}
@@ -217,10 +217,10 @@ http_rd_buf(nni_http_conn *conn, nni_aio *aio)
 			conn->rd_get = conn->rd_put = 0;
 		}
 		if (rv == NNG_EAGAIN) {
-			nni_iov iov;
-			iov.iov_buf = conn->rd_buf + conn->rd_put;
-			iov.iov_len = conn->rd_bufsz - conn->rd_put;
-			nni_aio_set_iov(conn->rd_aio, 1, &iov);
+			nni_iov iov1;
+			iov1.iov_buf = conn->rd_buf + conn->rd_put;
+			iov1.iov_len = conn->rd_bufsz - conn->rd_put;
+			nni_aio_set_iov(conn->rd_aio, 1, &iov1);
 			nni_aio_set_data(conn->rd_aio, 1, aio);
 			conn->rd(conn->sock, conn->rd_aio);
 		}

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -1494,6 +1494,8 @@ nni_http_server_set_tls(nni_http_server *s, nng_tls_config *tcfg)
 	}
 	return (0);
 #else
+	NNI_ARG_UNUSED(s);
+	NNI_ARG_UNUSED(tcfg);
 	return (NNG_ENOTSUP);
 #endif
 }
@@ -1511,6 +1513,8 @@ nni_http_server_get_tls(nni_http_server *s, nng_tls_config **tp)
 	nni_mtx_unlock(&s->mtx);
 	return (0);
 #else
+	NNI_ARG_UNUSED(s);
+	NNI_ARG_UNUSED(tp);
 	return (NNG_ENOTSUP);
 #endif
 }

--- a/src/supplemental/tls/mbedtls/tls.c
+++ b/src/supplemental/tls/mbedtls/tls.c
@@ -112,6 +112,8 @@ static void
 nni_tls_dbg(void *ctx, int level, const char *file, int line, const char *s)
 {
 	char buf[128];
+	NNI_ARG_UNUSED(ctx);
+	NNI_ARG_UNUSED(level);
 	snprintf(buf, sizeof(buf), "%s:%04d: %s", file, line, s);
 	nni_plat_println(buf);
 }

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -660,7 +660,7 @@ ws_send_control(nni_ws *ws, uint8_t op, uint8_t *buf, size_t len)
 
 	nni_mtx_lock(&ws->mtx);
 	if ((ws->closed) ||
-	    (ws_msg_init_control(&wm, ws, op, buf, sizeof(buf)) != 0)) {
+	    (ws_msg_init_control(&wm, ws, op, buf, len) != 0)) {
 		nni_mtx_unlock(&ws->mtx);
 		return;
 	}
@@ -1768,7 +1768,7 @@ ws_conn_cb(void *arg)
 	}
 
 	for (int i = 0; i < 16; i++) {
-		raw[i] = nni_random();
+		raw[i] = (uint8_t) nni_random();
 	}
 	nni_base64_encode(raw, 16, wskey, 24);
 	wskey[24] = '\0';

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -244,6 +244,8 @@ ws_hook(void *arg, nni_http_req *req, nni_http_res *res)
 {
 	ws_ep * ep = arg;
 	ws_hdr *h;
+	NNI_ARG_UNUSED(req);
+
 	// Eventually we'll want user customizable hooks.
 	// For now we just set the headers we want.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,7 +77,7 @@ if (NNG_TESTS)
 
         macro (add_nng_compat_test NAME TIMEOUT)
             list (APPEND all_tests ${NAME})
-            add_executable (${NAME} ${NAME}.c)
+            add_executable (${NAME} ${NAME}.c compat_testutil.c)
             target_link_libraries (${NAME} ${PROJECT_NAME}_static)
             target_link_libraries (${NAME} ${NNG_REQUIRED_LIBRARIES})
             target_compile_definitions(${NAME} PUBLIC -DNNG_STATIC_LIB)

--- a/tests/base64.c
+++ b/tests/base64.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Staysail Systems, Inc. <info@staysail.tech>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -45,7 +45,7 @@ TestMain("Base64 Verification", {
 		for (i = 0; (dec = cases[i].decoded) != NULL; i++) {
 			rv = nni_base64_encode(dec, strlen(dec), buf, 1024);
 			So(rv >= 0);
-			So(rv == strlen(cases[i].encoded));
+			So(rv == (int) strlen(cases[i].encoded));
 			buf[rv] = 0;
 			So(strcmp(buf, cases[i].encoded) == 0);
 		}
@@ -61,7 +61,7 @@ TestMain("Base64 Verification", {
 			rv = nni_base64_decode(
 			    enc, strlen(enc), (void *) buf, 1024);
 			So(rv >= 0);
-			So(rv == strlen(cases[i].decoded));
+			So(rv == (int) strlen(cases[i].decoded));
 			buf[rv] = 0;
 			So(strcmp(buf, cases[i].decoded) == 0);
 		}

--- a/tests/compat_bug777.c
+++ b/tests/compat_bug777.c
@@ -25,7 +25,7 @@
 #include "nng.h"
 #include "compat_testutil.h"
 
-int main (int argc, const char *argv[])
+int main (NN_UNUSED int argc, NN_UNUSED const char *argv[])
 {
     int sb;
     int sc1;

--- a/tests/compat_testutil.c
+++ b/tests/compat_testutil.c
@@ -1,0 +1,229 @@
+/*
+    Copyright (c) 2013 Insollo Entertainment, LLC. All rights reserved.
+    Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
+    Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+    Copyright 2018 Capitar IT Group BV <info@capitar.com>
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom
+    the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+*/
+
+// Note: This file started life in nanomsg.  We have copied it, and adjusted
+// it for validating the compatibility features of nanomsg.   As much as
+// possible we want to run tests from the nanomsg test suite unmodified.
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "compat_testutil.h"
+#include "nng_compat.h"
+
+int  test_socket_impl(char *file, int line, int family, int protocol);
+int  test_connect_impl(char *file, int line, int sock, char *address);
+int  test_bind_impl(char *file, int line, int sock, char *address);
+void test_close_impl(char *file, int line, int sock);
+void test_send_impl(char *file, int line, int sock, char *data);
+void test_recv_impl(char *file, int line, int sock, char *data);
+void test_drop_impl(char *file, int line, int sock, int err);
+int test_setsockopt_impl(char *file, int line, int sock, int level, int option,
+    const void *optval, size_t optlen);
+
+int
+test_socket_impl(char *file, int line, int family, int protocol)
+{
+	int sock;
+
+	sock = nn_socket(family, protocol);
+	if (sock == -1) {
+		fprintf(stderr, "Failed create socket: %s [%d] (%s:%d)\n",
+		    nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+
+	return (sock);
+}
+
+int
+test_connect_impl(char *file, int line, int sock, char *address)
+{
+	int rc;
+
+	rc = nn_connect(sock, address);
+	if (rc < 0) {
+		fprintf(stderr, "Failed connect to \"%s\": %s [%d] (%s:%d)\n",
+		    address, nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+	return (rc);
+}
+
+int
+test_bind_impl(char *file, int line, int sock, char *address)
+{
+	int rc;
+
+	rc = nn_bind(sock, address);
+	if (rc < 0) {
+		fprintf(stderr, "Failed bind to \"%s\": %s [%d] (%s:%d)\n",
+		    address, nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+	return (rc);
+}
+
+int
+test_setsockopt_impl(char *file, int line, int sock, int level, int option,
+    const void *optval, size_t optlen)
+{
+	int rc;
+
+	rc = nn_setsockopt(sock, level, option, optval, optlen);
+	if (rc < 0) {
+		fprintf(stderr, "Failed set option \"%d\": %s [%d] (%s:%d)\n",
+		    option, nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+	return rc;
+}
+
+void
+test_close_impl(char *file, int line, int sock)
+{
+	int rc;
+
+	rc = nn_close(sock);
+	if ((rc != 0) && (errno != EBADF && errno != ETERM)) {
+		fprintf(stderr, "Failed to close socket: %s [%d] (%s:%d)\n",
+		    nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+}
+
+void
+test_send_impl(char *file, int line, int sock, char *data)
+{
+	size_t data_len;
+	int    rc;
+
+	data_len = strlen(data);
+
+	rc = nn_send(sock, data, data_len, 0);
+	if (rc < 0) {
+		fprintf(stderr, "Failed to send: %s [%d] (%s:%d)\n",
+		    nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+	if (rc != (int) data_len) {
+		fprintf(stderr,
+		    "Data to send is truncated: %d != %d (%s:%d)\n", rc,
+		    (int) data_len, file, line);
+		nn_err_abort();
+	}
+}
+
+void
+test_recv_impl(char *file, int line, int sock, char *data)
+{
+	size_t data_len;
+	int    rc;
+	char * buf;
+
+	data_len = strlen(data);
+	/*  We allocate plus one byte so that we are sure that message received
+	    has correct length and not truncated  */
+	buf = malloc(data_len + 1);
+	alloc_assert(buf);
+
+	rc = nn_recv(sock, buf, data_len + 1, 0);
+	if (rc < 0) {
+		fprintf(stderr, "Failed to recv: %s [%d] (%s:%d)\n",
+		    nn_err_strerror(errno), (int) errno, file, line);
+		nn_err_abort();
+	}
+	if (rc != (int) data_len) {
+		fprintf(stderr,
+		    "Received data has wrong length: %d != %d (%s:%d)\n", rc,
+		    (int) data_len, file, line);
+		nn_err_abort();
+	}
+	if (memcmp(data, buf, data_len) != 0) {
+		/*  We don't print the data as it may have binary garbage  */
+		fprintf(
+		    stderr, "Received data is wrong (%s:%d)\n", file, line);
+		nn_err_abort();
+	}
+
+	free(buf);
+}
+
+void
+test_drop_impl(char *file, int line, int sock, int err)
+{
+	int  rc;
+	char buf[1024];
+
+	rc = nn_recv(sock, buf, sizeof(buf), 0);
+	if (rc < 0 && err != errno) {
+		fprintf(stderr,
+		    "Got wrong err to recv: %s [%d != %d] (%s:%d)\n",
+		    nn_err_strerror(errno), (int) errno, err, file, line);
+		nn_err_abort();
+	} else if (rc >= 0) {
+		fprintf(stderr, "Did not drop message: [%d bytes] (%s:%d)\n",
+		    rc, file, line);
+		nn_err_abort();
+	}
+}
+
+int
+get_test_port(int argc, const char *argv[])
+{
+	return (atoi(argc < 2 ? "5555" : argv[1]));
+}
+
+void
+test_addr_from(char *out, const char *proto, const char *ip, int port)
+{
+	sprintf(out, "%s://%s:%d", proto, ip, port);
+}
+
+extern int nng_thread_create(void **, void (*)(void *), void *);
+
+int
+nn_thread_init(struct nn_thread *thr, void (*func)(void *), void *arg)
+{
+	return (nng_thread_create(&thr->thr, func, arg));
+}
+
+extern void nng_thread_destroy(void *);
+
+void
+nn_thread_term(struct nn_thread *thr)
+{
+	nng_thread_destroy(thr->thr);
+}
+
+extern void nng_msleep(int32_t);
+
+void
+nn_sleep(int ms)
+{
+	nng_msleep(ms);
+}

--- a/tests/compat_testutil.h
+++ b/tests/compat_testutil.h
@@ -2,6 +2,8 @@
     Copyright (c) 2013 Insollo Entertainment, LLC. All rights reserved.
     Copyright 2017 Garrett D'Amore <garrett@damore.org>
     Copyright 2016 Franklin "Snaipe" Mathieu <franklinmathieu@gmail.com>
+    Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+    Copyright 2018 Capitar IT Group BV <info@capitar.com>
 
     Permission is hereby granted, free of charge, to any person obtaining a
     copy of this software and associated documentation files (the "Software"),
@@ -40,15 +42,25 @@
 #define errno_assert assert
 #define alloc_assert(x) assert(x != NULL)
 
-static int  test_socket_impl(char *file, int line, int family, int protocol);
-static int  test_connect_impl(char *file, int line, int sock, char *address);
-static int  test_bind_impl(char *file, int line, int sock, char *address);
-static void test_close_impl(char *file, int line, int sock);
-static void test_send_impl(char *file, int line, int sock, char *data);
-static void test_recv_impl(char *file, int line, int sock, char *data);
-static void test_drop_impl(char *file, int line, int sock, int err);
-static int  test_setsockopt_impl(char *file, int line, int sock, int level,
-     int option, const void *optval, size_t optlen);
+#if defined __GNUC__ || defined __llvm__ || defined __clang__
+#define NN_UNUSED __attribute__((unused))
+#else
+#define NN_UNUSED
+#endif
+
+extern int  test_socket_impl(char *file, int line, int family, int protocol);
+extern int  test_connect_impl(char *file, int line, int sock, char *address);
+extern int  test_bind_impl(char *file, int line, int sock, char *address);
+extern void test_close_impl(char *file, int line, int sock);
+extern void test_send_impl(char *file, int line, int sock, char *data);
+extern void test_recv_impl(char *file, int line, int sock, char *data);
+extern void test_drop_impl(char *file, int line, int sock, int err);
+extern int  test_setsockopt_impl(char *file, int line, int sock, int level,
+	int option, const void *optval, size_t optlen);
+extern int get_test_port(int argc, const char *argv[]);
+extern void test_addr_from(char *out, const char *proto, const char *ip,
+	int port);
+extern void nn_sleep(int);
 
 #define test_socket(f, p) test_socket_impl(__FILE__, __LINE__, (f), (p))
 #define test_connect(s, a) test_connect_impl(__FILE__, __LINE__, (s), (a))
@@ -60,190 +72,11 @@ static int  test_setsockopt_impl(char *file, int line, int sock, int level,
 #define test_setsockopt(s, l, o, v, z) \
 	test_setsockopt_impl(__FILE__, __LINE__, (s), (l), (o), (v), (z))
 
-#define NN_UNUSED
-
-static int
-test_socket_impl(char *file, int line, int family, int protocol)
-{
-	int sock;
-
-	sock = nn_socket(family, protocol);
-	if (sock == -1) {
-		fprintf(stderr, "Failed create socket: %s [%d] (%s:%d)\n",
-		    nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-
-	return sock;
-}
-
-static int
-test_connect_impl(char *file, int line, int sock, char *address)
-{
-	int rc;
-
-	rc = nn_connect(sock, address);
-	if (rc < 0) {
-		fprintf(stderr, "Failed connect to \"%s\": %s [%d] (%s:%d)\n",
-		    address, nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-	return rc;
-}
-
-static int
-test_bind_impl(char *file, int line, int sock, char *address)
-{
-	int rc;
-
-	rc = nn_bind(sock, address);
-	if (rc < 0) {
-		fprintf(stderr, "Failed bind to \"%s\": %s [%d] (%s:%d)\n",
-		    address, nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-	return rc;
-}
-
-static int
-test_setsockopt_impl(char *file, int line, int sock, int level, int option,
-    const void *optval, size_t optlen)
-{
-	int rc;
-
-	rc = nn_setsockopt(sock, level, option, optval, optlen);
-	if (rc < 0) {
-		fprintf(stderr, "Failed set option \"%d\": %s [%d] (%s:%d)\n",
-		    option, nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-	return rc;
-}
-
-static void
-test_close_impl(char *file, int line, int sock)
-{
-	int rc;
-
-	rc = nn_close(sock);
-	if ((rc != 0) && (errno != EBADF && errno != ETERM)) {
-		fprintf(stderr, "Failed to close socket: %s [%d] (%s:%d)\n",
-		    nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-}
-
-static void
-test_send_impl(char *file, int line, int sock, char *data)
-{
-	size_t data_len;
-	int    rc;
-
-	data_len = strlen(data);
-
-	rc = nn_send(sock, data, data_len, 0);
-	if (rc < 0) {
-		fprintf(stderr, "Failed to send: %s [%d] (%s:%d)\n",
-		    nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-	if (rc != (int) data_len) {
-		fprintf(stderr,
-		    "Data to send is truncated: %d != %d (%s:%d)\n", rc,
-		    (int) data_len, file, line);
-		nn_err_abort();
-	}
-}
-
-static void
-test_recv_impl(char *file, int line, int sock, char *data)
-{
-	size_t data_len;
-	int    rc;
-	char * buf;
-
-	data_len = strlen(data);
-	/*  We allocate plus one byte so that we are sure that message received
-	    has correct length and not truncated  */
-	buf = malloc(data_len + 1);
-	alloc_assert(buf);
-
-	rc = nn_recv(sock, buf, data_len + 1, 0);
-	if (rc < 0) {
-		fprintf(stderr, "Failed to recv: %s [%d] (%s:%d)\n",
-		    nn_err_strerror(errno), (int) errno, file, line);
-		nn_err_abort();
-	}
-	if (rc != (int) data_len) {
-		fprintf(stderr,
-		    "Received data has wrong length: %d != %d (%s:%d)\n", rc,
-		    (int) data_len, file, line);
-		nn_err_abort();
-	}
-	if (memcmp(data, buf, data_len) != 0) {
-		/*  We don't print the data as it may have binary garbage  */
-		fprintf(
-		    stderr, "Received data is wrong (%s:%d)\n", file, line);
-		nn_err_abort();
-	}
-
-	free(buf);
-}
-
-static void
-test_drop_impl(char *file, int line, int sock, int err)
-{
-	int  rc;
-	char buf[1024];
-
-	rc = nn_recv(sock, buf, sizeof(buf), 0);
-	if (rc < 0 && err != errno) {
-		fprintf(stderr,
-		    "Got wrong err to recv: %s [%d != %d] (%s:%d)\n",
-		    nn_err_strerror(errno), (int) errno, err, file, line);
-		nn_err_abort();
-	} else if (rc >= 0) {
-		fprintf(stderr, "Did not drop message: [%d bytes] (%s:%d)\n",
-		    rc, file, line);
-		nn_err_abort();
-	}
-}
-
-static int
-get_test_port(int argc, const char *argv[])
-{
-	return atoi(argc < 2 ? "5555" : argv[1]);
-}
-
-static void
-test_addr_from(char *out, const char *proto, const char *ip, int port)
-{
-	sprintf(out, "%s://%s:%d", proto, ip, port);
-}
-
-void
-nn_sleep(int32_t msec)
-{
-	void nng_msleep(int32_t);
-	nng_msleep(msec);
-}
-
 struct nn_thread {
 	void *thr;
 };
 
-int
-nn_thread_init(struct nn_thread *thr, void (*func)(void *), void *arg)
-{
-	int nng_thread_create(void **, void (*)(void *), void *);
-	return (nng_thread_create(&thr->thr, func, arg));
-}
-
-void
-nn_thread_term(struct nn_thread *thr)
-{
-	void nng_thread_destroy(void *);
-	nng_thread_destroy(thr->thr);
-}
+extern int nn_thread_init(struct nn_thread *, void (*)(void *), void *);
+extern void nn_thread_term(struct nn_thread *);
 
 #endif // TESTUTIL_H_INCLUDED

--- a/tests/convey.c
+++ b/tests/convey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Garrett D'Amore <garrett@damore.org>
+ * Copyright 2018 Garrett D'Amore <garrett@damore.org>
  *
  * This software is supplied under the terms of the MIT License, a
  * copy of which should be located in the distribution where this
@@ -96,7 +96,6 @@ static HANDLE convey_console;
 #endif
 
 #define CONVEY_EXIT_OK 0
-#define CONVEY_EXIT_USAGE 1
 #define CONVEY_EXIT_FAIL 2
 #define CONVEY_EXIT_FATAL 3
 #define CONVEY_EXIT_NOMEM 4
@@ -507,19 +506,18 @@ convey_start_timer(struct convey_timer *pc)
 	pc->timer_base = pcnt.QuadPart;
 	pc->timer_rate = pfreq.QuadPart;
 #elif defined(CLOCK_MONOTONIC) && !defined(CONVEY_USE_GETTIMEOFDAY)
-	uint64_t        usecs;
 	struct timespec ts;
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);
-	pc->timer_base = ts.tv_sec * 1000000000;
-	pc->timer_base += ts.tv_nsec;
+	pc->timer_base = (uint64_t) ts.tv_sec * 1000000000;
+	pc->timer_base += (uint64_t) ts.tv_nsec;
 	pc->timer_rate = 1000000000;
 #else
 	struct timeval tv;
 
 	gettimeofday(&tv, NULL);
-	pc->timer_base = tv.tv_sec * 1000000;
-	pc->timer_base += tv.tv_usec;
+	pc->timer_base = (uint64_t) tv.tv_sec * 1000000;
+	pc->timer_base += (uint64_t) tv.tv_usec;
 	pc->timer_rate = 1000000;
 #endif
 	pc->timer_running = 1;
@@ -542,7 +540,7 @@ convey_stop_timer(struct convey_timer *pc)
 
 		clock_gettime(CLOCK_MONOTONIC, &ts);
 		ns = (ts.tv_sec * 1000000000);
-		ns += ts.tv_nsec;
+		ns += (uint64_t) ts.tv_nsec;
 		pc->timer_count += (ns - pc->timer_base);
 #else
 		uint64_t       us;
@@ -639,7 +637,7 @@ convey_tls_get(void)
 
 #else
 
-pthread_key_t convey_tls_key;
+static pthread_key_t convey_tls_key;
 
 static int
 convey_tls_init(void)
@@ -851,8 +849,6 @@ conveyPrintf(const char *file, int line, const char *fmt, ...)
 	va_end(ap);
 }
 
-extern int conveyMainImpl(void);
-
 static void
 convey_init_term(void)
 {
@@ -885,9 +881,9 @@ convey_init_term(void)
 		// Values probably don't matter, just need to be
 		// different!
 		convey_nocolor = "\033[0m";
-		convey_green   = "\033[32m";
-		convey_yellow  = "\033[33m";
-		convey_red     = "\033[31m";
+		convey_green = "\033[32m";
+		convey_yellow = "\033[33m";
+		convey_red = "\033[31m";
 	}
 	term = getenv("TERM");
 #endif

--- a/tests/convey.h
+++ b/tests/convey.h
@@ -71,8 +71,8 @@
  * framework creates a context automatically for each convey scope.
  */
 typedef struct {
-	jmp_buf cs_jmp;
 	void *  cs_data;
+	jmp_buf cs_jmp;
 } conveyScope;
 
 /* These functions are not for use by tests -- they are used internally. */
@@ -90,6 +90,7 @@ extern void conveySkip(const char *, int, const char *, ...);
 extern void conveyFail(const char *, int, const char *, ...);
 extern void conveyError(const char *, int, const char *, ...);
 extern void conveyPrintf(const char *, int, const char *, ...);
+extern int  conveyMainImpl(void);
 
 /*
  * conveyRun is a helper macro not to be called directly by user

--- a/tests/convey_test.c
+++ b/tests/convey_test.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Garrett D'Amore <garrett@damore.org>
+ * Copyright 2018 Garrett D'Amore <garrett@damore.org>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"),
@@ -84,7 +84,9 @@ Main({
 	Test("Skipping works", {
 		int skipped = 0;
 		SkipConvey("ConveySkip works.", { So(skipped = 0); });
+		So(skipped == 0);
 		Convey("Assertion skipping works.", { SkipSo(skipped == 1); });
+		So(skipped == 0);
 	});
 
 	Test("Reset", {

--- a/tests/cplusplus_pair.cc
+++ b/tests/cplusplus_pair.cc
@@ -26,6 +26,8 @@ main(int argc, char **argv)
 	int        rv;
 	size_t     sz;
 	char       buf[8];
+	(void) argc;
+	(void) argv;
 
 	if ((rv = nng_pair1_open(&s1)) != 0) {
 		throw nng_strerror(rv);
@@ -68,6 +70,8 @@ main(int argc, char **argv)
 
 	std::cout << "Pass." << std::endl;
 #else
+	(void) argc;
+	(void) argv;
 	std::cout << "Skipped (protocol unconfigured)." << std::endl;
 #endif
 

--- a/tests/files.c
+++ b/tests/files.c
@@ -181,9 +181,10 @@ TestMain("Platform File Support", {
 		});
 
 		Convey("Directory walk works", {
-			struct walkarg wa = { 0 };
+			struct walkarg wa;
 			int            rv;
 
+			memset(&wa, 0, sizeof(wa));
 			rv = nni_file_walk(mydir, walker, &wa, 0);
 			So(rv == 0);
 			So(wa.a == 1);

--- a/tests/httpserver.c
+++ b/tests/httpserver.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Garrett D'Amore <garrett@damore.org>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -247,7 +247,7 @@ TestMain("HTTP Server", {
 				ptr = nng_http_res_get_header(
 				    res, "Content-Length");
 				So(ptr != NULL);
-				So(atoi(ptr) == strlen(doc1));
+				So(atoi(ptr) == (int) strlen(doc1));
 
 				iov.iov_len = strlen(doc1);
 				iov.iov_buf = chunk;

--- a/tests/idhash.c
+++ b/tests/idhash.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -145,13 +145,12 @@ Main({
 			nni_idhash *h;
 			int         expect[5];
 			uint64_t    id;
-			int         i;
 			So(nni_idhash_init(&h) == 0);
 			Reset({ nni_idhash_fini(h); });
 			nni_idhash_set_limits(h, 10, 13, 10);
 			So(1);
 			Convey("We can fill the table", {
-				for (i = 0; i < 4; i++) {
+				for (uint64_t i = 0; i < 4; i++) {
 					So(nni_idhash_alloc(
 					       h, &id, &expect[i]) == 0);
 					So(id == (i + 10));

--- a/tests/scalability.c
+++ b/tests/scalability.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -27,6 +27,7 @@ void
 serve(void *arg)
 {
 	nng_msg *msg;
+	(void) arg; // unused
 
 	for (;;) {
 		msg = NULL;

--- a/tests/sock.c
+++ b/tests/sock.c
@@ -75,8 +75,6 @@ TestMain("Socket Operations", {
 
 		Convey("We can set and get options", {
 			nng_duration to = 1234;
-			int64_t      v  = 0;
-			size_t       sz;
 
 			So(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, to) == 0);
 
@@ -99,7 +97,7 @@ TestMain("Socket Operations", {
 				       s1, NNG_OPT_SOCKNAME, name, &sz) == 0);
 				So(sz > 0 && sz < 64);
 				So(sz == nni_strnlen(name, 64) + 1);
-				So(atoi(name) == (unsigned) s1);
+				So(atoi(name) == (int) s1);
 
 				So(nng_setopt(
 				       s1, NNG_OPT_SOCKNAME, "hello", 6) == 0);
@@ -164,6 +162,8 @@ TestMain("Socket Operations", {
 			Convey("We can apply options before endpoint", {
 				nng_listener l;
 				char         addr[NNG_MAXADDRLEN];
+				size_t       sz;
+
 				trantest_next_address(
 				    addr, "ipc:///tmp/lopt_%u");
 
@@ -194,8 +194,8 @@ TestMain("Socket Operations", {
 				});
 			});
 			Convey("Short size is not copied", {
-				sz = 0;
-				to = 0;
+				size_t sz = 0;
+				to        = 0;
 				So(nng_getopt(
 				       s1, NNG_OPT_SENDTIMEO, &to, &sz) == 0);
 				So(sz == sizeof(to));
@@ -212,7 +212,7 @@ TestMain("Socket Operations", {
 			});
 
 			Convey("Correct size is copied", {
-				sz = sizeof(to);
+				size_t sz = sizeof(to);
 				So(nng_getopt(
 				       s1, NNG_OPT_SENDTIMEO, &to, &sz) == 0);
 				So(sz == sizeof(to));
@@ -220,8 +220,8 @@ TestMain("Socket Operations", {
 			});
 
 			Convey("Short size buf is not copied", {
-				int l = 5;
-				sz    = 0;
+				int    l  = 5;
+				size_t sz = 0;
 				So(nng_getopt(s1, NNG_OPT_RECVBUF, &l, &sz) ==
 				    0);
 				So(sz == sizeof(l));
@@ -241,8 +241,8 @@ TestMain("Socket Operations", {
 			});
 
 			Convey("Short timeout fails", {
-				to = 0;
-				sz = sizeof(to) - 1;
+				size_t sz = sizeof(to) - 1;
+				to        = 0;
 				So(nng_setopt(s1, NNG_OPT_RECVTIMEO, &to,
 				       sz) == NNG_EINVAL);
 				So(nng_setopt(s1, NNG_OPT_RECONNMINT, &to,

--- a/tests/stubs.h
+++ b/tests/stubs.h
@@ -1,5 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -40,13 +41,15 @@ getms(void)
 		return (0);
 	}
 	tv.tv_sec -= epoch;
-	return (((uint64_t)(tv.tv_sec) * 1000) + (tv.tv_usec / 1000));
+	return (
+	    ((uint64_t)(tv.tv_sec) * 1000) + (uint64_t)(tv.tv_usec / 1000));
 #endif
 }
 
 int
 nosocket(nng_socket *s)
 {
+	(void) s; // not used
 	ConveySkip("Protocol unconfigured");
 	return (NNG_ENOTSUP);
 }

--- a/tests/synch.c
+++ b/tests/synch.c
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -158,7 +158,6 @@ test_sync_fallback(void)
 	nni_plat_sync_fallback = 1;
 	Convey("Mutexes work", {
 		nni_mtx mx;
-		int     rv;
 
 		nni_mtx_init(&mx);
 

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -21,7 +21,7 @@
 #endif
 
 static int
-check_props_v4(nng_msg *msg, nng_listener l, nng_dialer d)
+check_props_v4(nng_msg *msg)
 {
 	nng_pipe     p;
 	size_t       z;

--- a/tests/tcp6.c
+++ b/tests/tcp6.c
@@ -37,7 +37,7 @@ has_v6(void)
 }
 
 static int
-check_props_v6(nng_msg *msg, nng_listener l, nng_dialer d)
+check_props_v6(nng_msg *msg)
 {
 	nng_pipe p;
 	size_t   z;
@@ -68,8 +68,6 @@ check_props_v6(nng_msg *msg, nng_listener l, nng_dialer d)
 		So(ra.s_un.s_family == NNG_AF_INET6);
 		So(ra.s_un.s_in6.sa_port != 0);
 		So(memcmp(ra.s_un.s_in6.sa_addr, loopback, 16) == 0);
-
-		So(nng_dialer_getopt(d, NNG_OPT_REMADDR, &ra, &z) != 0);
 	});
 
 	Convey("Malformed TCPv6 addresses do not panic", {

--- a/tests/tls.c
+++ b/tests/tls.c
@@ -103,7 +103,7 @@ static const char key[] =
     "-----END RSA PRIVATE KEY-----\n";
 
 static int
-check_props_v4(nng_msg *msg, nng_listener l, nng_dialer d)
+check_props_v4(nng_msg *msg)
 {
 	nng_pipe p;
 	size_t   z;
@@ -132,7 +132,7 @@ check_props_v4(nng_msg *msg, nng_listener l, nng_dialer d)
 }
 
 static int
-init_dialer_tls(trantest *tt, nng_dialer d)
+init_dialer_tls(nng_dialer d)
 {
 	nng_tls_config *cfg;
 	int             rv;
@@ -157,7 +157,7 @@ out:
 }
 
 static int
-init_listener_tls(trantest *tt, nng_listener l)
+init_listener_tls(nng_listener l)
 {
 	nng_tls_config *cfg;
 	int             rv;
@@ -177,7 +177,7 @@ out:
 }
 
 static int
-init_dialer_tls_file(trantest *tt, nng_dialer d)
+init_dialer_tls_file(nng_dialer d)
 {
 	int   rv;
 	char *tmpdir;
@@ -205,7 +205,7 @@ init_dialer_tls_file(trantest *tt, nng_dialer d)
 }
 
 static int
-init_listener_tls_file(trantest *tt, nng_listener l)
+init_listener_tls_file(nng_listener l)
 {
 	int   rv;
 	char *tmpdir;
@@ -368,7 +368,7 @@ TestMain("TLS Transport", {
 		});
 		trantest_next_address(addr, "tls+tcp://*:%u");
 		So(nng_listener_create(&l, s1, addr) == 0);
-		So(init_listener_tls_file(NULL, l) == 0);
+		So(init_listener_tls_file(l) == 0);
 		So(nng_listener_start(l, 0) == 0);
 		nng_msleep(100);
 
@@ -376,7 +376,7 @@ TestMain("TLS Transport", {
 		trantest_prev_address(addr, "tls+tcp://127.0.0.1:%u");
 		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
 		So(nng_dialer_create(&d, s2, addr) == 0);
-		So(init_dialer_tls_file(NULL, d) == 0);
+		So(init_dialer_tls_file(d) == 0);
 		So(nng_dialer_setopt_int(d, NNG_OPT_TLS_AUTH_MODE,
 		       NNG_TLS_AUTH_MODE_OPTIONAL) == 0);
 		So(nng_dialer_setopt_string(
@@ -413,14 +413,14 @@ TestMain("TLS Transport", {
 		});
 		trantest_next_address(addr, "tls+tcp://*:%u");
 		So(nng_listener_create(&l, s1, addr) == 0);
-		So(init_listener_tls_file(NULL, l) == 0);
+		So(init_listener_tls_file(l) == 0);
 		So(nng_listener_start(l, 0) == 0);
 		nng_msleep(100);
 
 		// reset port back one
 		trantest_prev_address(addr, "tls+tcp://localhost:%u");
 		So(nng_dialer_create(&d, s2, addr) == 0);
-		So(init_dialer_tls_file(NULL, d) == 0);
+		So(init_dialer_tls_file(d) == 0);
 		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
 		So(nng_dialer_start(d, 0) == 0);
 		nng_msleep(100);

--- a/tests/ws.c
+++ b/tests/ws.c
@@ -22,7 +22,7 @@
 #endif
 
 static int
-check_props_v4(nng_msg *msg, nng_listener l, nng_dialer d)
+check_props_v4(nng_msg *msg)
 {
 	nng_pipe     p;
 	size_t       z;

--- a/tests/wss.c
+++ b/tests/wss.c
@@ -130,7 +130,7 @@ validloopback(nng_sockaddr *sa)
 }
 
 static int
-check_props(nng_msg *msg, nng_listener l, nng_dialer d)
+check_props(nng_msg *msg)
 {
 	nng_pipe     p;
 	size_t       z;
@@ -180,7 +180,7 @@ check_props(nng_msg *msg, nng_listener l, nng_dialer d)
 }
 
 static int
-init_dialer_wss(trantest *tt, nng_dialer d)
+init_dialer_wss(nng_dialer d)
 {
 	nng_tls_config *cfg;
 	int             rv;
@@ -206,7 +206,7 @@ out:
 }
 
 static int
-init_listener_wss(trantest *tt, nng_listener l)
+init_listener_wss(nng_listener l)
 {
 	nng_tls_config *cfg;
 	int             rv;

--- a/tests/wssfile.c
+++ b/tests/wssfile.c
@@ -130,7 +130,7 @@ validloopback(nng_sockaddr *sa)
 }
 
 static int
-check_props(nng_msg *msg, nng_listener l, nng_dialer d)
+check_props(nng_msg *msg)
 {
 	nng_pipe     p;
 	size_t       z;
@@ -138,7 +138,6 @@ check_props(nng_msg *msg, nng_listener l, nng_dialer d)
 	nng_sockaddr ra;
 	char *       buf;
 	size_t       len;
-	int          v;
 
 	p = nng_msg_get_pipe(msg);
 	So(p > 0);
@@ -181,7 +180,7 @@ check_props(nng_msg *msg, nng_listener l, nng_dialer d)
 }
 
 static int
-init_dialer_wss_file(trantest *tt, nng_dialer d)
+init_dialer_wss_file(nng_dialer d)
 {
 	int   rv;
 	char *tmpdir;
@@ -209,7 +208,7 @@ init_dialer_wss_file(trantest *tt, nng_dialer d)
 }
 
 static int
-init_listener_wss_file(trantest *tt, nng_listener l)
+init_listener_wss_file(nng_listener l)
 {
 	int   rv;
 	char *tmpdir;
@@ -267,8 +266,6 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 		nng_socket   s1;
 		nng_socket   s2;
 		nng_listener l;
-		char *       buf;
-		size_t       sz;
 		char         addr[NNG_MAXADDRLEN];
 
 		So(nng_pair_open(&s1) == 0);
@@ -279,7 +276,7 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 		});
 		trantest_next_address(addr, "wss://:%u/test");
 		So(nng_listener_create(&l, s1, addr) == 0);
-		So(init_listener_wss_file(NULL, l) == 0);
+		So(init_listener_wss_file(l) == 0);
 		So(nng_listener_start(l, 0) == 0);
 		nng_msleep(100);
 
@@ -309,7 +306,7 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 		});
 		trantest_next_address(addr, "wss://:%u/test");
 		So(nng_listener_create(&l, s1, addr) == 0);
-		So(init_listener_wss_file(NULL, l) == 0);
+		So(init_listener_wss_file(l) == 0);
 		So(nng_listener_start(l, 0) == 0);
 		nng_msleep(100);
 
@@ -317,7 +314,7 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 		trantest_prev_address(addr, "wss://127.0.0.1:%u/test");
 		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
 		So(nng_dialer_create(&d, s2, addr) == 0);
-		So(init_dialer_wss_file(NULL, d) == 0);
+		So(init_dialer_wss_file(d) == 0);
 		So(nng_dialer_setopt_int(d, NNG_OPT_TLS_AUTH_MODE,
 		       NNG_TLS_AUTH_MODE_OPTIONAL) == 0);
 		So(nng_dialer_setopt_string(
@@ -361,14 +358,14 @@ TestMain("WebSocket Secure (TLS) Transport (file based)", {
 		});
 		trantest_next_address(addr, "wss://:%u/test");
 		So(nng_listener_create(&l, s1, addr) == 0);
-		So(init_listener_wss_file(NULL, l) == 0);
+		So(init_listener_wss_file(l) == 0);
 		So(nng_listener_start(l, 0) == 0);
 		nng_msleep(100);
 
 		// reset port back one
 		trantest_prev_address(addr, "wss://localhost:%u/test");
 		So(nng_dialer_create(&d, s2, addr) == 0);
-		So(init_dialer_wss_file(NULL, d) == 0);
+		So(init_dialer_wss_file(d) == 0);
 		So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, 200) == 0);
 		So(nng_dialer_start(d, 0) == 0);
 		nng_msleep(100);


### PR DESCRIPTION
We enabled verbose compiler warnings, and found a lot of issues.
Some of these were even real bugs.  As a bonus, we actually save
some initialization steps in the compat layer, and avoid passing
some variables we don't need.