### PR TITLE
fixes #306 Linger should be passed down to TCP sockets.

### DIFF
--- a/docs/man/nng_options.5.adoc
+++ b/docs/man/nng_options.5.adoc
@@ -81,10 +81,19 @@ This is the linger time of the socket in milliseconds.
 When this value is non-zero, then the system will
 attempt to defer closing until it has undelivered data, or until the specified
 timeout has expired.
+The actual time to linger will be rounded up based upon the granularity
+provided by the system; most often this is a whole second.
+This value defaults to one (with any rounding up applied.)
 
 NOTE: Not all transports support lingering, and
 so closing a socket or exiting the application can still result in the loss
 of undelivered messages.
+
+NOTE: Setting a linger time of zero disables linger.
+This can cause not only lost data, but for some protocols it causes
+a reset of the communications channel, which can be perceived as a remote
+reset by peers.
+Thus, setting this to zero is not recommended.
 
 [[NNG_OPT_LOCADDR]]
 ((`NNG_OPT_LOCADDR`))::

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -242,6 +242,15 @@ extern void nni_plat_tcp_pipe_send(nni_plat_tcp_pipe *, nni_aio *);
 // receive zero bytes.)  The platform may not modify the I/O vector.
 extern void nni_plat_tcp_pipe_recv(nni_plat_tcp_pipe *, nni_aio *);
 
+// nni_plat_tcp_pipe_set_linger sets the linger interval on a pipe.
+// The time period is in msec, but may be rounded up to nearest second
+// depending on the platform.  Turning this to 0 may cause close to
+// send RST (abort), and so is not recommended.
+extern int nni_plat_tcp_pipe_set_linger(nni_plat_tcp_pipe *, nng_duration);
+
+// nni_plat_tcp_pipe_set_nodelay disables NAGLE.
+extern int nni_plat_tcp_pipe_set_nodelay(nni_plat_tcp_pipe *, bool);
+
 // nni_plat_tcp_pipe_peername gets the peer name.
 extern int nni_plat_tcp_pipe_peername(nni_plat_tcp_pipe *, nni_sockaddr *);
 

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -499,7 +499,7 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 	if ((s = NNI_ALLOC_STRUCT(s)) == NULL) {
 		return (NNG_ENOMEM);
 	}
-	s->s_linger          = 0;
+	s->s_linger          = 1;
 	s->s_sndtimeo        = -1;
 	s->s_rcvtimeo        = -1;
 	s->s_closing         = 0;

--- a/src/platform/posix/posix_aio.h
+++ b/src/platform/posix/posix_aio.h
@@ -31,6 +31,8 @@ extern void nni_posix_pipedesc_send(nni_posix_pipedesc *, nni_aio *);
 extern void nni_posix_pipedesc_close(nni_posix_pipedesc *);
 extern int  nni_posix_pipedesc_peername(nni_posix_pipedesc *, nni_sockaddr *);
 extern int  nni_posix_pipedesc_sockname(nni_posix_pipedesc *, nni_sockaddr *);
+extern int  nni_posix_pipedesc_set_linger(nni_posix_pipedesc *, nng_duration);
+extern int  nni_posix_pipedesc_set_nodelay(nni_posix_pipedesc *, bool);
 
 extern int  nni_posix_epdesc_init(nni_posix_epdesc **);
 extern void nni_posix_epdesc_set_local(nni_posix_epdesc *, void *, size_t);

--- a/src/platform/posix/posix_pipedesc.c
+++ b/src/platform/posix/posix_pipedesc.c
@@ -25,6 +25,9 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+
 // nni_posix_pipedesc is a descriptor kept one per transport pipe (i.e. open
 // file descriptor for TCP socket, etc.)  This contains the list of pending
 // aios for that underlying socket, as well as the socket itself.
@@ -325,6 +328,39 @@ nni_posix_pipedesc_sockname(nni_posix_pipedesc *pd, nni_sockaddr *sa)
 		return (nni_plat_errno(errno));
 	}
 	return (nni_posix_sockaddr2nn(sa, &ss));
+}
+
+int
+nni_posix_pipedesc_set_linger(nni_posix_pipedesc *pd, nng_duration linger)
+{
+// POSIX says that SO_LINGER should exist, and be calculated as
+// seconds.  macOS defaults to ticks.
+#ifdef SO_LINGER_SOCK
+#define NNI_SO_LINGER SO_LINGER_SOCK
+#else
+#define NNI_SO_LINGER SO_LINGER
+#endif
+	struct linger sl;
+	memset(&sl, 0, sizeof(sl));
+	if (linger > 0) {
+		sl.l_onoff  = 1;
+		sl.l_linger = (int) ((linger + 999) / 1000);
+	} else {
+		sl.l_onoff  = 0;
+		sl.l_linger = 0;
+	}
+	(void) setsockopt(
+	    pd->node.fd, SOL_SOCKET, NNI_SO_LINGER, &sl, sizeof(sl));
+	return (0);
+}
+
+int
+nni_posix_pipedesc_set_nodelay(nni_posix_pipedesc *pd, bool nodelay)
+{
+	int onoff = nodelay ? 1 : 0;
+	(void) setsockopt(
+	    pd->node.fd, IPPROTO_TCP, TCP_NODELAY, &onoff, sizeof(onoff));
+	return (0);
 }
 
 int

--- a/src/platform/posix/posix_tcp.c
+++ b/src/platform/posix/posix_tcp.c
@@ -113,6 +113,18 @@ nni_plat_tcp_pipe_recv(nni_plat_tcp_pipe *p, nni_aio *aio)
 }
 
 int
+nni_plat_tcp_pipe_set_linger(nni_plat_tcp_pipe *p, nng_duration linger)
+{
+	return (nni_posix_pipedesc_set_linger((void *) p, linger));
+}
+
+int
+nni_plat_tcp_pipe_set_nodelay(nni_plat_tcp_pipe *p, bool nodelay)
+{
+	return (nni_posix_pipedesc_set_nodelay((void *) p, nodelay));
+}
+
+int
 nni_plat_tcp_pipe_peername(nni_plat_tcp_pipe *p, nni_sockaddr *sa)
 {
 	return (nni_posix_pipedesc_peername((void *) p, sa));

--- a/src/platform/windows/win_tcp.c
+++ b/src/platform/windows/win_tcp.c
@@ -226,6 +226,30 @@ nni_plat_tcp_pipe_close(nni_plat_tcp_pipe *pipe)
 }
 
 int
+nni_plat_tcp_pipe_set_linger(nni_plat_tcp_pipe *pipe, nng_duration linger)
+{
+	LINGER sl;
+
+	if (linger > 0) {
+		sl.l_onoff  = 1;
+		sl.l_linger = (unsigned short) (linger / 1000);
+	} else {
+		sl.l_onoff  = 0;
+		sl.l_linger = 0;
+	}
+	setsockopt(pipe->s, SOL_SOCKET, SO_LINGER, &sl, sizeof(sl));
+	return (0);
+}
+
+int
+nni_plat_tcp_pipe_set_nodelay(nni_plat_tcp_pipe *pipe, bool nodelay)
+{
+	BOOL nd = nodelay ? TRUE : FALSE;
+	setsockopt(pipe->s, IPPROTO_TCP, TCP_NODELAY, &nd, sizeof(nd));
+	return (0);
+}
+
+int
 nni_plat_tcp_pipe_peername(nni_plat_tcp_pipe *pipe, nni_sockaddr *sa)
 {
 	if (nni_win_sockaddr2nn(sa, &pipe->peername) < 0) {

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -120,6 +120,7 @@ nni_tcp_pipe_init(nni_tcp_pipe **pipep, nni_tcp_ep *ep, void *tpp)
 		return (rv);
 	}
 
+	nni_plat_tcp_pipe_set_linger(tpp, ep->linger);
 	p->proto  = ep->proto;
 	p->rcvmax = ep->rcvmax;
 	p->tpp    = tpp;


### PR DESCRIPTION
fixes #304 perf tool exits too quickly on throughput client

While here I also added most of the plumbing for TCP nodelay.