### PR TITLE
Simply posix pollq architecture somewhat.

### DIFF
--- a/src/platform/posix/posix_pipedesc.c
+++ b/src/platform/posix/posix_pipedesc.c
@@ -358,8 +358,8 @@ nni_posix_pipedesc_init(nni_posix_pipedesc **pdp, int fd)
 	nni_aio_list_init(&pd->readq);
 	nni_aio_list_init(&pd->writeq);
 
-	rv = nni_posix_pollq_add(nni_posix_pollq_get(fd), &pd->node);
-	if (rv != 0) {
+	if (((rv = nni_posix_pollq_init(&pd->node)) != 0) ||
+	    ((rv = nni_posix_pollq_add(&pd->node)) != 0)) {
 		nni_mtx_fini(&pd->mtx);
 		NNI_FREE_STRUCT(pd);
 		return (rv);
@@ -373,7 +373,7 @@ nni_posix_pipedesc_fini(nni_posix_pipedesc *pd)
 {
 	// Make sure no other polling activity is pending.
 	nni_posix_pipedesc_close(pd);
-	nni_posix_pollq_remove(&pd->node);
+	nni_posix_pollq_fini(&pd->node);
 	if (pd->node.fd >= 0) {
 		(void) close(pd->node.fd);
 	}

--- a/src/platform/posix/posix_pollq.h
+++ b/src/platform/posix/posix_pollq.h
@@ -41,7 +41,9 @@ extern nni_posix_pollq *nni_posix_pollq_get(int);
 extern int              nni_posix_pollq_sysinit(void);
 extern void             nni_posix_pollq_sysfini(void);
 
-extern int  nni_posix_pollq_add(nni_posix_pollq *, nni_posix_pollq_node *);
+extern int  nni_posix_pollq_init(nni_posix_pollq_node *);
+extern void nni_posix_pollq_fini(nni_posix_pollq_node *);
+extern int  nni_posix_pollq_add(nni_posix_pollq_node *);
 extern void nni_posix_pollq_remove(nni_posix_pollq_node *);
 extern void nni_posix_pollq_arm(nni_posix_pollq_node *, int);
 extern void nni_posix_pollq_disarm(nni_posix_pollq_node *, int);

--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -244,9 +244,8 @@ nni_plat_udp_open(nni_plat_udp **upp, nni_sockaddr *bindaddr)
 	nni_aio_list_init(&udp->udp_recvq);
 	nni_aio_list_init(&udp->udp_sendq);
 
-	rv = nni_posix_pollq_add(
-	    nni_posix_pollq_get(udp->udp_fd), &udp->udp_pitem);
-	if (rv != 0) {
+	if (((rv = nni_posix_pollq_init(&udp->udp_pitem)) != 0) ||
+	    ((rv = nni_posix_pollq_add(&udp->udp_pitem)) != 0)) {
 		(void) close(udp->udp_fd);
 		nni_mtx_fini(&udp->udp_mtx);
 		NNI_FREE_STRUCT(udp);
@@ -261,7 +260,7 @@ void
 nni_plat_udp_close(nni_plat_udp *udp)
 {
 	// We're no longer interested in events.
-	nni_posix_pollq_remove(&udp->udp_pitem);
+	nni_posix_pollq_fini(&udp->udp_pitem);
 
 	nni_mtx_lock(&udp->udp_mtx);
 	nni_posix_udp_doclose(udp);


### PR DESCRIPTION
This change is being made to facilitate the work done for the
kqueue port.  We have created two new functions, nni_posix_pollq_init
and nni_posix_pollq_fini, which can be used when creating or destroying
the pollq nodes.  Then nodes are *added* and *removed* from the pollq
structure with nni_posix_pollq_add and nni_posix_pollq_remove.  The
add function in particular MUST NEVER be called unless the node has
a valid file descriptor.