### PR TITLE
ci: dump failure details on test failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
       - run:
           name: Run Tests
           command: cd build && ninja test
+          environment:
+            CTEST_OUTPUT_ON_FAILURE: 1
 
 #      - run:
 #          name: Check Format

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
   - cd build
   - cmake -G Ninja -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DNNG_ENABLE_COVERAGE=${COVERAGE:-OFF} ..
   - ninja
-  - ninja test
+  - env CTEST_OUTPUT_ON_FAILURE=1 ninja test
   - env CLANG_FORMAT=${CLANG_FORMAT:-no} ../etc/format-check.sh
 
 after_success:


### PR DESCRIPTION
the [failed ci run](https://travis-ci.org/nanomsg/nng/jobs/349661097) for https://github.com/nanomsg/nng/pull/264 doesn't have many actionable details about what failed.

by setting the `CTEST_OUTPUT_ON_FAILURE` environment variable, the ctest runner will at least dump details about which assertions failed in the event of a failure, which should help with diagnosis.