### PR TITLE
fixes #281 desire nng_sleep_aio()

### DIFF
--- a/docs/man/libnng.adoc
+++ b/docs/man/libnng.adoc
@@ -157,6 +157,7 @@ The following functions are used in the asynchronous model:
 |<<nng_aio_wait#,nng_aio_wait(3)>>|wait for asynchronous I/O operation
 |<<nng_recv_aio#,nng_recv_aio(3)>>|receive message asynchronously
 |<<nng_send_aio#,nng_send_aio(3)>>|send message asynchronously
+|<<nng_sleep_aio#,nng_sleep_aio(3)>>|sleep asynchronously
 |===
 
 === Protocols

--- a/docs/man/nng_sleep_aio.adoc
+++ b/docs/man/nng_sleep_aio.adoc
@@ -1,0 +1,49 @@
+= nng_sleep_aio(3)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_sleep_aio - sleep asynchronously
+
+== SYNOPSIS
+
+[source, c]
+-----------
+#include <nng/nng.h>
+
+void nng_sleep_aio(nng_duration msec, nng_aio *aio);
+-----------
+
+== DESCRIPTION
+
+The `nng_sleep_aio()` function performs an asynchronous "`sleep``",
+causing the callback for _aio_ to be executed after _msec_ milliseconds.
+This is logically the equivalent of starting an asynchronous operation
+that does nothing at all, but expires after _msec_ duration, _except_ that
+the completion result will be zero rather `NNG_ETIMEDOUT`.
+
+NOTE: This overrides and replaces any timeout on the _aio_ set with
+<<nng_aio_set_timeout#,nng_aio_set_timeout(3)>>.
+
+== RETURN VALUES
+
+None.
+
+== ERRORS
+
+None.
+
+== SEE ALSO
+
+<<nng_aio_abort#,nng_aio_abort(3)>>,
+<<nng_aio_alloc#,nng_aio_alloc(3)>>,
+<<nng_aio_set_timeout#,nng_aio_set_timeout(3)>>,
+<<nng#,nng(7)>>

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -151,6 +151,8 @@ extern void nni_aio_get_iov(nni_aio *, unsigned *, nni_iov **);
 extern void nni_aio_normalize_timeout(nni_aio *, nng_duration);
 extern void nni_aio_bump_count(nni_aio *, size_t);
 
+extern void nni_sleep_aio(nni_duration, nni_aio *);
+
 extern int  nni_aio_sys_init(void);
 extern void nni_aio_sys_fini(void);
 #endif // CORE_AIO_H

--- a/src/nng.c
+++ b/src/nng.c
@@ -1039,6 +1039,12 @@ nng_aio_free(nng_aio *aio)
 	nni_aio_fini(aio);
 }
 
+void
+nng_sleep_aio(nng_duration ms, nng_aio *aio)
+{
+	nni_sleep_aio(ms, aio);
+}
+
 int
 nng_aio_result(nng_aio *aio)
 {

--- a/src/nng.h
+++ b/src/nng.h
@@ -352,6 +352,11 @@ NNG_DECL int nng_aio_set_iov(nng_aio *, unsigned, const nng_iov *);
 // given aio.
 NNG_DECL void nng_aio_finish(nng_aio *, int);
 
+// nng_aio_sleep does a "sleeping" operation, basically does nothing
+// but wait for the specified number of milliseconds to expire, then
+// calls the callback.  This returns 0, rather than NNG_ETIMEDOUT.
+NNG_DECL void nng_sleep_aio(nng_duration, nng_aio *);
+
 // Message API.
 NNG_DECL int   nng_msg_alloc(nng_msg **, size_t);
 NNG_DECL void  nng_msg_free(nng_msg *);


### PR DESCRIPTION
This adds nng_sleep_aio(), and tests it, and documents it.

We want this to make writing certain async services easier.

We can probably use this to eliminate some of the timeouts and separate timeout thread too!