### PR TITLE
fixes #324 nni_aio_set_synch leads to race condition

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -79,19 +79,6 @@ extern void *nni_aio_get_output(nni_aio *, unsigned);
 extern void     nni_aio_set_msg(nni_aio *, nni_msg *);
 extern nni_msg *nni_aio_get_msg(nni_aio *);
 
-// nni_aio_set_synch sets a synchronous completion flag on the AIO.
-// When this is set, the next time the AIO is completed, the callback
-// be run synchronously, from the thread calling the finish routine.
-// It is important that this only be set when the provider knows that
-// it is not holding any locks or resources when completing the operation,
-// or when the consumer knows that the callback routine does not acquire
-// any locks.  Use with caution to avoid deadlocks.  The flag is cleared
-// automatically when the completion callback is executed.  Some care has
-// been taken so that other aio operations like aio_wait will work,
-// although it is still an error to try waiting for an aio from that aio's
-// completion callback.
-void nni_aio_set_synch(nni_aio *);
-
 // nni_aio_result returns the result code (0 on success, or an NNG errno)
 // for the operation.  It is only valid to call this when the operation is
 // complete (such as when the callback is executed or after nni_aio_wait
@@ -123,6 +110,11 @@ extern int  nni_aio_list_active(nni_aio *);
 
 // nni_aio_finish is called by the provider when an operation is complete.
 extern void nni_aio_finish(nni_aio *, int, size_t);
+// nni_aio_finish_synch is to be called when a synchronous completion is
+// desired.  It is very important that the caller not hold any locks when
+// calling this, but it is useful for chaining completions to minimize
+// context switch overhead during completions.
+extern void nni_aio_finish_synch(nni_aio *, int, size_t);
 extern void nni_aio_finish_error(nni_aio *, int);
 extern void nni_aio_finish_msg(nni_aio *, nni_msg *);
 

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -604,8 +604,7 @@ ws_write_cb(void *arg)
 	if (aio != NULL) {
 		nng_msg *msg = nni_aio_get_msg(aio);
 		nni_aio_set_msg(aio, NULL);
-		nni_aio_set_synch(aio);
-		nni_aio_finish(aio, 0, nni_msg_len(msg));
+		nni_aio_finish_synch(aio, 0, nni_msg_len(msg));
 		nni_msg_free(msg);
 	}
 }
@@ -1022,8 +1021,7 @@ ws_read_cb(void *arg)
 			body += frame->len;
 		}
 		nni_aio_set_msg(wm->aio, msg);
-		nni_aio_set_synch(aio);
-		nni_aio_finish(wm->aio, 0, nni_msg_len(msg));
+		nni_aio_finish_synch(wm->aio, 0, nni_msg_len(msg));
 		ws_msg_fini(wm);
 	}
 }

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -252,8 +252,7 @@ nni_ipc_pipe_send_cb(void *arg)
 	n   = nni_msg_len(msg);
 	nni_aio_set_msg(aio, NULL);
 	nni_msg_free(msg);
-	nni_aio_set_synch(aio);
-	nni_aio_finish(aio, 0, n);
+	nni_aio_finish_synch(aio, 0, n);
 }
 
 static void
@@ -341,8 +340,7 @@ nni_ipc_pipe_recv_cb(void *arg)
 	nni_mtx_unlock(&pipe->mtx);
 
 	nni_aio_set_msg(aio, msg);
-	nni_aio_set_synch(aio);
-	nni_aio_finish(aio, 0, nni_msg_len(msg));
+	nni_aio_finish_synch(aio, 0, nni_msg_len(msg));
 	return;
 
 recv_error:

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -250,8 +250,7 @@ nni_tcp_pipe_send_cb(void *arg)
 	n   = nni_msg_len(msg);
 	nni_aio_set_msg(aio, NULL);
 	nni_msg_free(msg);
-	nni_aio_set_synch(aio);
-	nni_aio_finish(aio, 0, n);
+	nni_aio_finish_synch(aio, 0, n);
 }
 
 static void
@@ -321,9 +320,8 @@ nni_tcp_pipe_recv_cb(void *arg)
 	}
 	nni_mtx_unlock(&p->mtx);
 
-	nni_aio_set_synch(aio);
 	nni_aio_set_msg(aio, msg);
-	nni_aio_finish(aio, 0, nni_msg_len(msg));
+	nni_aio_finish_synch(aio, 0, nni_msg_len(msg));
 	return;
 
 recv_error:

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -257,8 +257,7 @@ nni_tls_pipe_send_cb(void *arg)
 	n   = nni_msg_len(msg);
 	nni_aio_set_msg(aio, NULL);
 	nni_msg_free(msg);
-	nni_aio_set_synch(aio);
-	nni_aio_finish(aio, 0, n);
+	nni_aio_finish_synch(aio, 0, n);
 }
 
 static void
@@ -329,9 +328,8 @@ nni_tls_pipe_recv_cb(void *arg)
 	}
 	nni_mtx_unlock(&p->mtx);
 
-	nni_aio_set_synch(aio);
 	nni_aio_set_msg(aio, msg);
-	nni_aio_finish(aio, 0, nni_msg_len(msg));
+	nni_aio_finish_synch(aio, 0, nni_msg_len(msg));
 	return;
 
 recv_error:

--- a/src/transport/zerotier/zerotier.c
+++ b/src/transport/zerotier/zerotier.c
@@ -1368,7 +1368,6 @@ zt_wire_packet_send(ZT_Node *node, void *userptr, void *thr, int64_t socket,
 
 	// This should be non-blocking/best-effort, so while
 	// not great that we're holding the lock, also not tragic.
-	nni_aio_set_synch(aio);
 	nni_plat_udp_send(udp, aio);
 
 	return (0);


### PR DESCRIPTION
fixes #325 synchronous aio completion crash
fixes #327 move nni_clock() operations to outside the nni_aio_lk.

This work was done for the context tree, and is necessary to properly
enable that branch.

