### PR TITLE
fixes #308 Close can block

### DIFF
--- a/docs/man/nng_options.5.adoc
+++ b/docs/man/nng_options.5.adoc
@@ -21,7 +21,6 @@ nng_options - socket, dialer, listener, and pipe options
 
 #define NNG_OPT_SOCKNAME   "socket-name"
 #define NNG_OPT_RAW        "raw"
-#define NNG_OPT_LINGER     "linger"
 #define NNG_OPT_RECVBUF    "recv-buffer"
 #define NNG_OPT_SENDBUF    "send-buffer"
 #define NNG_OPT_RECVFD     "recv-fd"
@@ -72,19 +71,6 @@ example there is no single meaningful address for a socket, since sockets
 can have multiple dialers and endpoints associated with them.
 An attempt has been made to include details about such restrictions in the
 description of the option.
-
-[[NNG_OPT_LINGER]]
-((`NNG_OPT_LINGER`))::
-(((lingering)))
-(`<<nng_duration.5#,nng_duration>>`)
-This is the linger time of the socket in milliseconds.
-When this value is non-zero, then the system will
-attempt to defer closing until it has undelivered data, or until the specified
-timeout has expired.
-
-NOTE: Not all transports support lingering, and
-so closing a socket or exiting the application can still result in the loss
-of undelivered messages.
 
 [[NNG_OPT_LOCADDR]]
 ((`NNG_OPT_LOCADDR`))::

--- a/src/core/msgqueue.h
+++ b/src/core/msgqueue.h
@@ -17,10 +17,6 @@
 // they are a thread-safe way to pass messages between subsystems.  They
 // do have additional capabilities though.
 //
-// A closed message queue cannot be written to, but if there are messages
-// still in it and it is draining, it can be read from.  This permits
-// linger operations to work.
-//
 // Message queues can be closed many times safely.
 //
 // Readers & writers in a message queue can be woken either by a timeout
@@ -107,12 +103,6 @@ extern void nni_msgq_set_cb(nni_msgq *, nni_msgq_cb, void *);
 // message queue will return NNG_ECLOSED.  Messages inside the queue
 // are freed.  Unlike closing a go channel, this operation is idempotent.
 extern void nni_msgq_close(nni_msgq *);
-
-// nni_msgq_drain is like nng_msgq_close, except that reads
-// against the queue are permitted for up to the time limit.  The
-// operation blocks until either the queue is empty, or the timeout
-// has expired.  Any messages still in the queue at the timeout are freed.
-extern void nni_msgq_drain(nni_msgq *, nni_time);
 
 // nni_msgq_resize resizes the message queue; messages already in the queue
 // will be preserved as long as there is room.  Messages that are dropped

--- a/src/nng.h
+++ b/src/nng.h
@@ -554,7 +554,6 @@ enum nng_flag_enum {
 // Options.
 #define NNG_OPT_SOCKNAME "socket-name"
 #define NNG_OPT_RAW "raw"
-#define NNG_OPT_LINGER "linger"
 #define NNG_OPT_RECVBUF "recv-buffer"
 #define NNG_OPT_SENDBUF "send-buffer"
 #define NNG_OPT_RECVFD "recv-fd"

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -48,7 +48,6 @@ struct nni_tcp_ep {
 	nni_plat_tcp_ep *tep;
 	uint16_t         proto;
 	size_t           rcvmax;
-	nni_duration     linger;
 	nni_aio *        aio;
 	nni_aio *        user_aio;
 	nni_url *        url;
@@ -795,26 +794,6 @@ nni_tcp_ep_getopt_recvmaxsz(void *arg, void *v, size_t *szp, int typ)
 	return (nni_copyout_size(ep->rcvmax, v, szp, typ));
 }
 
-static int
-nni_tcp_ep_setopt_linger(void *arg, const void *v, size_t sz, int typ)
-{
-	nni_tcp_ep * ep = arg;
-	nng_duration val;
-	int          rv;
-
-	if (((rv = nni_copyin_ms(&val, v, sz, typ)) == 0) && (ep != NULL)) {
-		ep->linger = val;
-	}
-	return (rv);
-}
-
-static int
-nni_tcp_ep_getopt_linger(void *arg, void *v, size_t *szp, int typ)
-{
-	nni_tcp_ep *ep = arg;
-	return (nni_copyout_ms(ep->linger, v, szp, typ));
-}
-
 static nni_tran_pipe_option nni_tcp_pipe_options[] = {
 	{
 	    .po_name   = NNG_OPT_LOCADDR,
@@ -854,12 +833,6 @@ static nni_tran_ep_option nni_tcp_ep_options[] = {
 	    .eo_type   = NNI_TYPE_STRING,
 	    .eo_getopt = nni_tcp_ep_getopt_url,
 	    .eo_setopt = NULL,
-	},
-	{
-	    .eo_name   = NNG_OPT_LINGER,
-	    .eo_type   = NNI_TYPE_DURATION,
-	    .eo_getopt = nni_tcp_ep_getopt_linger,
-	    .eo_setopt = nni_tcp_ep_setopt_linger,
 	},
 	// terminate list
 	{

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -54,7 +54,6 @@ struct nni_tls_ep {
 	nni_plat_tcp_ep *tep;
 	uint16_t         proto;
 	size_t           rcvmax;
-	nni_duration     linger;
 	int              authmode;
 	nni_aio *        aio;
 	nni_aio *        user_aio;
@@ -819,26 +818,6 @@ nni_tls_ep_getopt_recvmaxsz(void *arg, void *v, size_t *szp, int typ)
 }
 
 static int
-nni_tls_ep_setopt_linger(void *arg, const void *v, size_t sz, int typ)
-{
-	nni_tls_ep * ep = arg;
-	nng_duration val;
-	int          rv;
-
-	if (((rv = nni_copyin_ms(&val, v, sz, typ)) == 0) && (ep != NULL)) {
-		ep->linger = val;
-	}
-	return (rv);
-}
-
-static int
-nni_tls_ep_getopt_linger(void *arg, void *v, size_t *szp, int typ)
-{
-	nni_tls_ep *ep = arg;
-	return (nni_copyout_ms(ep->linger, v, szp, typ));
-}
-
-static int
 tls_setopt_config(void *arg, const void *data, size_t sz, int typ)
 {
 	nni_tls_ep *    ep = arg;
@@ -982,12 +961,6 @@ static nni_tran_ep_option nni_tls_ep_options[] = {
 	    .eo_type   = NNI_TYPE_SIZE,
 	    .eo_getopt = nni_tls_ep_getopt_recvmaxsz,
 	    .eo_setopt = nni_tls_ep_setopt_recvmaxsz,
-	},
-	{
-	    .eo_name   = NNG_OPT_LINGER,
-	    .eo_type   = NNI_TYPE_DURATION,
-	    .eo_getopt = nni_tls_ep_getopt_linger,
-	    .eo_setopt = nni_tls_ep_setopt_linger,
 	},
 	{
 	    .eo_name   = NNG_OPT_URL,

--- a/tests/sock.c
+++ b/tests/sock.c
@@ -471,10 +471,10 @@ TestMain("Socket Operations", {
 			So(nng_listener_getopt_int(1999, NNG_OPT_RAW, &i) ==
 			    NNG_ENOENT);
 
-			So(nng_dialer_getopt_ms(1999, NNG_OPT_LINGER, &t) ==
+			So(nng_dialer_getopt_ms(1999, NNG_OPT_RECVTIMEO, &t) ==
 			    NNG_ENOENT);
-			So(nng_listener_getopt_ms(1999, NNG_OPT_LINGER, &t) ==
-			    NNG_ENOENT);
+			So(nng_listener_getopt_ms(
+			       1999, NNG_OPT_SENDTIMEO, &t) == NNG_ENOENT);
 
 		});
 


### PR DESCRIPTION
Ultimately, this just removes the support for lingering altogether.
Based on prior experience, lingering has always been unreliable, and
was removed in legacy libnanomsg ages ago.

The problem is that operating system support for lingering is very
inconsistent at best, and for some transports the very concept is somewhat
meaningless.

Making things worse, we were never able to adequately capture an exit()
event from another thread -- so lingering was always a false promise.

Applications that need to be sure that messages are delivered should
either include an ack in their protocol, use req/rep (which has an ack),
or inject a suitable delay of their own.

For things going over local networks, an extra delay of 100 msec should
be sufficient *most of the time*.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
