### PR TITLE
Fixes for POSIX pollq structure.

### DIFF
--- a/src/platform/posix/posix_pollq_poll.c
+++ b/src/platform/posix/posix_pollq_poll.c
@@ -283,9 +283,7 @@ nni_posix_pollq_arm(nni_posix_pollq_node *node, int events)
 	nni_posix_pollq *pq = node->pq;
 	int              oevents;
 
-	if (pq == NULL) {
-		return;
-	}
+	NNI_ASSERT(pq != NULL);
 
 	nni_mtx_lock(&pq->mtx);
 	oevents = node->events;


### PR DESCRIPTION
It was possible for pollq arm to be called on a node that was removed
in some circumstances -- particularly and ep that was closed in the
callback.

While here, lets use normal booleans for closed state, and only call
the arm function (which is not free -- typicall it involves a mutex
and may even involve a system call) if we are going to arm some events.

We also initialize these things properly, and clean up a stale comment.

This work is done to faciliate the kqueue work by @liamstask.