### PR TITLE
circle ci: add workflows for linux clang and gcc builds

### DIFF
--- a/.circleci/build-and-test.sh
+++ b/.circleci/build-and-test.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#
+# common build & test steps for CircleCI jobs
+#
+
+uname -a
+cmake --version
+ninja --version
+
+mkdir build
+cd build
+cmake -G Ninja -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-Debug} -DNNG_ENABLE_COVERAGE=${COVERAGE:-OFF} ..
+ninja
+env CTEST_OUTPUT_ON_FAILURE=1 ninja test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,38 +1,67 @@
-# Debian packages we want (makes life better);
-#
-# - asciidoctor
-# - cmake
-# - libmbedtls-dev
-# - ninja-build
-# - clang
-# - clang-format
-# - gcc (-7?)
-# - g++ (-7?)
-#
-version: 2
+
+# TODO: create custom docker images for each of these environments
+# to avoid re-downloading & installing dependencies each time
+
+version: 2.0
 jobs:
-  build:
+  "clang - build, test":
     docker:
-      - image: debian:stretch
+      - image: ubuntu:16.04
+        environment:
+          CC: clang-4.0
+          CXX: clang++-4.0
+          CLANG_FORMAT: clang-format-4.0
+          CTEST_OUTPUT_ON_FAILURE: 1
     steps:
       - checkout
-      - run:
-          name: Install Dependencies
-          command: apt-get update -qq && apt-get install -y build-essential asciidoctor cmake libmbedtls-dev ninja-build clang clang-format
-      - run:
-          name: Configure
-          command: mkdir build && cd build && cmake -DNNG_TRANSPORT_TLS=ON -G Ninja ..
+      - run: apt-get update -qq
+      - run: apt-get install -y software-properties-common
+      # llvm apt details: https://apt.llvm.org
+      - run: apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main"
+      - run: apt-get update -qq
+      - run: >
+          apt-get install -y
+          build-essential
+          curl
+          asciidoctor
+          cmake
+          libmbedtls-dev
+          ninja-build
+          clang-4.0
+          clang-format-4.0
+      - run: ./etc/format-check.sh
+      - run: ./.circleci/build-and-test.sh
 
-      - run:
-          name: Build
-          command: cd build && ninja
+  "gcc - build, test, coverage":
+    docker:
+      - image: ubuntu:16.04
+        environment:
+          CC: gcc-7
+          CXX: g++-7
+          COVERAGE: "ON"
+          GCOV: gcov-7
+    steps:
+      - checkout
+      - run: apt-get update -qq
+      - run: apt-get install -y software-properties-common
+      - run: add-apt-repository ppa:ubuntu-toolchain-r/test
+      - run: apt-get update -qq
+      - run: >
+          apt-get install -y
+          build-essential
+          curl
+          asciidoctor
+          cmake
+          libmbedtls-dev
+          ninja-build
+          gcc-7
+          g++-7
+      - run: ./.circleci/build-and-test.sh
+      - run: ./etc/codecov.sh
 
-      - run:
-          name: Run Tests
-          command: cd build && ninja test
-          environment:
-            CTEST_OUTPUT_ON_FAILURE: 1
-
-#      - run:
-#          name: Check Format
-#          command: ./etc/format-check.sh
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - "clang - build, test"
+      - "gcc - build, test, coverage"

--- a/.circleci/images/clang/Dockerfile
+++ b/.circleci/images/clang/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -qq && apt-get install -y software-properties-common
+RUN apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main"
+RUN apt-get update -qq && apt-get install -y \
+    asciidoctor \
+    build-essential \
+    clang-4.0 \
+    clang++-4.0 \
+    clang-format-4.0 \
+    cmake \
+    curl \
+    git \
+    gzip \
+    libmbedtls-dev \
+    ninja-build \
+    openssh-client

--- a/.circleci/images/docker-deploy.sh
+++ b/.circleci/images/docker-deploy.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# increment tag each time either dockerfile changes
+TAG=0.0.1
+
+docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
+
+pushd clang
+docker build -t nng/ci/clang:$TAG .
+popd
+
+pushd gcc
+docker build -t nng/ci/gcc:$TAG .
+popd
+
+docker push nng/ci/clang:$TAG
+docker push nng/ci/gcc:$TAG

--- a/.circleci/images/gcc/Dockerfile
+++ b/.circleci/images/gcc/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:16.04
+
+RUN apt-get update -qq && apt-get install -y software-properties-common
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update -qq && apt-get install -y \
+    asciidoctor \
+    build-essential \
+    cmake \
+    curl \
+    g++-7 \
+    gcc-7 \
+    git \
+    gzip \
+    libmbedtls-dev \
+    ninja-build \
+    openssh-client


### PR DESCRIPTION
fixes #202

Includes build configs for clang and gcc on linux. It's possible to setup macOS as well, but requires an explicit support request to CircleCI for open source projects.

These run in parallel and are passing build & test for both, and uploading coverage info on the gcc image. I believe this represents parity with the travis build config, such that it could be dropped.

**Caveats**
Currently, the builds must install dependencies each time, which can be pretty slow. The recommended way to avoid this is to use custom docker images that include the dependencies - docker images are cached by circle ci.

This involves a little more coordination, since those docker images would be hosted on docker hub (hub.docker.com) and should probably be managed under a nanomsg organization (there's also [this page](https://circleci.com/docs/2.0/contexts) on managing credentials for orgs on circle ci).

But I've included Dockerfiles to build those custom images and a sample script to deploy them, so would be a matter of getting that working w that appropriate credentials if you can set them up.