### PR TITLE
fixes #262 NNG_OPT_URL should be resolved

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include (CheckLibraryExists)
 include (CheckCSourceCompiles)
 include (CMakeDependentOption)
 include (GNUInstallDirs)
+include (TestBigEndian)
 
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
@@ -263,6 +264,14 @@ endif()
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NNG_WARN_FLAGS} ${NNG_COVERAGE_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${NNG_WARN_FLAGS} ${NNG_COVERAGE_FLAGS}")
+
+TEST_BIG_ENDIAN(NNG_BIG_ENDIAN)
+if (NNG_BIG_ENDIAN)
+    add_definitions (-DNNG_BIG_ENDIAN)
+else()
+    add_definitions (-DNNG_LITTLE_ENDIAN)
+endif()
+
 
 find_package (Threads REQUIRED)
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -111,8 +111,8 @@ typedef struct {
 	} while (0)
 
 #define NNI_GET16(ptr, v)                            \
-	v = (((uint32_t)((uint8_t)(ptr)[0])) << 8) + \
-	    (((uint32_t)(uint8_t)(ptr)[1]))
+	v = (((uint16_t)((uint8_t)(ptr)[0])) << 8) + \
+	    (((uint16_t)(uint8_t)(ptr)[1]))
 
 #define NNI_GET32(ptr, v)                             \
 	v = (((uint32_t)((uint8_t)(ptr)[0])) << 24) + \

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -618,10 +618,6 @@ nni_ep_getopt(nni_ep *ep, const char *name, void *valp, size_t *szp)
 {
 	nni_tran_ep_option *eo;
 
-	if (strcmp(name, NNG_OPT_URL) == 0) {
-		return (nni_getopt_str(ep->ep_url->u_rawurl, valp, szp));
-	}
-
 	for (eo = ep->ep_ops.ep_options; eo && eo->eo_name; eo++) {
 		int rv;
 		if (strcmp(eo->eo_name, name) != 0) {
@@ -634,6 +630,13 @@ nni_ep_getopt(nni_ep *ep, const char *name, void *valp, size_t *szp)
 		rv = eo->eo_getopt(ep->ep_data, valp, szp);
 		nni_mtx_unlock(&ep->ep_mtx);
 		return (rv);
+	}
+
+	// We provide a fallback on the URL, but let the implementation
+	// override.  This allows the URL to be created with wildcards,
+	// that are resolved later.
+	if (strcmp(name, NNG_OPT_URL) == 0) {
+		return (nni_getopt_str(ep->ep_url->u_rawurl, valp, szp));
 	}
 
 	return (nni_sock_getopt(ep->ep_sock, name, valp, szp));

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -207,7 +207,7 @@ extern void nni_plat_tcp_ep_close(nni_plat_tcp_ep *);
 
 // nni_plat_tcp_listen creates an TCP socket in listening mode, bound
 // to the specified path.
-extern int nni_plat_tcp_ep_listen(nni_plat_tcp_ep *);
+extern int nni_plat_tcp_ep_listen(nni_plat_tcp_ep *, nni_sockaddr *);
 
 // nni_plat_tcp_ep_accept starts an accept to receive an incoming connection.
 // An accepted connection will be passed back in the a_pipe member.
@@ -247,6 +247,12 @@ extern int nni_plat_tcp_pipe_peername(nni_plat_tcp_pipe *, nni_sockaddr *);
 
 // nni_plat_tcp_pipe_sockname gets the local name.
 extern int nni_plat_tcp_pipe_sockname(nni_plat_tcp_pipe *, nni_sockaddr *);
+
+// nni_plat_tcp_ntop obtains the IP address for the socket (enclosing it
+// in brackets if it is IPv6) and port.  Enough space for both must
+// be present (48 bytes and 6 bytes each), although if either is NULL then
+// those components are skipped.
+extern int nni_plat_tcp_ntop(const nni_sockaddr *, char *, char *);
 
 // nni_plat_tcp_resolv resolves a TCP name asynchronously.  The family
 // should be one of NNG_AF_INET, NNG_AF_INET6, or NNG_AF_UNSPEC.  The

--- a/src/platform/posix/posix_aio.h
+++ b/src/platform/posix/posix_aio.h
@@ -40,5 +40,6 @@ extern void nni_posix_epdesc_close(nni_posix_epdesc *);
 extern void nni_posix_epdesc_connect(nni_posix_epdesc *, nni_aio *);
 extern int  nni_posix_epdesc_listen(nni_posix_epdesc *);
 extern void nni_posix_epdesc_accept(nni_posix_epdesc *, nni_aio *);
+extern int  nni_posix_epdesc_sockname(nni_posix_epdesc *, nni_sockaddr *);
 
 #endif // PLATFORM_POSIX_AIO_H

--- a/src/platform/posix/posix_epdesc.c
+++ b/src/platform/posix/posix_epdesc.c
@@ -343,6 +343,18 @@ nni_posix_epdesc_accept(nni_posix_epdesc *ed, nni_aio *aio)
 	nni_mtx_unlock(&ed->mtx);
 }
 
+int
+nni_posix_epdesc_sockname(nni_posix_epdesc *ed, nni_sockaddr *sa)
+{
+	struct sockaddr_storage ss;
+	socklen_t               sslen = sizeof(ss);
+
+	if (getsockname(ed->node.fd, (void *) &ss, &sslen) != 0) {
+		return (nni_plat_errno(errno));
+	}
+	return (nni_posix_sockaddr2nn(sa, &ss));
+}
+
 void
 nni_posix_epdesc_connect(nni_posix_epdesc *ed, nni_aio *aio)
 {

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -895,7 +895,7 @@ http_server_start(nni_http_server *s)
 	if (rv != 0) {
 		return (rv);
 	}
-	if ((rv = nni_plat_tcp_ep_listen(s->tep)) != 0) {
+	if ((rv = nni_plat_tcp_ep_listen(s->tep, NULL)) != 0) {
 		nni_plat_tcp_ep_fini(s->tep);
 		s->tep = NULL;
 		return (rv);

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -80,6 +80,25 @@ TestMain("TCP Transport", {
 		So(nng_dial(s2, addr, NULL, 0) == 0);
 	});
 
+	Convey("We can bind to port zero", {
+		nng_socket   s1;
+		nng_socket   s2;
+		nng_listener l;
+		char         addr[NNG_MAXADDRLEN];
+		size_t       sz;
+
+		So(nng_pair_open(&s1) == 0);
+		So(nng_pair_open(&s2) == 0);
+		Reset({
+			nng_close(s2);
+			nng_close(s1);
+		});
+		So(nng_listen(s1, "tcp://127.0.0.1:0", &l, 0) == 0);
+		sz = NNG_MAXADDRLEN;
+		So(nng_listener_getopt(l, NNG_OPT_URL, addr, &sz) == 0);
+		So(nng_dial(s2, addr, NULL, 0) == 0);
+	});
+
 	Convey("Malformed TCP addresses do not panic", {
 		nng_socket s1;
 

--- a/tests/tls.c
+++ b/tests/tls.c
@@ -9,7 +9,9 @@
 //
 
 #include "convey.h"
+
 #include "nng.h"
+
 #include "protocol/pair1/pair.h"
 #include "supplemental/tls/tls.h"
 #include "transport/tls/tls.h"
@@ -290,6 +292,26 @@ TestMain("TLS Transport", {
 		So(nng_listen(s1, addr, NULL, 0) == 0);
 		// reset port back one
 		trantest_prev_address(addr, "tls+tcp://127.0.0.1:%u");
+		So(nng_dial(s2, addr, NULL, 0) == 0);
+	});
+
+	Convey("We can bind to port zero", {
+		nng_socket   s1;
+		nng_socket   s2;
+		nng_listener l;
+		char         addr[NNG_MAXADDRLEN];
+		size_t       sz;
+
+		So(nng_tls_register() == 0);
+		So(nng_pair_open(&s1) == 0);
+		So(nng_pair_open(&s2) == 0);
+		Reset({
+			nng_close(s2);
+			nng_close(s1);
+		});
+		So(nng_listen(s1, "tls+tcp://127.0.0.1:0", &l, 0) == 0);
+		sz = NNG_MAXADDRLEN;
+		So(nng_listener_getopt(l, NNG_OPT_URL, addr, &sz) == 0);
 		So(nng_dial(s2, addr, NULL, 0) == 0);
 	});
 

--- a/tests/zt.c
+++ b/tests/zt.c
@@ -285,6 +285,20 @@ TestMain("ZeroTier Transport", {
 		nng_msleep(2000); // to give dialer time to start up
 	});
 
-	trantest_test_extended("zt://*." NWID ":%u", check_props);
+	// We need to determine our ephemeral ID:
+
+	nng_socket   s_test;
+	nng_listener l_test;
+	uint64_t     node;
+	char         fmt[128];
+
+	So(nng_pair_open(&s_test) == 0);
+	So(nng_listener_create(&l_test, s_test, "zt://*." NWID ":0") == 0);
+	So(nng_listener_start(l_test, 0) == 0);
+	So(nng_listener_getopt_uint64(l_test, NNG_OPT_ZT_NODE, &node) == 0);
+	snprintf(fmt, sizeof(fmt), "zt://%llx." NWID ":%%u", node);
+	nng_listener_close(l_test);
+
+	trantest_test_extended(fmt, check_props);
 
 })

--- a/tools/nngcat/nngcat.c
+++ b/tools/nngcat/nngcat.c
@@ -1008,6 +1008,15 @@ main(int ac, const char **av)
 			}
 			rv  = nng_dialer_start(d, async);
 			act = "dial";
+			if ((rv == 0) && (verbose == OPT_VERBOSE)) {
+				char   ustr[256];
+				size_t sz;
+				sz = sizeof(ustr);
+				if (nng_dialer_getopt(
+				        d, NNG_OPT_URL, ustr, &sz) == 0) {
+					printf("Connected to: %s\n", ustr);
+				}
+			}
 			break;
 		case OPT_LISTEN:
 		case OPT_LISTEN_IPC:
@@ -1027,6 +1036,15 @@ main(int ac, const char **av)
 			}
 			rv  = nng_listener_start(l, async);
 			act = "listen";
+			if ((rv == 0) && (verbose == OPT_VERBOSE)) {
+				char   ustr[256];
+				size_t sz;
+				sz = sizeof(ustr);
+				if (nng_listener_getopt(
+				        l, NNG_OPT_URL, ustr, &sz) == 0) {
+					printf("Listening at: %s\n", ustr);
+				}
+			}
 			break;
 		default:
 			fatal("Invalid address mode! (Bug!)");


### PR DESCRIPTION
This causes TCP, TLS, and ZT endpoints to resolve any
wildcards, and even IP addresses, when reporting the listen
URL.  The dialer URL is reported unresolved.  Test cases
for this are added as well, and nngcat actually reports this
if --verbose is supplied.

