### PR TITLE
nng_sleep_aio should honor aio timeout.

### DIFF
--- a/docs/man/nng_sleep_aio.adoc
+++ b/docs/man/nng_sleep_aio.adoc
@@ -26,12 +26,11 @@ void nng_sleep_aio(nng_duration msec, nng_aio *aio);
 
 The `nng_sleep_aio()` function performs an asynchronous "`sleep``",
 causing the callback for _aio_ to be executed after _msec_ milliseconds.
-This is logically the equivalent of starting an asynchronous operation
-that does nothing at all, but expires after _msec_ duration, _except_ that
-the completion result will be zero rather `NNG_ETIMEDOUT`.
+If the sleep finishes completely, the result will always be zero.
 
-NOTE: This overrides and replaces any timeout on the _aio_ set with
-<<nng_aio_set_timeout#,nng_aio_set_timeout(3)>>.
+NOTE: If a timeout is set on _aio_ using
+<<nng_aio_timeout#,nng_aio_set_timeout(3)>>, and it is shorter than _msec_,
+then the sleep will wake up early, with a result code of `NNG_ETIMEDOUT`.
 
 == RETURN VALUES
 

--- a/tests/aio.c
+++ b/tests/aio.c
@@ -56,6 +56,25 @@ Main({
 			So((nng_clock() - start) <= 1000);
 			nng_aio_free(saio);
 		});
+
+		Convey("Sleep timeout works", {
+			nng_time start = 0;
+			nng_time end   = 0;
+			nng_aio *saio;
+			So(nng_aio_alloc(&saio, sleepdone, &end) == 0);
+			nng_aio_set_timeout(saio, 100);
+			start = nng_clock();
+			nng_sleep_aio(2000, saio);
+			nng_aio_wait(saio);
+			So(nng_aio_result(saio) == NNG_ETIMEDOUT);
+			So(end != 0);
+			So((end - start) >= 100);
+			So((end - start) <= 1000);
+			So((nng_clock() - start) >= 100);
+			So((nng_clock() - start) <= 1000);
+			nng_aio_free(saio);
+		});
+
 		Convey("Given a connected pair of sockets", {
 			nng_socket s1;
 			nng_socket s2;


### PR DESCRIPTION
The first problem was that using nng_sleep_aio
was found to reset the timeout, and this caused subsequent
operations to start failing with timeouts when reusing
the AIO for other operations.

The second thing is that we think it would be nicer if the
presence of real aio timeouts were still honored, so that
if the timeout is shorter than the sleep time, then we get
back an NNG_ETIMEDOUT like every other operation, and we
get back a 0 if the logical sleep operation completes
normally.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
