### PR TITLE
fixes bad address tests in tcp and tls

### DIFF
--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -98,6 +98,7 @@ nni_posix_gai_errno(int rv)
 		return (nni_plat_errno(errno));
 
 	case EAI_NONAME:
+	case EAI_NODATA:
 	case EAI_SERVICE:
 		return (NNG_EADDRINVAL);
 

--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -98,7 +98,9 @@ nni_posix_gai_errno(int rv)
 		return (nni_plat_errno(errno));
 
 	case EAI_NONAME:
+#ifdef EAI_NODATA
 	case EAI_NODATA:
+#endif
 	case EAI_SERVICE:
 		return (NNG_EADDRINVAL);
 


### PR DESCRIPTION
this will fix these two tests failing on my fedora 27 box

[toppk@static build]$  ../build/tests/tcp


Failures:

  * Assertion Failed (Malformed TCP addresses do not panic)
  File: ../tests/tcp.c
  Line: 54
  Test: nng_listen(s1, "tcp://127.0.0.1.32", ((void *)0), 0) == NNG_EADDRINVAL
  
FAIL    ../build/tests/tcp                                     1.093s
[toppk@static build]$  ../build/tests/tls


Failures:

  * Assertion Failed (Malformed TLS addresses do not panic)
  File: ../tests/tls.c
  Line: 259
  Test: nng_listen(s1, "tls+tcp://127.0.0.1.32", ((void *)0), 0) == NNG_EADDRINVAL
  
FAIL    ../build/tests/tls                                     2.531s
[toppk@static build]$ 