### PR TITLE
fixes #331 replace NNG_OPT_RAW option with constructor

### DIFF
--- a/docs/man/nng.7.adoc
+++ b/docs/man/nng.7.adoc
@@ -73,45 +73,72 @@ other languages please check the http://nanomsg.org/[website].
 
 == Conceptual Overview
 
-_nng_ presents a _socket_ view of networking.  The sockets are constructed
-using protocol-specific functions, as a given socket implements precisely
-one _nng_ protocol.
+_nng_ presents a _socket_ view of networking.
+The sockets are constructed using protocol-specific functions, as a given
+socket implements precisely one _nng_ protocol.
 
 Each socket can be used to send and receive messages (if the protocol)
-supports it, and implements the appropriate protocol semantics.  For
-example, <<nng_sub.7#,nng_sub(7)>> sockets automatically filter incoming
+supports it, and implements the appropriate protocol semantics.
+For example, <<nng_sub.7#,_sub_>> sockets automatically filter incoming
 messages to discard those for topics that have not been subscribed.
 
 _nng_ sockets are message oriented, so that messages are either delivered
-wholly, or not at all.  Partial delivery is not possible.  Furthermore,
-_nng_ does not provide any other delivery or ordering guarantees;
-messages may be dropped or reordered.  (Some protocols, such as
-<<nng_req.7#,nng_req(7)>> may offer stronger guarantees by
-performing their own retry and validation schemes.)
+wholly, or not at all.  Partial delivery is not possible.
+Furthermore, _nng_ does not provide any other delivery or ordering guarantees;
+messages may be dropped or reordered
+(Some protocols, such as <<nng_req.7#,_req_>> may offer stronger
+guarantees by performing their own retry and validation schemes.)
 
 Each socket can have zero, one, or many "endpoints", which are either
-_listeners_ or _dialers_. (A given socket may freely choose whether it uses
-listeners, dialers, or both.)  These "endpoints" provide access to
-underlying transports, such as TCP, etc.
+_listeners_ or _dialers_.
+(A given socket may freely choose whether it uses listeners, dialers, or both.)
+These "endpoints" provide access to underlying transports, such as TCP, etc.
 
-Each endpoint is associated with a URL, which is a service address.  For
-dialers, this will be the service address that will be contacted, whereas
-for listeners this is where the listener will bind and watch for new
-connections.
+Each endpoint is associated with a URL, which is a service address.
+For dialers, this will be the service address that will be contacted, whereas
+for listeners this is where the listener will accept new connections.
 
-Endpoints do not themselves transport data.  They are instead responsible
-for the creation of _pipes_, which can be thought of as message-oriented,
-connected, streams.  Pipes frequently correspond to a single underlying
-byte stream -- for example both IPC and TCP transports implement their
-pipes using a 1:1 relationship with a connected socket.
+Endpoints do not themselves transport data.
+They are instead responsible for the creation of _pipes_, which can be
+thought of as message-oriented connected streams.
+Pipes frequently correspond to a single underlying byte stream.
+For example both IPC and TCP transports implement their
+pipes using a 1:1 relationship with a connected operating system socket.
 
-Endpoints create pipes as needed.  Listeners will create them when a new
-client connection request arrives, and dialers will generally create one,
-then wait for it to disconnect before reconnecting.
+Endpoints create pipes as needed.
+Listeners will create them when a new client connection request arrives,
+and dialers will generally create one, then wait for it to disconnect before
+reconnecting.
 
 Most applications should not have to worry about endpoints or pipes at
 all; the socket abstraction should provide all the functionality needed
 other than in a few specific circumstances.
+
+[[raw_mode]](((raw mode)))
+=== Raw Mode
+
+(((cooked mode)))
+Most applications will use _nng_ sockets in "`cooked`" mode. 
+This mode provides the full semantics of the protocol.
+For example, <<nng_req.7#,_req_>> sockets will automatically
+match a reply to a request, and resend requests periodically if no reply
+was received.
+
+There are situations, such as with <<nng_device.7#,proxies>>,
+where it is desirable to bypass these semantics and simply pass messages
+to and from the socket with no extra semantic handling.
+This is possible using "`raw`" mode sockets.
+
+Raw mode sockets are generally constructed with a different function,
+such as <<nng_req_open.3#,`nng_req0_open_raw()`>>.
+Using these sockets, the application can simply send and receive messages,
+and is responsible for supplying any additional socket semantics.
+Typically this means that the application will need to inspect message
+headers on incoming messages, and supply them on outgoing messages.
+
+TIP: The <<nng_device.3#,`nng_device()`>> function only works with raw mode
+sockets, but as it only forwards the messages, no additional application
+processing is needed.
 
 === URLs
 

--- a/docs/man/nng_bus.7.adoc
+++ b/docs/man/nng_bus.7.adoc
@@ -18,8 +18,6 @@ nng_bus - bus protocol
 [source,c]
 ----
 #include <nng/protocol/bus0/bus.h>
-
-int nng_bus0_open(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -51,7 +49,7 @@ the more likely that message loss is to occur.
 
 === Socket Operations
 
-The <<nng_bus_open.3#,`nng_bus0_open()`>> call creates a bus socket.
+The <<nng_bus_open.3#,`nng_bus0_open()`>> functions create a bus socket.
 This socket may be used to send and receive messages.
 Sending messages will attempt to deliver to each directly connected peer.
 

--- a/docs/man/nng_bus_open.3.adoc
+++ b/docs/man/nng_bus_open.3.adoc
@@ -21,6 +21,8 @@ nng_bus_open - create bus socket
 #include <nng/protocol/bus0/bus.h>
 
 int nng_bus0_open(nng_socket *s);
+
+int nng_bus0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -28,9 +30,13 @@ int nng_bus0_open(nng_socket *s);
 The `nng_bus0_open()` function creates a <<nng_bus.7#,_bus_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_bus0_open_raw()` function creates a <<nng_bus.7#,_bus_>> version 0
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode, and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_device.3.adoc
+++ b/docs/man/nng_device.3.adoc
@@ -31,6 +31,11 @@ This function is used to create forwarders, which can be used to create
 complex network topologies to provide for improved ((horizontal scalability)),
 reliability, and isolation.
 
+Only <<nng_options.5#NNG_OPT_RAW,raw>> mode sockets may be used with this
+function.
+These can be created using `_raw` forms of the various socket constructors,
+such as <<nng_req_open.3#,`nng_req0_open_raw()`>>.
+
 The `nng_device()` function does not return until one of the sockets
 is closed.
 
@@ -60,11 +65,14 @@ be a _bus_ socket.
 
 === Operation
 
-This `nng_device()` function puts each socket into raw mode
-(see <<nng_options.5#NNG_OPT_RAW,`NNG_OPT_RAW`>>), and then moves messages
-between them.
-When a protocol has a ((backtrace)) style header, routing information is
-added as the message crosses the forwarder, allowing replies to be
+The `nng_device()` function moves messages between the provided sockets.
+
+When a protocol has a ((backtrace)) style header, routing information
+is present in the header of received messages, and is copied to the
+header of the output bound message.
+The underlying raw mode protocols supply the necessary header
+adjustments to add or remove routing headers as needed.
+This allows replies to be
 returned to requestors, and responses to be routed back to surveyors.
 
 Additionally, some protocols have a maximum ((time-to-live)) to protect

--- a/docs/man/nng_options.5.adoc
+++ b/docs/man/nng_options.5.adoc
@@ -99,7 +99,7 @@ listeners but not dialers.
 (((raw mode)))
 (((cooked mode)))
 (`bool`)
-This option determines whether the socket is in "`raw`" mode.
+This read-only option indicates whether the socket is in "`raw`" mode.
 If `true`, the socket is in "`raw`" mode, and if `false` the socket is
 in "`cooked`" mode.
 Raw mode sockets generally do not have any protocol-specific semantics applied
@@ -107,6 +107,7 @@ to them; instead the application is expected to perform such semantics itself.
 (For example, in "`cooked`" mode a <<nng_rep.7#,_rep_>> socket would
 automatically copy message headers from a received message to the corresponding
 reply, whereas in "`raw`" mode this is not done.)
+See <<nng.7#raw_mode,Raw Mode>> for more details.
 
 [[NNG_OPT_RECONNMINT]]
 ((`NNG_OPT_RECONNMINT`))::

--- a/docs/man/nng_pair.7.adoc
+++ b/docs/man/nng_pair.7.adoc
@@ -19,16 +19,12 @@ nng_pair - pair protocol
 [source,c]
 ----
 #include <nng/protocol/pair0/pair.h>
-
-int nng_pair0_open(nng_socket *s);
 ----
 
 .Version 1
 [source,c]
 ----
 #include <nng/protocol/pair1/pair.h>
-
-int nng_pair1_open(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -43,9 +39,10 @@ some additional sophistication in the application.
 
 === Socket Operations
 
-The `nng_pair_open()` call creates a _pair_ socket.  Normally, this
-pattern will block when attempting to send a message, if no peer is
-able to receive the message.
+The <<nng_pair_open.3#,`nng_pair_open()`>> functions create _pair_ socket.
+
+Normally, this pattern will block when attempting to send a message if
+no peer is able to receive the message.
 
 NOTE: Even though this mode may appear to be "reliable", because back-pressure
 prevents discarding messages most of the time, there are topologies involving

--- a/docs/man/nng_pair_open.3.adoc
+++ b/docs/man/nng_pair_open.3.adoc
@@ -21,6 +21,8 @@ nng_pair_open - create pair socket
 #include <nng/protocol/pair0/pair.h>
 
 int nng_pair0_open(nng_socket *s);
+
+int nng_pair0_open_raw(nng_socket *s);
 ----
 
 .Version 1
@@ -29,6 +31,8 @@ int nng_pair0_open(nng_socket *s);
 #include <nng/protocol/pair1/pair.h>
 
 int nng_pair1_open(nng_socket *s);
+
+int nng_pair1_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -36,6 +40,11 @@ int nng_pair1_open(nng_socket *s);
 The `nng_pair0_open()` and `nng_pair1_open()` functions
 create a <<nng_pair.7#,_pair_>> version 0 or version 1
 <<nng_socket.5#,socket>> and return it at the location pointed to by _s_.
+
+The `nng_pair0_open_raw()` and `nng_pair1_open_raw()` functions
+create a <<nng_pair.7#,_pair_>> version 0 or version 1
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and return it at the location pointed to by _s_.
 
 == RETURN VALUES
 

--- a/docs/man/nng_pub.7.adoc
+++ b/docs/man/nng_pub.7.adoc
@@ -18,8 +18,6 @@ nng_pub - publisher protocol
 [source,c]
 ----
 #include <nng/protocol/pubsub0/pub.h>
-
-int nng_pub0_open(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -46,7 +44,7 @@ Applications should construct their messages accordingly.
 
 === Socket Operations
 
-The <<nng_pub_open.3#,`nng_pub0_open()`>> call creates a publisher socket.
+The <<nng_pub_open.3#,`nng_pub0_open()`>> functions create a publisher socket.
 This socket may be used to send messages, but is unable to receive them.
 Attempts to receive messages will result in `NNG_ENOTSUP`.
 

--- a/docs/man/nng_pub_open.3.adoc
+++ b/docs/man/nng_pub_open.3.adoc
@@ -21,6 +21,8 @@ nng_pub_open - create pub socket
 #include <nng/protocol/pubsub0/pub.h>
 
 int nng_pub0_open(nng_socket *s);
+
+int nng_pub0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -28,9 +30,13 @@ int nng_pub0_open(nng_socket *s);
 The `nng_pub0_open()` function creates a <<nng_pub.7#,_pub_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_pub0_open_raw()` function creates a <<nng_pub.7#,_pub_>> version 0
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_pull.7.adoc
+++ b/docs/man/nng_pull.7.adoc
@@ -16,11 +16,9 @@ nng_pull - pull protocol
 == SYNOPSIS
 
 [source,c]
-----------
+----
 #include <nng/protocol/pipeline0/pull.h>
-
-int nng_pull0_open(nng_socket *s);
-----------
+----
 
 == DESCRIPTION
 
@@ -37,7 +35,7 @@ This property makes this pattern useful in ((load-balancing)) scenarios.
 
 === Socket Operations
 
-The <<nng_pull_open.3#,`nng_pull0_open()`>> call creates a puller socket.
+The <<nng_pull_open.3#,`nng_pull0_open()`>> functions create a puller socket.
 This socket may be used to receive messages, but is unable to send them.
 Attempts to send messages will result in `NNG_ENOTSUP`.
 

--- a/docs/man/nng_pull_open.3.adoc
+++ b/docs/man/nng_pull_open.3.adoc
@@ -21,6 +21,8 @@ nng_pull_open - create pull socket
 #include <nng/protocol/pipeline0/pull.h>
 
 int nng_pull0_open(nng_socket *s);
+
+int nng_pull0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -28,9 +30,13 @@ int nng_pull0_open(nng_socket *s);
 The `nng_pull0_open()` function creates a <<nng_pull.7#,_pull_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_pull0_open_raw()` function creates a <<nng_pull.7#,_pull_>> version 0
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_push.7.adoc
+++ b/docs/man/nng_push.7.adoc
@@ -16,11 +16,9 @@ nng_push - push protocol
 == SYNOPSIS
 
 [source,c]
-----------
+----
 #include <nng/protocol/pipeline0/push.h>
-
-int nng_push0_open(nng_socket *s);
-----------
+----
 
 == DESCRIPTION
 

--- a/docs/man/nng_push_open.3.adoc
+++ b/docs/man/nng_push_open.3.adoc
@@ -21,6 +21,8 @@ nng_push_open - create push socket
 #include <nng/protocol/pipeline0/push.h>
 
 int nng_push0_open(nng_socket *s);
+
+int nng_push0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -28,9 +30,13 @@ int nng_push0_open(nng_socket *s);
 The `nng_push0_open()` function creates a <<nng_push.7#,_push_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_push0_open_raw()` function creates a <<nng_push.7#,_push_>> version 0
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_rep.7.adoc
+++ b/docs/man/nng_rep.7.adoc
@@ -18,8 +18,6 @@ nng_rep - reply protocol
 [source,c]
 ----
 #include <nng/protocol/reqrep0/rep.h>
-
-int nng_rep0_open(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -40,7 +38,7 @@ The _rep_ protocol is the replier side, and the
 
 === Socket Operations
 
-The <<nng_rep_open.3#,`nng_rep0_open()`>> call creates a replier socket.
+The <<nng_rep_open.3#,`nng_rep0_open()`>> functions create a replier socket.
 This socket may be used to receive messages (requests), and then to send
 replies.
 Generally a reply can only be sent after receiving a request.
@@ -50,8 +48,7 @@ is no outstanding request.)
 Attempts to send on a socket with no outstanding requests will result
 in `NNG_ESTATE`. 
 
-Raw mode sockets (set with <<nng_options.5#NNG_OPT_RAW,`NNG_OPT_RAW`>>)
-ignore all these restrictions.
+<<nng.7#raw_mode,Raw>> mode sockets ignore all these restrictions.
 
 === Protocol Versions
 

--- a/docs/man/nng_rep_open.3.adoc
+++ b/docs/man/nng_rep_open.3.adoc
@@ -28,9 +28,13 @@ int nng_rep0_open(nng_socket *s);
 The `nng_rep0_open()` function creates a <<nng_rep.7#,_rep_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_rep0_open_raw()` function creates a <<nng_rep.7#,_rep_>> version 0
+<<nng_socket.5#,socket>>
+in <<nng.7#,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_req.7.adoc
+++ b/docs/man/nng_req.7.adoc
@@ -16,11 +16,9 @@ nng_req - request protocol
 == SYNOPSIS
 
 [source,c]
-----------
+----
 #include <nng/protocol/reqrep0/req.h>
-
-int nng_req0_open(nng_socket *s);
-----------
+----
 
 == DESCRIPTION
 
@@ -54,7 +52,7 @@ The _req_ protocol is the requester side, and the
 
 === Socket Operations
 
-The <<nng_req_open.3#,`nng_req0_open()`>> call creates a requester socket.
+The <<nng_req_open.3#,`nng_req0_open()`>> functions create a requester socket.
 This socket may be used to send messages (requests),
 and then to receive replies.
 Generally a reply can only be received after sending a request.
@@ -70,8 +68,7 @@ that has already been placed on the wire.
 Attempts to receive on a socket with no outstanding requests will result
 in `NNG_ESTATE`. 
 
-Raw mode sockets (set with <<nng_options.5#NNG_OPT_RAW,`NNG_OPT_RAW`>>)
-ignore all these restrictions.
+<<nng.7#raw_mode,Raw>> mode sockets ignore all these restrictions.
 
 === Protocol Versions
 

--- a/docs/man/nng_req_open.3.adoc
+++ b/docs/man/nng_req_open.3.adoc
@@ -21,6 +21,8 @@ nng_req_open - create rep socket
 #include <nng/protocol/reqrep0/req.h>
 
 int nng_req0_open(nng_socket *s);
+
+int nng_req0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -28,9 +30,14 @@ int nng_req0_open(nng_socket *s);
 The `nng_req0_open()` function creates a <<nng_req.7#,_req_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_req0_open_raw()` function creates a <<nng_req.7#,_req_>> version 0
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode
+and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 
@@ -39,6 +46,7 @@ This function returns 0 on success, and non-zero otherwise.
 
 == SEE ALSO
 
+<<nng_options.5#,nng_options(5)>>,
 <<nng_socket.5#,nng_socket(5)>>,
 <<nng_rep.7#,nng_rep(7)>>,
 <<nng_req.7#,nng_req(7)>>,

--- a/docs/man/nng_respondent.7.adoc
+++ b/docs/man/nng_respondent.7.adoc
@@ -18,8 +18,6 @@ nng_respondent - respondent protocol
 [source,c]
 ----------
 #include <nng/protocol/survey0/respond.h>
-
-int nng_respondent0_open(nng_socket *s);
 ----------
 
 == DESCRIPTION
@@ -41,7 +39,7 @@ The _respondent_ protocol is the respondent side, and the
 
 === Socket Operations
 
-The <<nng_respondent_open.3#,`nng_respondent0_open()`>> call creates a
+The <<nng_respondent_open.3#,`nng_respondent0_open()`>> functions create a
 respondent socket.
 This socket may be used to receive messages, and then to send replies.
 A reply can only be sent after receiving a survey, and generally the

--- a/docs/man/nng_respondent_open.3.adoc
+++ b/docs/man/nng_respondent_open.3.adoc
@@ -21,6 +21,8 @@ nng_respondent_open - create respondent socket
 #include <nng/protocol/survey0/respond.h>
 
 int nng_respondent0_open(nng_socket *s);
+
+int nng_respondent0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -30,9 +32,14 @@ The `nng_respondent0_open()` function creates a
 version 0 <<nng_socket.5#,socket>> and returns it at the location
 pointed to by _s_.
 
+The `nng_respondent0_open_raw()` function creates a
+<<nng_respondent.7#,_respondent_>>
+version 0 <<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_sockaddr_in6.5.adoc
+++ b/docs/man/nng_sockaddr_in6.5.adoc
@@ -28,7 +28,6 @@ typedef struct {
     uint16_t sa_port;
     uint8_t  sa_addr[16];
 } nng_sockaddr_in6;
-
 ----
 
 == DESCRIPTION

--- a/docs/man/nng_sub.7.adoc
+++ b/docs/man/nng_sub.7.adoc
@@ -19,8 +19,6 @@ nng_sub - subscriber protocol
 ----
 #include <nng/nng.h>
 #include <nng/protocol/pubsub0/sub.h>
-
-int nng_sub0_open(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -45,7 +43,7 @@ Applications should construct their messages accordingly.
 
 === Socket Operations
 
-The <<nng_sub_open.3#,`nng_sub0_open()`>> call creates a subscriber socket.
+The <<nng_sub_open.3#,`nng_sub0_open()`>> functions create a subscriber socket.
 This socket may be used to receive messages, but is unable to send them.
 Attempts to send messages will result in `NNG_ENOTSUP`.
 

--- a/docs/man/nng_sub_open.3.adoc
+++ b/docs/man/nng_sub_open.3.adoc
@@ -21,6 +21,8 @@ nng_sub_open - create sub socket
 #include <nng/protocol/pubsub0/sub.h>
 
 int nng_sub0_open(nng_socket *s);
+
+int nng_sub0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -28,9 +30,13 @@ int nng_sub0_open(nng_socket *s);
 The `nng_sub0_open()` function creates a <<nng_sub.7#,_sub_>> version 0
 <<nng_socket.5#,socket>> and returns it at the location pointed to by _s_.
 
+The `nng_sub0_open()` function creates a <<nng_sub.7#,_sub_>> version 0
+<<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/docs/man/nng_surveyor.7.adoc
+++ b/docs/man/nng_surveyor.7.adoc
@@ -19,8 +19,6 @@ nng_surveyor - surveyor protocol
 ----
 #include <nng/nng.h>
 #include <nng/protocol/survey0/survey.h>
-
-int nng_surveyor0_open(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -43,7 +41,7 @@ The _surveyor_ protocol is the surveyor side, and the
 === Socket Operations
 
 The <<nng_surveyor_open.3#,`nng_surveyor0_open()`>>
-call creates a surveyor socket.
+functions create a surveyor socket.
 This socket may be used to send messages (surveys), and then to receive replies.
 A reply can only be received after sending a survey.
 A surveyor can normally expect to receive at most one reply from each responder.
@@ -59,8 +57,7 @@ Only one survey can be outstanding at a time; sending another survey will
 cancel the prior one, and any responses from respondents from the prior
 survey that arrive after this will be discarded.
 
-Raw mode sockets (set with <<nng_options.5#NNG_OPT_RAW,`NNG_OPT_RAW`>>)
-ignore all these restrictions.
+<<nng.7#raw_mode,Raw>> mode sockets ignore all these restrictions.
 
 === Protocol Versions
 

--- a/docs/man/nng_surveyor_open.3.adoc
+++ b/docs/man/nng_surveyor_open.3.adoc
@@ -21,6 +21,8 @@ nng_surveyor_open - create surveyor socket
 #include <nng/protocol/survey0/survey.h>
 
 int nng_surveyor0_open(nng_socket *s);
+
+int nng_surveyor0_open_raw(nng_socket *s);
 ----
 
 == DESCRIPTION
@@ -29,9 +31,13 @@ The `nng_surveyor0_open()` function creates a <<nng_surveyor.7#,_surveyor_>>
 version 0 <<nng_socket.5#,socket>> and returns it at the location
 pointed to by _s_.
 
+The `nng_surveyor0_open_raw()` function creates a <<nng_surveyor.7#,_surveyor_>>
+version 0 <<nng_socket.5#,socket>> in
+<<nng.7#raw_mode,raw>> mode and returns it at the location pointed to by _s_.
+
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/src/compat/nanomsg/nn.c
+++ b/src/compat/nanomsg/nn.c
@@ -110,40 +110,81 @@ nn_errno(void)
 static const struct {
 	uint16_t p_id;
 	int (*p_open)(nng_socket *);
+	int (*p_open_raw)(nng_socket *);
 } nn_protocols[] = {
-// clang-format off
 #ifdef NNG_HAVE_BUS0
-	{ NN_BUS, nng_bus0_open },
+	{
+	    .p_id       = NN_BUS,
+	    .p_open     = nng_bus0_open,
+	    .p_open_raw = nng_bus0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_PAIR0
-	{ NN_PAIR, nng_pair0_open },
-#endif
-#ifdef NNG_HAVE_PUSH0
-	{ NN_PUSH, nng_push0_open },
+	{
+	    .p_id       = NN_PAIR,
+	    .p_open     = nng_pair0_open,
+	    .p_open_raw = nng_pair0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_PULL0
-	{ NN_PULL, nng_pull0_open },
+	{
+	    .p_id       = NN_PULL,
+	    .p_open     = nng_pull0_open,
+	    .p_open_raw = nng_pull0_open_raw,
+	},
+#endif
+#ifdef NNG_HAVE_PUSH0
+	{
+	    .p_id       = NN_PUSH,
+	    .p_open     = nng_push0_open,
+	    .p_open_raw = nng_push0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_PUB0
-	{ NN_PUB, nng_pub0_open },
+	{
+	    .p_id       = NN_PUB,
+	    .p_open     = nng_pub0_open,
+	    .p_open_raw = nng_pub0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_SUB0
-	{ NN_SUB, nng_sub0_open },
+	{
+	    .p_id       = NN_SUB,
+	    .p_open     = nng_sub0_open,
+	    .p_open_raw = nng_sub0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_REQ0
-	{ NN_REQ, nng_req0_open },
+	{
+	    .p_id       = NN_REQ,
+	    .p_open     = nng_req0_open,
+	    .p_open_raw = nng_req0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_REP0
-	{ NN_REP, nng_rep0_open },
+	{
+	    .p_id       = NN_REP,
+	    .p_open     = nng_rep0_open,
+	    .p_open_raw = nng_rep0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_SURVEYOR0
-	{ NN_SURVEYOR, nng_surveyor0_open },
+	{
+	    .p_id       = NN_SURVEYOR,
+	    .p_open     = nng_surveyor0_open,
+	    .p_open_raw = nng_surveyor0_open_raw,
+	},
 #endif
 #ifdef NNG_HAVE_RESPONDENT0
-	{ NN_RESPONDENT, nng_respondent0_open },
+	{
+	    .p_id       = NN_RESPONDENT,
+	    .p_open     = nng_respondent0_open,
+	    .p_open_raw = nng_respondent0_open_raw,
+	},
 #endif
-	{ 0, NULL },
-	// clang-format on
+	{
+	    .p_id = 0,
+	},
 };
 
 int
@@ -168,17 +209,16 @@ nn_socket(int domain, int protocol)
 		return (-1);
 	}
 
-	if ((rv = nn_protocols[i].p_open(&sock)) != 0) {
+	if (domain == AF_SP_RAW) {
+		rv = nn_protocols[i].p_open_raw(&sock);
+	} else {
+		rv = nn_protocols[i].p_open(&sock);
+	}
+	if (rv != 0) {
 		nn_seterror(rv);
 		return (-1);
 	}
-	if (domain == AF_SP_RAW) {
-		if ((rv = nng_setopt_bool(sock, NNG_OPT_RAW, true)) != 0) {
-			nn_seterror(rv);
-			nng_close(sock);
-			return (-1);
-		}
-	}
+
 	return ((int) sock);
 }
 

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -105,6 +105,8 @@ nni_device_init(nni_device_data **dp, nni_sock *s1, nni_sock *s2)
 	nni_device_data *dd;
 	int              npath = 2;
 	int              i;
+	bool             raw;
+	size_t           rsz;
 
 	// Specifying either of these as null turns the device into
 	// a loopback reflector.
@@ -120,6 +122,21 @@ nni_device_init(nni_device_data **dp, nni_sock *s1, nni_sock *s2)
 	}
 	if ((nni_sock_peer(s1) != nni_sock_proto(s2)) ||
 	    (nni_sock_peer(s2) != nni_sock_proto(s1))) {
+		return (NNG_EINVAL);
+	}
+
+	raw = false;
+	rsz = sizeof(raw);
+	if (((nni_sock_getopt(s1, NNG_OPT_RAW, &raw, &rsz, NNI_TYPE_BOOL) !=
+	        0)) ||
+	    (!raw)) {
+		return (NNG_EINVAL);
+	}
+
+	rsz = sizeof(raw);
+	if (((nni_sock_getopt(s2, NNG_OPT_RAW, &raw, &rsz, NNI_TYPE_BOOL) !=
+	        0)) ||
+	    (!raw)) {
 		return (NNG_EINVAL);
 	}
 
@@ -201,7 +218,7 @@ nni_device(nni_sock *s1, nni_sock *s2)
 	if ((rv = nni_aio_init(&aio, NULL, NULL)) != 0) {
 		return (rv);
 	}
-	if (nni_device_init(&dd, s1, s2) != 0) {
+	if ((rv = nni_device_init(&dd, s1, s2)) != 0) {
 		nni_aio_fini(aio);
 		return (rv);
 	}

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -127,10 +127,12 @@ struct nni_proto {
 
 // These flags determine which operations make sense.  We use them so that
 // we can reject attempts to create notification fds for operations that make
-// no sense.
+// no sense.  Also, we can detect raw mode, thereby providing handling for
+// that at the socket layer (NNG_PROTO_FLAG_RAW).
 #define NNI_PROTO_FLAG_RCV 1    // Protocol can receive
 #define NNI_PROTO_FLAG_SND 2    // Protocol can send
 #define NNI_PROTO_FLAG_SNDRCV 3 // Protocol can both send & recv
+#define NNI_PROTO_FLAG_RAW 4    // Protocol is raw
 
 // nni_proto_open is called by the protocol to create a socket instance
 // with its ops vector.  The intent is that applications will only see

--- a/src/protocol/bus0/bus.h
+++ b/src/protocol/bus0/bus.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -17,8 +17,14 @@ extern "C" {
 
 NNG_DECL int nng_bus0_open(nng_socket *);
 
+NNG_DECL int nng_bus0_open_raw(nng_socket *);
+
 #ifndef nng_bus_open
 #define nng_bus_open nng_bus0_open
+#endif
+
+#ifndef nng_bus_open_raw
+#define nng_bus_open_raw nng_bus0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/pair0/pair.h
+++ b/src/protocol/pair0/pair.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -17,8 +17,14 @@ extern "C" {
 
 NNG_DECL int nng_pair0_open(nng_socket *);
 
+NNG_DECL int nng_pair0_open_raw(nng_socket *);
+
 #ifndef nng_pair_open
 #define nng_pair_open nng_pair0_open
+#endif
+
+#ifndef nng_pair_open_raw
+#define nng_pair_open_raw nng_pair0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/pair1/pair.h
+++ b/src/protocol/pair1/pair.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_pair1_open(nng_socket *);
+NNG_DECL int nng_pair1_open_raw(nng_socket *);
 
 #ifndef nng_pair_open
 #define nng_pair_open nng_pair1_open
+#endif
+
+#ifndef nng_pair_open_raw
+#define nng_pair_open_raw nng_pair1_open_raw
 #endif
 
 #define NNG_OPT_PAIR1_POLY "pair1:polyamorous"

--- a/src/protocol/pipeline0/pull.h
+++ b/src/protocol/pipeline0/pull.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_pull0_open(nng_socket *);
+NNG_DECL int nng_pull0_open_raw(nng_socket *);
 
 #ifndef nng_pull_open
 #define nng_pull_open nng_pull0_open
+#endif
+
+#ifndef nng_pull_open_raw
+#define nng_pull_open_raw nng_pull0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/pipeline0/push.h
+++ b/src/protocol/pipeline0/push.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_push0_open(nng_socket *);
+NNG_DECL int nng_push0_open_raw(nng_socket *);
 
 #ifndef nng_push_open
 #define nng_push_open nng_push0_open
+#endif
+
+#ifndef nng_push_open_raw
+#define nng_push_open_raw nng_push0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/pubsub0/pub.h
+++ b/src/protocol/pubsub0/pub.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_pub0_open(nng_socket *);
+NNG_DECL int nng_pub0_open_raw(nng_socket *);
 
 #ifndef nng_pub_open
 #define nng_pub_open nng_pub0_open
+#endif
+
+#ifndef nng_pub_open_raw
+#define nng_pub_open_raw nng_pub0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/pubsub0/sub.h
+++ b/src/protocol/pubsub0/sub.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -17,8 +17,14 @@ extern "C" {
 
 NNG_DECL int nng_sub0_open(nng_socket *);
 
+NNG_DECL int nng_sub0_open_raw(nng_socket *);
+
 #ifndef nng_sub_open
 #define nng_sub_open nng_sub0_open
+#endif
+
+#ifndef nng_sub_open_raw
+#define nng_sub_open_raw nng_sub0_open_raw
 #endif
 
 #define NNG_OPT_SUB_SUBSCRIBE "sub:subscribe"

--- a/src/protocol/reqrep0/rep.h
+++ b/src/protocol/reqrep0/rep.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_rep0_open(nng_socket *);
+NNG_DECL int nng_rep0_open_raw(nng_socket *);
 
 #ifndef nng_rep_open
 #define nng_rep_open nng_rep0_open
+#endif
+
+#ifndef nng_rep_open
+#define nng_rep_open_raw nng_rep0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/reqrep0/req.h
+++ b/src/protocol/reqrep0/req.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,13 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_req0_open(nng_socket *);
+NNG_DECL int nng_req0_open_raw(nng_socket *);
 
 #ifndef nng_req_open
 #define nng_req_open nng_req0_open
+#endif
+#ifndef nng_req_open_raw
+#define nng_req_open_raw nng_req0_open_raw
 #endif
 
 #define NNG_OPT_REQ_RESENDTIME "req:resend-time"

--- a/src/protocol/survey0/respond.h
+++ b/src/protocol/survey0/respond.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_respondent0_open(nng_socket *);
+NNG_DECL int nng_respondent0_open_raw(nng_socket *);
 
 #ifndef nng_respondent_open
 #define nng_respondent_open nng_respondent0_open
+#endif
+
+#ifndef nng_respondent_open_raw
+#define nng_respondent_open_raw nng_respondent0_open_raw
 #endif
 
 #ifdef __cplusplus

--- a/src/protocol/survey0/survey.h
+++ b/src/protocol/survey0/survey.h
@@ -1,6 +1,6 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
-// Copyright 2017 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -16,9 +16,14 @@ extern "C" {
 #endif
 
 NNG_DECL int nng_surveyor0_open(nng_socket *);
+NNG_DECL int nng_surveyor0_open_raw(nng_socket *);
 
 #ifndef nng_surveyor_open
 #define nng_surveyor_open nng_surveyor0_open
+#endif
+
+#ifndef nng_surveyor_open_raw
+#define nng_surveyor_open_raw nng_surveyor0_open_raw
 #endif
 
 #define NNG_OPT_SURVEYOR_SURVEYTIME "surveyor:survey-time"

--- a/tests/device.c
+++ b/tests/device.c
@@ -42,6 +42,12 @@ Main({
 		const char *addr1 = "inproc://dev1";
 		const char *addr2 = "inproc://dev2";
 
+		Convey("We cannot create cooked mode device", {
+			nng_socket s1;
+			So(nng_pair1_open(&s1) == 0);
+			Reset({ nng_close(s1); });
+			So(nng_device(s1, s1) == NNG_EINVAL);
+		});
 		Convey("We can create a PAIRv1 device", {
 			nng_socket   dev1;
 			nng_socket   dev2;
@@ -51,11 +57,8 @@ Main({
 			nng_msg *    msg;
 			nng_thread * thr;
 
-			So(nng_pair1_open(&dev1) == 0);
-			So(nng_pair1_open(&dev2) == 0);
-
-			So(nng_setopt_bool(dev1, NNG_OPT_RAW, true) == 0);
-			So(nng_setopt_bool(dev2, NNG_OPT_RAW, true) == 0);
+			So(nng_pair1_open_raw(&dev1) == 0);
+			So(nng_pair1_open_raw(&dev2) == 0);
 
 			struct dev_data ddata;
 			ddata.s1 = dev1;

--- a/tests/pair1.c
+++ b/tests/pair1.c
@@ -101,14 +101,8 @@ TestMain("PAIRv1 protocol", {
 		});
 
 		Convey("Cannot set raw mode after connect", {
-			So(nng_listen(s1, addr, NULL, 0) == 0);
-			So(nng_dial(c1, addr, NULL, 0) == 0);
-			nng_msleep(100);
-
 			So(nng_setopt_bool(s1, NNG_OPT_RAW, true) ==
-			    NNG_ESTATE);
-			So(nng_setopt_bool(c1, NNG_OPT_RAW, false) ==
-			    NNG_ESTATE);
+			    NNG_EREADONLY);
 		});
 
 		Convey("Polyamorous mode is best effort", {
@@ -174,150 +168,6 @@ TestMain("PAIRv1 protocol", {
 
 			So(nng_setopt_bool(s1, NNG_OPT_PAIR1_POLY, true) ==
 			    NNG_ESTATE);
-		});
-
-		Convey("Monogamous raw mode works", {
-			nng_msg *msg;
-			uint32_t hops;
-
-			So(nng_setopt_bool(s1, NNG_OPT_RAW, true) == 0);
-			So(nng_setopt_bool(c1, NNG_OPT_RAW, true) == 0);
-			So(nng_setopt_bool(c2, NNG_OPT_RAW, true) == 0);
-
-			So(nng_listen(s1, addr, NULL, 0) == 0);
-			So(nng_dial(c1, addr, NULL, 0) == 0);
-			nng_msleep(20);
-
-			Convey("Send/recv work", {
-				So(nng_msg_alloc(&msg, 0) == 0);
-				APPENDSTR(msg, "GAMMA");
-				So(nng_msg_header_append_u32(msg, 1) == 0);
-				So(nng_msg_header_len(msg) ==
-				    sizeof(uint32_t));
-				So(nng_sendmsg(c1, msg, 0) == 0);
-				So(nng_recvmsg(s1, &msg, 0) == 0);
-				So(nng_msg_get_pipe(msg) != 0);
-				CHECKSTR(msg, "GAMMA");
-				So(nng_msg_header_len(msg) ==
-				    sizeof(uint32_t));
-				So(nng_msg_header_trim_u32(msg, &hops) == 0);
-				So(hops == 2);
-				nng_msg_free(msg);
-
-				So(nng_msg_alloc(&msg, 0) == 0);
-				APPENDSTR(msg, "EPSILON");
-				So(nng_msg_header_append_u32(msg, 1) == 0);
-				So(nng_sendmsg(s1, msg, 0) == 0);
-				So(nng_recvmsg(c1, &msg, 0) == 0);
-				CHECKSTR(msg, "EPSILON");
-				So(nng_msg_header_len(msg) ==
-				    sizeof(uint32_t));
-				So(nng_msg_header_trim_u32(msg, &hops) == 0);
-				So(nng_msg_get_pipe(msg) != 0);
-				So(hops == 2);
-				nng_msg_free(msg);
-			});
-
-			Convey("Missing raw header fails", {
-				So(nng_msg_alloc(&msg, 0) == 0);
-				So(nng_sendmsg(c1, msg, 0) == 0);
-				So(nng_recvmsg(s1, &msg, 0) == NNG_ETIMEDOUT);
-
-				So(nng_msg_alloc(&msg, 0) == 0);
-				So(nng_msg_append_u32(msg, 0xFEEDFACE) == 0);
-				So(nng_msg_header_append_u32(msg, 1) == 0);
-				So(nng_sendmsg(c1, msg, 0) == 0);
-				So(nng_recvmsg(s1, &msg, 0) == 0);
-				So(nng_msg_trim_u32(msg, &v) == 0);
-				So(v == 0xFEEDFACE);
-				nng_msg_free(msg);
-			});
-
-			Convey("Reserved bits in raw header", {
-
-				Convey("Nonzero bits fail", {
-					So(nng_msg_alloc(&msg, 0) == 0);
-					So(nng_msg_header_append_u32(
-					       msg, 0xDEAD0000) == 0);
-					So(nng_sendmsg(c1, msg, 0) == 0);
-					So(nng_recvmsg(s1, &msg, 0) ==
-					    NNG_ETIMEDOUT);
-				});
-				Convey("Zero bits pass", {
-					So(nng_msg_alloc(&msg, 0) == 0);
-					So(nng_msg_append_u32(
-					       msg, 0xFEEDFACE) == 0);
-					So(nng_msg_header_append_u32(msg, 1) ==
-					    0);
-					So(nng_sendmsg(c1, msg, 0) == 0);
-					So(nng_recvmsg(s1, &msg, 0) == 0);
-					So(nng_msg_trim_u32(msg, &v) == 0);
-					So(v == 0xFEEDFACE);
-					nng_msg_free(msg);
-				});
-			});
-
-			Convey("TTL is honored", {
-				int ttl;
-
-				So(nng_setopt_int(s1, NNG_OPT_MAXTTL, 4) == 0);
-				So(nng_getopt_int(s1, NNG_OPT_MAXTTL, &ttl) ==
-				    0);
-				So(ttl == 4);
-				Convey("Bad TTL bounces", {
-					So(nng_msg_alloc(&msg, 0) == 0);
-					So(nng_msg_header_append_u32(msg, 4) ==
-					    0);
-					So(nng_sendmsg(c1, msg, 0) == 0);
-					So(nng_recvmsg(s1, &msg, 0) ==
-					    NNG_ETIMEDOUT);
-				});
-				Convey("Good TTL passes", {
-					So(nng_msg_alloc(&msg, 0) == 0);
-					So(nng_msg_append_u32(
-					       msg, 0xFEEDFACE) == 0);
-					So(nng_msg_header_append_u32(msg, 3) ==
-					    0);
-					So(nng_sendmsg(c1, msg, 0) == 0);
-					So(nng_recvmsg(s1, &msg, 0) == 0);
-					So(nng_msg_trim_u32(msg, &v) == 0);
-					So(v == 0xFEEDFACE);
-					So(nng_msg_header_trim_u32(msg, &v) ==
-					    0);
-					So(v == 4);
-					nng_msg_free(msg);
-				});
-
-				Convey("Large TTL passes", {
-					ttl = 0xff;
-					So(nng_setopt_int(
-					       s1, NNG_OPT_MAXTTL, 0xff) == 0);
-					So(nng_msg_alloc(&msg, 0) == 0);
-					So(nng_msg_append_u32(msg, 1234) == 0);
-					So(nng_msg_header_append_u32(
-					       msg, 0xfe) == 0);
-					So(nng_sendmsg(c1, msg, 0) == 0);
-					So(nng_recvmsg(s1, &msg, 0) == 0);
-					So(nng_msg_trim_u32(msg, &v) == 0);
-					So(v == 1234);
-					So(nng_msg_header_trim_u32(msg, &v) ==
-					    0);
-					So(v == 0xff);
-					nng_msg_free(msg);
-				});
-
-				Convey("Max TTL fails", {
-					ttl = 0xff;
-					So(nng_setopt_int(
-					       s1, NNG_OPT_MAXTTL, 0xff) == 0);
-					So(nng_msg_alloc(&msg, 0) == 0);
-					So(nng_msg_header_append_u32(
-					       msg, 0xff) == 0);
-					So(nng_sendmsg(c1, msg, 0) == 0);
-					So(nng_recvmsg(s1, &msg, 0) ==
-					    NNG_ETIMEDOUT);
-				});
-			});
 		});
 
 		Convey("We cannot set insane TTLs", {
@@ -428,94 +278,253 @@ TestMain("PAIRv1 protocol", {
 			CHECKSTR(msg, "AGAIN");
 			nng_msg_free(msg);
 		});
+	});
 
-		Convey("Polyamorous raw mode works", {
-			nng_msg *msg;
-			bool     v;
-			uint32_t hops;
-			nng_pipe p1;
-			nng_pipe p2;
+	Convey("Monogamous raw mode works", {
+		nng_msg *msg;
+		uint32_t hops;
 
-			So(nng_getopt_bool(s1, NNG_OPT_PAIR1_POLY, &v) == 0);
-			So(v == 0);
+		So(nng_pair1_open_raw(&s1) == 0);
+		So(nng_pair1_open_raw(&c1) == 0);
+		So(nng_pair1_open_raw(&c2) == 0);
 
-			So(nng_setopt_bool(s1, NNG_OPT_PAIR1_POLY, true) == 0);
-			So(nng_getopt_bool(s1, NNG_OPT_PAIR1_POLY, &v) == 0);
-			So(v == true);
+		Reset({
+			nng_close(s1);
+			nng_close(c1);
+			nng_close(c2);
+		});
 
-			v = false;
-			So(nng_setopt_bool(s1, NNG_OPT_RAW, true) == 0);
-			So(nng_getopt_bool(s1, NNG_OPT_RAW, &v) == 0);
-			So(v == true);
+		tmo = MILLISECOND(300);
+		So(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, tmo) == 0);
+		So(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, tmo) == 0);
+		So(nng_setopt_ms(c2, NNG_OPT_RECVTIMEO, tmo) == 0);
+		tmo = 0;
+		So(nng_getopt_ms(s1, NNG_OPT_RECVTIMEO, &tmo) == 0);
+		So(tmo == MILLISECOND(300));
 
-			So(nng_listen(s1, addr, NULL, 0) == 0);
-			So(nng_dial(c1, addr, NULL, 0) == 0);
-			So(nng_dial(c2, addr, NULL, 0) == 0);
-			nng_msleep(20);
+		So(nng_listen(s1, addr, NULL, 0) == 0);
+		So(nng_dial(c1, addr, NULL, 0) == 0);
+		nng_msleep(20);
 
-			Convey("Send/recv works", {
+		Convey("Send/recv work", {
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "GAMMA");
+			So(nng_msg_header_append_u32(msg, 1) == 0);
+			So(nng_msg_header_len(msg) == sizeof(uint32_t));
+			So(nng_sendmsg(c1, msg, 0) == 0);
+			So(nng_recvmsg(s1, &msg, 0) == 0);
+			So(nng_msg_get_pipe(msg) != 0);
+			CHECKSTR(msg, "GAMMA");
+			So(nng_msg_header_len(msg) == sizeof(uint32_t));
+			So(nng_msg_header_trim_u32(msg, &hops) == 0);
+			So(hops == 2);
+			nng_msg_free(msg);
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "EPSILON");
+			So(nng_msg_header_append_u32(msg, 1) == 0);
+			So(nng_sendmsg(s1, msg, 0) == 0);
+			So(nng_recvmsg(c1, &msg, 0) == 0);
+			CHECKSTR(msg, "EPSILON");
+			So(nng_msg_header_len(msg) == sizeof(uint32_t));
+			So(nng_msg_header_trim_u32(msg, &hops) == 0);
+			So(nng_msg_get_pipe(msg) != 0);
+			So(hops == 2);
+			nng_msg_free(msg);
+		});
+
+		Convey("Missing raw header fails", {
+			So(nng_msg_alloc(&msg, 0) == 0);
+			So(nng_sendmsg(c1, msg, 0) == 0);
+			So(nng_recvmsg(s1, &msg, 0) == NNG_ETIMEDOUT);
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			So(nng_msg_append_u32(msg, 0xFEEDFACE) == 0);
+			So(nng_msg_header_append_u32(msg, 1) == 0);
+			So(nng_sendmsg(c1, msg, 0) == 0);
+			So(nng_recvmsg(s1, &msg, 0) == 0);
+			So(nng_msg_trim_u32(msg, &v) == 0);
+			So(v == 0xFEEDFACE);
+			nng_msg_free(msg);
+		});
+
+		Convey("Reserved bits in raw header", {
+
+			Convey("Nonzero bits fail", {
 				So(nng_msg_alloc(&msg, 0) == 0);
-				APPENDSTR(msg, "ONE");
+				So(nng_msg_header_append_u32(
+				       msg, 0xDEAD0000) == 0);
+				So(nng_sendmsg(c1, msg, 0) == 0);
+				So(nng_recvmsg(s1, &msg, 0) == NNG_ETIMEDOUT);
+			});
+			Convey("Zero bits pass", {
+				So(nng_msg_alloc(&msg, 0) == 0);
+				So(nng_msg_append_u32(msg, 0xFEEDFACE) == 0);
+				So(nng_msg_header_append_u32(msg, 1) == 0);
 				So(nng_sendmsg(c1, msg, 0) == 0);
 				So(nng_recvmsg(s1, &msg, 0) == 0);
-				CHECKSTR(msg, "ONE");
-				p1 = nng_msg_get_pipe(msg);
-				So(p1 != 0);
-				So(nng_msg_header_trim_u32(msg, &hops) == 0);
-				So(hops == 1);
+				So(nng_msg_trim_u32(msg, &v) == 0);
+				So(v == 0xFEEDFACE);
 				nng_msg_free(msg);
+			});
+		});
 
+		Convey("TTL is honored", {
+			int ttl;
+
+			So(nng_setopt_int(s1, NNG_OPT_MAXTTL, 4) == 0);
+			So(nng_getopt_int(s1, NNG_OPT_MAXTTL, &ttl) == 0);
+			So(ttl == 4);
+			Convey("Bad TTL bounces", {
 				So(nng_msg_alloc(&msg, 0) == 0);
-				APPENDSTR(msg, "TWO");
-				So(nng_sendmsg(c2, msg, 0) == 0);
+				So(nng_msg_header_append_u32(msg, 4) == 0);
+				So(nng_sendmsg(c1, msg, 0) == 0);
+				So(nng_recvmsg(s1, &msg, 0) == NNG_ETIMEDOUT);
+			});
+			Convey("Good TTL passes", {
+				So(nng_msg_alloc(&msg, 0) == 0);
+				So(nng_msg_append_u32(msg, 0xFEEDFACE) == 0);
+				So(nng_msg_header_append_u32(msg, 3) == 0);
+				So(nng_sendmsg(c1, msg, 0) == 0);
 				So(nng_recvmsg(s1, &msg, 0) == 0);
-				CHECKSTR(msg, "TWO");
-				p2 = nng_msg_get_pipe(msg);
-				So(p2 != 0);
-				So(nng_msg_header_trim_u32(msg, &hops) == 0);
-				So(hops == 1);
-				nng_msg_free(msg);
-
-				So(p1 != p2);
-
-				So(nng_msg_alloc(&msg, 0) == 0);
-				nng_msg_set_pipe(msg, p1);
-				APPENDSTR(msg, "UNO");
-				So(nng_msg_header_append_u32(msg, 1) == 0);
-				So(nng_sendmsg(s1, msg, 0) == 0);
-				So(nng_recvmsg(c1, &msg, 0) == 0);
-				CHECKSTR(msg, "UNO");
-				nng_msg_free(msg);
-
-				So(nng_msg_alloc(&msg, 0) == 0);
-				nng_msg_set_pipe(msg, p2);
-				APPENDSTR(msg, "DOS");
-				So(nng_msg_header_append_u32(msg, 1) == 0);
-				So(nng_sendmsg(s1, msg, 0) == 0);
-				So(nng_recvmsg(c2, &msg, 0) == 0);
-				CHECKSTR(msg, "DOS");
+				So(nng_msg_trim_u32(msg, &v) == 0);
+				So(v == 0xFEEDFACE);
+				So(nng_msg_header_trim_u32(msg, &v) == 0);
+				So(v == 4);
 				nng_msg_free(msg);
 			});
 
-			Convey("Closed pipes don't work", {
+			Convey("Large TTL passes", {
+				ttl = 0xff;
+				So(nng_setopt_int(s1, NNG_OPT_MAXTTL, 0xff) ==
+				    0);
 				So(nng_msg_alloc(&msg, 0) == 0);
-				APPENDSTR(msg, "ONE");
+				So(nng_msg_append_u32(msg, 1234) == 0);
+				So(nng_msg_header_append_u32(msg, 0xfe) == 0);
 				So(nng_sendmsg(c1, msg, 0) == 0);
 				So(nng_recvmsg(s1, &msg, 0) == 0);
-				CHECKSTR(msg, "ONE");
-				p1 = nng_msg_get_pipe(msg);
-				So(p1 != 0);
+				So(nng_msg_trim_u32(msg, &v) == 0);
+				So(v == 1234);
+				So(nng_msg_header_trim_u32(msg, &v) == 0);
+				So(v == 0xff);
 				nng_msg_free(msg);
-
-				nng_close(c1);
-
-				So(nng_msg_alloc(&msg, 0) == 0);
-				nng_msg_set_pipe(msg, p1);
-				APPENDSTR(msg, "EIN");
-				So(nng_msg_header_append_u32(msg, 1) == 0);
-				So(nng_sendmsg(s1, msg, 0) == 0);
-				So(nng_recvmsg(c2, &msg, 0) == NNG_ETIMEDOUT);
 			});
+
+			Convey("Max TTL fails", {
+				ttl = 0xff;
+				So(nng_setopt_int(s1, NNG_OPT_MAXTTL, 0xff) ==
+				    0);
+				So(nng_msg_alloc(&msg, 0) == 0);
+				So(nng_msg_header_append_u32(msg, 0xff) == 0);
+				So(nng_sendmsg(c1, msg, 0) == 0);
+				So(nng_recvmsg(s1, &msg, 0) == NNG_ETIMEDOUT);
+			});
+		});
+	});
+
+	Convey("Polyamorous raw mode works", {
+		nng_msg *msg;
+		bool     v;
+		uint32_t hops;
+		nng_pipe p1;
+		nng_pipe p2;
+
+		So(nng_pair1_open_raw(&s1) == 0);
+		So(nng_pair1_open(&c1) == 0);
+		So(nng_pair1_open(&c2) == 0);
+
+		Reset({
+			nng_close(s1);
+			nng_close(c1);
+			nng_close(c2);
+		});
+
+		tmo = MILLISECOND(300);
+		So(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, tmo) == 0);
+		So(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, tmo) == 0);
+		So(nng_setopt_ms(c2, NNG_OPT_RECVTIMEO, tmo) == 0);
+		tmo = 0;
+		So(nng_getopt_ms(s1, NNG_OPT_RECVTIMEO, &tmo) == 0);
+		So(tmo == MILLISECOND(300));
+
+		So(nng_getopt_bool(s1, NNG_OPT_PAIR1_POLY, &v) == 0);
+		So(v == 0);
+
+		So(nng_setopt_bool(s1, NNG_OPT_PAIR1_POLY, true) == 0);
+		So(nng_getopt_bool(s1, NNG_OPT_PAIR1_POLY, &v) == 0);
+		So(v == true);
+
+		v = false;
+		So(nng_getopt_bool(s1, NNG_OPT_RAW, &v) == 0);
+		So(v == true);
+
+		So(nng_listen(s1, addr, NULL, 0) == 0);
+		So(nng_dial(c1, addr, NULL, 0) == 0);
+		So(nng_dial(c2, addr, NULL, 0) == 0);
+		nng_msleep(20);
+
+		Convey("Send/recv works", {
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "ONE");
+			So(nng_sendmsg(c1, msg, 0) == 0);
+			So(nng_recvmsg(s1, &msg, 0) == 0);
+			CHECKSTR(msg, "ONE");
+			p1 = nng_msg_get_pipe(msg);
+			So(p1 != 0);
+			So(nng_msg_header_trim_u32(msg, &hops) == 0);
+			So(hops == 1);
+			nng_msg_free(msg);
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "TWO");
+			So(nng_sendmsg(c2, msg, 0) == 0);
+			So(nng_recvmsg(s1, &msg, 0) == 0);
+			CHECKSTR(msg, "TWO");
+			p2 = nng_msg_get_pipe(msg);
+			So(p2 != 0);
+			So(nng_msg_header_trim_u32(msg, &hops) == 0);
+			So(hops == 1);
+			nng_msg_free(msg);
+
+			So(p1 != p2);
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			nng_msg_set_pipe(msg, p1);
+			APPENDSTR(msg, "UNO");
+			So(nng_msg_header_append_u32(msg, 1) == 0);
+			So(nng_sendmsg(s1, msg, 0) == 0);
+			So(nng_recvmsg(c1, &msg, 0) == 0);
+			CHECKSTR(msg, "UNO");
+			nng_msg_free(msg);
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			nng_msg_set_pipe(msg, p2);
+			APPENDSTR(msg, "DOS");
+			So(nng_msg_header_append_u32(msg, 1) == 0);
+			So(nng_sendmsg(s1, msg, 0) == 0);
+			So(nng_recvmsg(c2, &msg, 0) == 0);
+			CHECKSTR(msg, "DOS");
+			nng_msg_free(msg);
+		});
+
+		Convey("Closed pipes don't work", {
+			So(nng_msg_alloc(&msg, 0) == 0);
+			APPENDSTR(msg, "ONE");
+			So(nng_sendmsg(c1, msg, 0) == 0);
+			So(nng_recvmsg(s1, &msg, 0) == 0);
+			CHECKSTR(msg, "ONE");
+			p1 = nng_msg_get_pipe(msg);
+			So(p1 != 0);
+			nng_msg_free(msg);
+
+			nng_close(c1);
+
+			So(nng_msg_alloc(&msg, 0) == 0);
+			nng_msg_set_pipe(msg, p1);
+			APPENDSTR(msg, "EIN");
+			So(nng_msg_header_append_u32(msg, 1) == 0);
+			So(nng_sendmsg(s1, msg, 0) == 0);
+			So(nng_recvmsg(c2, &msg, 0) == NNG_ETIMEDOUT);
 		});
 	});
 })

--- a/tests/sock.c
+++ b/tests/sock.c
@@ -128,11 +128,6 @@ TestMain("Socket Operations", {
 				So(nng_getopt_bool(s1, NNG_OPT_RAW, &raw) ==
 				    0);
 				So(raw == false);
-				So(nng_setopt_bool(s1, NNG_OPT_RAW, true) ==
-				    0);
-				So(nng_getopt_bool(s1, NNG_OPT_RAW, &raw) ==
-				    0);
-				So(raw == true);
 			});
 
 			Convey("URL option works", {
@@ -255,16 +250,9 @@ TestMain("Socket Operations", {
 				       sz) == NNG_EINVAL);
 			});
 
-			Convey("Bogus raw fails", {
-				// Bool type is 1 byte.
-				So(nng_setopt_int(s1, NNG_OPT_RAW, 42) ==
-				    NNG_EBADTYPE);
-				So(nng_setopt_int(s1, NNG_OPT_RAW, -42) ==
-				    NNG_EBADTYPE);
-				So(nng_setopt_int(s1, NNG_OPT_RAW, 0) ==
-				    NNG_EBADTYPE);
-				So(nng_setopt(s1, NNG_OPT_RAW, "abcd", 4) ==
-				    NNG_EINVAL);
+			Convey("Cannot set raw", {
+				So(nng_setopt_bool(s1, NNG_OPT_RAW, true) ==
+				    NNG_EREADONLY);
 			});
 
 			Convey("Unsupported options fail", {


### PR DESCRIPTION
This makes the raw mode something that is immutable, determined
at socket construction.  This is an enabling change for the
separate context support coming soon.

As a result, this is an API breaking change for users of the raw
mode option (NNG_OPT_RAW).  There aren't many of them out there.

Cooked mode is entirely unaffected.

There are changes to tests and documentation included.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
