### PR TITLE
fixes #419 want to nni_aio_stop without blocking

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -44,9 +44,16 @@ extern void nni_aio_fini_cb(nni_aio *);
 // best pattern is to call nni_aio_stop on all linked aios, before calling
 // nni_aio_fini on any of them.  This function will block until any
 // callbacks are executed, and therefore it should never be executed
-// from a callback itself.  (To abort operations without blocking
-// use nni_aio_cancel instead.)
+// from a callback itself.  (To abort operations in a non-blocking close()
+// context, use nni_aio_close instead.)
 extern void nni_aio_stop(nni_aio *);
+
+// nni_aio_close closes the aio. This will abort any in-flight operation on
+// the aio with NNG_ECLOSED.  It will also cause nni_aio_begin() to return
+// NNG_ECLOSED, but the call to nni_aio_begin() will automatically also
+// queue a completion callback on the aio with NNG_ECLOSED.  This operation
+// does not wait for existing operations to complete.
+extern void nni_aio_close(nni_aio *);
 
 // nni_aio_set_data sets user data.  This should only be done by the
 // consumer, initiating the I/O.  The intention is to be able to store

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -45,9 +45,9 @@ typedef struct nni_ctx              nni_ctx;
 typedef struct nni_ep               nni_ep;
 typedef struct nni_pipe             nni_pipe;
 typedef struct nni_tran             nni_tran;
-typedef struct nni_tran_ep          nni_tran_ep;
+typedef struct nni_tran_ep_ops      nni_tran_ep_ops;
 typedef struct nni_tran_ep_option   nni_tran_ep_option;
-typedef struct nni_tran_pipe        nni_tran_pipe;
+typedef struct nni_tran_pipe_ops    nni_tran_pipe_ops;
 typedef struct nni_tran_pipe_option nni_tran_pipe_option;
 
 typedef struct nni_proto_ctx_option  nni_proto_ctx_option;

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -120,8 +120,8 @@ nni_device_init(nni_device_data **dp, nni_sock *s1, nni_sock *s2)
 	if ((s1 == NULL) || (s2 == NULL)) {
 		return (NNG_EINVAL);
 	}
-	if ((nni_sock_peer(s1) != nni_sock_proto(s2)) ||
-	    (nni_sock_peer(s2) != nni_sock_proto(s1))) {
+	if ((nni_sock_peer_id(s1) != nni_sock_proto_id(s2)) ||
+	    (nni_sock_peer_id(s2) != nni_sock_proto_id(s1))) {
 		return (NNG_EINVAL);
 	}
 

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -249,10 +249,10 @@ nni_ep_shutdown(nni_ep *ep)
 	nni_mtx_unlock(&ep->ep_mtx);
 
 	// Abort any remaining in-flight operations.
-	nni_aio_abort(ep->ep_acc_aio, NNG_ECLOSED);
-	nni_aio_abort(ep->ep_con_aio, NNG_ECLOSED);
-	nni_aio_abort(ep->ep_con_syn, NNG_ECLOSED);
-	nni_aio_abort(ep->ep_tmo_aio, NNG_ECLOSED);
+	nni_aio_close(ep->ep_acc_aio);
+	nni_aio_close(ep->ep_con_aio);
+	nni_aio_close(ep->ep_con_syn);
+	nni_aio_close(ep->ep_tmo_aio);
 
 	// Stop the underlying transport.
 	ep->ep_ops.ep_close(ep->ep_data);
@@ -276,10 +276,10 @@ nni_ep_close(nni_ep *ep)
 
 	nni_ep_shutdown(ep);
 
-	nni_aio_stop(ep->ep_acc_aio);
-	nni_aio_stop(ep->ep_con_aio);
-	nni_aio_stop(ep->ep_con_syn);
-	nni_aio_stop(ep->ep_tmo_aio);
+	nni_aio_close(ep->ep_acc_aio);
+	nni_aio_close(ep->ep_con_aio);
+	nni_aio_close(ep->ep_con_syn);
+	nni_aio_close(ep->ep_tmo_aio);
 
 	nni_mtx_lock(&ep->ep_mtx);
 	NNI_LIST_FOREACH (&ep->ep_pipes, p) {

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -15,30 +15,30 @@
 #include <string.h>
 
 struct nni_ep {
-	nni_tran_ep   ep_ops;  // transport ops
-	nni_tran *    ep_tran; // transport pointer
-	void *        ep_data; // transport private
-	uint64_t      ep_id;   // endpoint id
-	nni_list_node ep_node; // per socket list
-	nni_sock *    ep_sock;
-	nni_url *     ep_url;
-	int           ep_mode;
-	int           ep_started;
-	int           ep_closed;  // full shutdown
-	int           ep_closing; // close pending (waiting on refcnt)
-	int           ep_refcnt;
-	int           ep_tmo_run;
-	nni_mtx       ep_mtx;
-	nni_cv        ep_cv;
-	nni_list      ep_pipes;
-	nni_aio *     ep_acc_aio;
-	nni_aio *     ep_con_aio;
-	nni_aio *     ep_con_syn;  // used for sync connect
-	nni_aio *     ep_tmo_aio;  // backoff timer
-	nni_duration  ep_maxrtime; // maximum time for reconnect
-	nni_duration  ep_currtime; // current time for reconnect
-	nni_duration  ep_inirtime; // initial time for reconnect
-	nni_time      ep_conntime; // time of last good connect
+	nni_tran_ep_ops ep_ops;  // transport ops
+	nni_tran *      ep_tran; // transport pointer
+	void *          ep_data; // transport private
+	uint64_t        ep_id;   // endpoint id
+	nni_list_node   ep_node; // per socket list
+	nni_sock *      ep_sock;
+	nni_url *       ep_url;
+	int             ep_mode;
+	int             ep_started;
+	int             ep_closed;  // full shutdown
+	int             ep_closing; // close pending (waiting on refcnt)
+	int             ep_refcnt;
+	int             ep_tmo_run;
+	nni_mtx         ep_mtx;
+	nni_cv          ep_cv;
+	nni_list        ep_pipes;
+	nni_aio *       ep_acc_aio;
+	nni_aio *       ep_con_aio;
+	nni_aio *       ep_con_syn;  // used for sync connect
+	nni_aio *       ep_tmo_aio;  // backoff timer
+	nni_duration    ep_maxrtime; // maximum time for reconnect
+	nni_duration    ep_currtime; // current time for reconnect
+	nni_duration    ep_inirtime; // initial time for reconnect
+	nni_time        ep_conntime; // time of last good connect
 };
 
 // Functionality related to end points.

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -68,12 +68,12 @@ nni_fini(void)
 		}
 		nni_mtx_unlock(&nni_init_mtx);
 	}
+	nni_reap_sys_fini(); // must be before timer and aio (expire)
 	nni_tran_sys_fini();
 	nni_proto_sys_fini();
 	nni_pipe_sys_fini();
 	nni_ep_sys_fini();
 	nni_sock_sys_fini();
-	nni_reap_sys_fini(); // must be before timer and aio (expire)
 	nni_random_sys_fini();
 	nni_aio_sys_fini();
 	nni_timer_sys_fini();

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -205,7 +205,7 @@ nni_pipe_close(nni_pipe *p)
 	nni_mtx_unlock(&p->p_mtx);
 
 	// abort any pending negotiation/start process.
-	nni_aio_abort(p->p_start_aio, NNG_ECLOSED);
+	nni_aio_close(p->p_start_aio);
 }
 
 bool

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -18,21 +18,22 @@
 // performed in the context of the protocol.
 
 struct nni_pipe {
-	uint32_t      p_id;
-	nni_tran_pipe p_tran_ops;
-	void *        p_tran_data;
-	void *        p_proto_data;
-	nni_list_node p_sock_node;
-	nni_list_node p_ep_node;
-	nni_sock *    p_sock;
-	nni_ep *      p_ep;
-	bool          p_closed;
-	bool          p_stop;
-	int           p_refcnt;
-	nni_mtx       p_mtx;
-	nni_cv        p_cv;
-	nni_list_node p_reap_node;
-	nni_aio *     p_start_aio;
+	uint32_t           p_id;
+	nni_tran_pipe_ops  p_tran_ops;
+	nni_proto_pipe_ops p_proto_ops;
+	void *             p_tran_data;
+	void *             p_proto_data;
+	nni_list_node      p_sock_node;
+	nni_list_node      p_ep_node;
+	nni_sock *         p_sock;
+	nni_ep *           p_ep;
+	bool               p_closed;
+	bool               p_stop;
+	int                p_refcnt;
+	nni_mtx            p_mtx;
+	nni_cv             p_cv;
+	nni_list_node      p_reap_node;
+	nni_aio *          p_start_aio;
 };
 
 static nni_idhash *nni_pipes;
@@ -126,6 +127,10 @@ nni_pipe_destroy(nni_pipe *p)
 	}
 	nni_mtx_unlock(&nni_pipe_lk);
 
+	if (p->p_proto_data != NULL) {
+		p->p_proto_ops.pipe_fini(p->p_proto_data);
+	}
+
 	if (p->p_tran_data != NULL) {
 		p->p_tran_ops.p_fini(p->p_tran_data);
 	}
@@ -197,15 +202,17 @@ nni_pipe_close(nni_pipe *p)
 	}
 	p->p_closed = true;
 
+	// abort any pending negotiation/start process.
+	nni_aio_close(p->p_start_aio);
+
+	p->p_proto_ops.pipe_stop(p->p_proto_data);
+
 	// Close the underlying transport.
 	if (p->p_tran_data != NULL) {
 		p->p_tran_ops.p_close(p->p_tran_data);
 	}
 
 	nni_mtx_unlock(&p->p_mtx);
-
-	// abort any pending negotiation/start process.
-	nni_aio_close(p->p_start_aio);
 }
 
 bool
@@ -222,7 +229,6 @@ void
 nni_pipe_stop(nni_pipe *p)
 {
 	// Guard against recursive calls.
-	nni_pipe_close(p);
 	nni_mtx_lock(&p->p_mtx);
 	if (p->p_stop) {
 		nni_mtx_unlock(&p->p_mtx);
@@ -230,6 +236,7 @@ nni_pipe_stop(nni_pipe *p)
 	}
 	p->p_stop = true;
 	nni_mtx_unlock(&p->p_mtx);
+	nni_pipe_close(p);
 
 	// Put it on the reaplist for async cleanup
 	nni_mtx_lock(&nni_pipe_reap_lk);
@@ -250,12 +257,9 @@ nni_pipe_start_cb(void *arg)
 	nni_pipe *p   = arg;
 	nni_aio * aio = p->p_start_aio;
 
-	if (nni_aio_result(aio) != 0) {
-		nni_pipe_stop(p);
-		return;
-	}
-
-	if (nni_sock_pipe_start(p->p_sock, p) != 0) {
+	if ((nni_aio_result(aio) != 0) ||
+	    (nni_sock_pipe_start(p->p_sock, p) != 0) ||
+	    (p->p_proto_ops.pipe_start(p->p_proto_data) != 0)) {
 		nni_pipe_stop(p);
 	}
 }
@@ -263,10 +267,11 @@ nni_pipe_start_cb(void *arg)
 int
 nni_pipe_create(nni_ep *ep, void *tdata)
 {
-	nni_pipe *p;
-	int       rv;
-	nni_tran *tran = nni_ep_tran(ep);
-	nni_sock *sock = nni_ep_sock(ep);
+	nni_pipe *          p;
+	int                 rv;
+	nni_tran *          tran = nni_ep_tran(ep);
+	nni_sock *          sock = nni_ep_sock(ep);
+	nni_proto_pipe_ops *pops = nni_sock_proto_pipe_ops(sock);
 
 	if ((p = NNI_ALLOC_STRUCT(p)) == NULL) {
 		// In this case we just toss the pipe...
@@ -276,6 +281,7 @@ nni_pipe_create(nni_ep *ep, void *tdata)
 
 	// Make a private copy of the transport ops.
 	p->p_tran_ops   = *tran->tran_pipe;
+	p->p_proto_ops  = *pops;
 	p->p_tran_data  = tdata;
 	p->p_proto_data = NULL;
 	p->p_ep         = ep;
@@ -290,6 +296,7 @@ nni_pipe_create(nni_ep *ep, void *tdata)
 
 	nni_mtx_init(&p->p_mtx);
 	nni_cv_init(&p->p_cv, &nni_pipe_lk);
+
 	if ((rv = nni_aio_init(&p->p_start_aio, nni_pipe_start_cb, p)) == 0) {
 		uint64_t id;
 		nni_mtx_lock(&nni_pipe_lk);
@@ -299,8 +306,17 @@ nni_pipe_create(nni_ep *ep, void *tdata)
 		nni_mtx_unlock(&nni_pipe_lk);
 	}
 
-	if ((rv != 0) || ((rv = nni_ep_pipe_add(ep, p)) != 0) ||
-	    ((rv = nni_sock_pipe_add(sock, p)) != 0)) {
+	if (rv == 0) {
+		void *sdata = nni_sock_proto_data(sock);
+		rv          = pops->pipe_init(&p->p_proto_data, p, sdata);
+	}
+	if (rv == 0) {
+		rv = nni_ep_pipe_add(ep, p);
+	}
+	if (rv == 0) {
+		rv = nni_sock_pipe_add(sock, p);
+	}
+	if (rv != 0) {
 		nni_pipe_destroy(p);
 	}
 
@@ -336,12 +352,6 @@ void *
 nni_pipe_get_proto_data(nni_pipe *p)
 {
 	return (p->p_proto_data);
-}
-
-void
-nni_pipe_set_proto_data(nni_pipe *p, void *data)
-{
-	p->p_proto_data = data;
 }
 
 void

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -253,13 +253,13 @@ nni_sock_setopt_sockname(nni_sock *s, const void *buf, size_t sz, int typ)
 static int
 nni_sock_getopt_proto(nni_sock *s, void *buf, size_t *szp, int typ)
 {
-	return (nni_copyout_int(nni_sock_proto(s), buf, szp, typ));
+	return (nni_copyout_int(nni_sock_proto_id(s), buf, szp, typ));
 }
 
 static int
 nni_sock_getopt_peer(nni_sock *s, void *buf, size_t *szp, int typ)
 {
-	return (nni_copyout_int(nni_sock_peer(s), buf, szp, typ));
+	return (nni_copyout_int(nni_sock_peer_id(s), buf, szp, typ));
 }
 
 static int
@@ -434,9 +434,7 @@ nni_sock_rele(nni_sock *s)
 int
 nni_sock_pipe_start(nni_sock *s, nni_pipe *pipe)
 {
-	void *      pdata = nni_pipe_get_proto_data(pipe);
 	nng_pipe_cb cb;
-	int         rv;
 
 	NNI_ASSERT(s != NULL);
 	nni_mtx_lock(&s->s_mx);
@@ -464,26 +462,13 @@ nni_sock_pipe_start(nni_sock *s, nni_pipe *pipe)
 		return (NNG_ECLOSED);
 	}
 
-	// Protocol can reject for other reasons.
-	// This must be the last operation, until this point
-	// the protocol has not actually "seen" the pipe.
-	rv = s->s_pipe_ops.pipe_start(pdata);
-
 	nni_mtx_unlock(&s->s_mx);
-	return (rv);
+	return (0);
 }
 
 int
 nni_sock_pipe_add(nni_sock *s, nni_pipe *p)
 {
-	int   rv;
-	void *pdata;
-
-	if ((rv = s->s_pipe_ops.pipe_init(&pdata, p, s->s_data)) != 0) {
-		return (rv);
-	}
-	nni_pipe_set_proto_data(p, pdata);
-
 	// Initialize protocol pipe data.
 	nni_mtx_lock(&s->s_mx);
 	if (s->s_closing) {
@@ -503,7 +488,6 @@ nni_sock_pipe_add(nni_sock *s, nni_pipe *p)
 void
 nni_sock_pipe_remove(nni_sock *sock, nni_pipe *pipe)
 {
-	void *      pdata;
 	nng_pipe_cb cb;
 
 	nni_mtx_lock(&sock->s_mx);
@@ -515,14 +499,8 @@ nni_sock_pipe_remove(nni_sock *sock, nni_pipe *pipe)
 		cb(p, NNG_PIPE_REM, arg);
 		nni_mtx_lock(&sock->s_mx);
 	}
-	pdata = nni_pipe_get_proto_data(pipe);
-	if (pdata != NULL) {
-		sock->s_pipe_ops.pipe_stop(pdata);
-		nni_pipe_set_proto_data(pipe, NULL);
-		if (nni_list_active(&sock->s_pipes, pipe)) {
-			nni_list_remove(&sock->s_pipes, pipe);
-		}
-		sock->s_pipe_ops.pipe_fini(pdata);
+	if (nni_list_active(&sock->s_pipes, pipe)) {
+		nni_list_remove(&sock->s_pipes, pipe);
 	}
 	if (sock->s_closing && nni_list_empty(&sock->s_pipes)) {
 		nni_cv_wake(&sock->s_cv);
@@ -588,9 +566,6 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 
 	NNI_ASSERT(s->s_sock_ops.sock_open != NULL);
 	NNI_ASSERT(s->s_sock_ops.sock_close != NULL);
-
-	NNI_ASSERT(s->s_pipe_ops.pipe_start != NULL);
-	NNI_ASSERT(s->s_pipe_ops.pipe_stop != NULL);
 
 	NNI_LIST_NODE_INIT(&s->s_node);
 	NNI_LIST_INIT(&s->s_options, nni_sockopt, node);
@@ -883,15 +858,15 @@ nni_sock_recv(nni_sock *sock, nni_aio *aio)
 	sock->s_sock_ops.sock_recv(sock->s_data, aio);
 }
 
-// nni_sock_protocol returns the socket's 16-bit protocol number.
+// nni_sock_proto_id returns the socket's 16-bit protocol number.
 uint16_t
-nni_sock_proto(nni_sock *sock)
+nni_sock_proto_id(nni_sock *sock)
 {
 	return (sock->s_self_id.p_id);
 }
 
 uint16_t
-nni_sock_peer(nni_sock *sock)
+nni_sock_peer_id(nni_sock *sock)
 {
 	return (sock->s_peer_id.p_id);
 }
@@ -906,6 +881,18 @@ const char *
 nni_sock_peer_name(nni_sock *sock)
 {
 	return (sock->s_peer_id.p_name);
+}
+
+struct nni_proto_pipe_ops *
+nni_sock_proto_pipe_ops(nni_sock *sock)
+{
+	return (&sock->s_pipe_ops);
+}
+
+void *
+nni_sock_proto_data(nni_sock *sock)
+{
+	return (sock->s_data);
 }
 
 void

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -20,10 +20,13 @@ extern int         nni_sock_open(nni_sock **, const nni_proto *);
 extern void        nni_sock_close(nni_sock *);
 extern void        nni_sock_closeall(void);
 extern int         nni_sock_shutdown(nni_sock *);
-extern uint16_t    nni_sock_proto(nni_sock *);
-extern uint16_t    nni_sock_peer(nni_sock *);
+extern uint16_t    nni_sock_proto_id(nni_sock *);
+extern uint16_t    nni_sock_peer_id(nni_sock *);
 extern const char *nni_sock_proto_name(nni_sock *);
 extern const char *nni_sock_peer_name(nni_sock *);
+extern void *      nni_sock_proto_data(nni_sock *);
+
+extern struct nni_proto_pipe_ops *nni_sock_proto_pipe_ops(nni_sock *);
 
 extern int nni_sock_setopt(
     nni_sock *, const char *, const void *, size_t, int);

--- a/src/core/transport.c
+++ b/src/core/transport.c
@@ -118,7 +118,7 @@ nni_tran_chkopt(const char *name, const void *v, size_t sz, int typ)
 
 	nni_mtx_lock(&nni_tran_lk);
 	NNI_LIST_FOREACH (&nni_tran_list, t) {
-		const nni_tran_ep *       ep;
+		const nni_tran_ep_ops *   ep;
 		const nni_tran_ep_option *eo;
 
 		// Generally we look for endpoint options.

--- a/src/core/transport.h
+++ b/src/core/transport.h
@@ -23,10 +23,10 @@ struct nni_tran {
 	const char *tran_scheme;
 
 	// tran_ep links our endpoint-specific operations.
-	const nni_tran_ep *tran_ep;
+	const nni_tran_ep_ops *tran_ep;
 
 	// tran_pipe links our pipe-specific operations.
-	const nni_tran_pipe *tran_pipe;
+	const nni_tran_pipe_ops *tran_pipe;
 
 	// tran_init, if not NULL, is called once during library
 	// initialization.
@@ -77,7 +77,7 @@ struct nni_tran_ep_option {
 // For a given endpoint, the framework holds a lock so that each entry
 // point is run exclusively of the others. (Transports must still guard
 // against any asynchronous operations they manage themselves, though.)
-struct nni_tran_ep {
+struct nni_tran_ep_ops {
 	// ep_init creates a vanilla endpoint. The value created is
 	// used for the first argument for all other endpoint functions.
 	int (*ep_init)(void **, nni_url *, nni_sock *, int);
@@ -128,7 +128,7 @@ struct nni_tran_pipe_option {
 // with socket locks held, so it is forbidden for the transport to call
 // back into the socket at this point.  (Which is one reason pointers back
 // to socket or even enclosing pipe state, are not provided.)
-struct nni_tran_pipe {
+struct nni_tran_pipe_ops {
 	// p_fini destroys the pipe.  This should clean up all local
 	// resources, including closing files and freeing memory, used by
 	// the pipe.  After this call returns, the system will not make

--- a/src/protocol/bus0/bus.c
+++ b/src/protocol/bus0/bus.c
@@ -177,18 +177,18 @@ bus0_pipe_stop(void *arg)
 	bus0_pipe *p = arg;
 	bus0_sock *s = p->psock;
 
+	nni_mtx_lock(&s->mtx);
+	if (nni_list_active(&s->pipes, p)) {
+		nni_list_remove(&s->pipes, p);
+	}
+	nni_mtx_unlock(&s->mtx);
+
 	nni_aio_close(p->aio_getq);
 	nni_aio_close(p->aio_send);
 	nni_aio_close(p->aio_recv);
 	nni_aio_close(p->aio_putq);
 
 	nni_msgq_close(p->sendq);
-
-	nni_mtx_lock(&s->mtx);
-	if (nni_list_active(&s->pipes, p)) {
-		nni_list_remove(&s->pipes, p);
-	}
-	nni_mtx_unlock(&s->mtx);
 }
 
 static void

--- a/src/protocol/pair0/pair.c
+++ b/src/protocol/pair0/pair.c
@@ -81,6 +81,10 @@ static void
 pair0_pipe_fini(void *arg)
 {
 	pair0_pipe *p = arg;
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_getq);
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -140,10 +144,10 @@ pair0_pipe_stop(void *arg)
 	pair0_pipe *p = arg;
 	pair0_sock *s = p->psock;
 
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_getq);
 
 	nni_mtx_lock(&s->mtx);
 	if (s->ppipe == p) {

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -120,6 +120,11 @@ static void
 pair1_pipe_fini(void *arg)
 {
 	pair1_pipe *p = arg;
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_getq);
+
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_putq);
@@ -203,16 +208,17 @@ pair1_pipe_stop(void *arg)
 	pair1_pipe *p = arg;
 	pair1_sock *s = p->psock;
 
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_getq);
+
 	nni_mtx_lock(&s->mtx);
 	nni_idhash_remove(s->pipes, nni_pipe_id(p->npipe));
 	nni_list_node_remove(&p->node);
 	nni_mtx_unlock(&s->mtx);
 
 	nni_msgq_close(p->sendq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_getq);
 }
 
 static void
@@ -405,7 +411,8 @@ pair1_sock_open(void *arg)
 static void
 pair1_sock_close(void *arg)
 {
-	NNI_ARG_UNUSED(arg);
+	pair1_sock *s = arg;
+	nni_aio_close(s->aio_getq);
 }
 
 static int

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -72,9 +72,6 @@ pull0_pipe_fini(void *arg)
 {
 	pull0_pipe *p = arg;
 
-	nni_aio_stop(p->putq_aio);
-	nni_aio_stop(p->recv_aio);
-
 	nni_aio_fini(p->putq_aio);
 	nni_aio_fini(p->recv_aio);
 	NNI_FREE_STRUCT(p);
@@ -113,12 +110,21 @@ pull0_pipe_start(void *arg)
 }
 
 static void
-pull0_pipe_stop(void *arg)
+pull0_pipe_close(void *arg)
 {
 	pull0_pipe *p = arg;
 
 	nni_aio_close(p->putq_aio);
 	nni_aio_close(p->recv_aio);
+}
+
+static void
+pull0_pipe_stop(void *arg)
+{
+	pull0_pipe *p = arg;
+
+	nni_aio_stop(p->putq_aio);
+	nni_aio_stop(p->recv_aio);
 }
 
 static void
@@ -201,6 +207,7 @@ static nni_proto_pipe_ops pull0_pipe_ops = {
 	.pipe_init  = pull0_pipe_init,
 	.pipe_fini  = pull0_pipe_fini,
 	.pipe_start = pull0_pipe_start,
+	.pipe_close = pull0_pipe_close,
 	.pipe_stop  = pull0_pipe_stop,
 };
 

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -72,6 +72,9 @@ pull0_pipe_fini(void *arg)
 {
 	pull0_pipe *p = arg;
 
+	nni_aio_stop(p->putq_aio);
+	nni_aio_stop(p->recv_aio);
+
 	nni_aio_fini(p->putq_aio);
 	nni_aio_fini(p->recv_aio);
 	NNI_FREE_STRUCT(p);
@@ -114,8 +117,8 @@ pull0_pipe_stop(void *arg)
 {
 	pull0_pipe *p = arg;
 
-	nni_aio_stop(p->putq_aio);
-	nni_aio_stop(p->recv_aio);
+	nni_aio_close(p->putq_aio);
+	nni_aio_close(p->recv_aio);
 }
 
 static void

--- a/src/protocol/pipeline0/push.c
+++ b/src/protocol/pipeline0/push.c
@@ -86,6 +86,9 @@ static void
 push0_pipe_fini(void *arg)
 {
 	push0_pipe *p = arg;
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_getq);
 
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
@@ -140,9 +143,9 @@ push0_pipe_stop(void *arg)
 {
 	push0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_getq);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_getq);
 }
 
 static void

--- a/src/protocol/pipeline0/push.c
+++ b/src/protocol/pipeline0/push.c
@@ -86,9 +86,6 @@ static void
 push0_pipe_fini(void *arg)
 {
 	push0_pipe *p = arg;
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_getq);
 
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
@@ -139,13 +136,22 @@ push0_pipe_start(void *arg)
 }
 
 static void
-push0_pipe_stop(void *arg)
+push0_pipe_close(void *arg)
 {
 	push0_pipe *p = arg;
 
 	nni_aio_close(p->aio_recv);
 	nni_aio_close(p->aio_send);
 	nni_aio_close(p->aio_getq);
+}
+static void
+push0_pipe_stop(void *arg)
+{
+	push0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_getq);
 }
 
 static void
@@ -217,6 +223,7 @@ static nni_proto_pipe_ops push0_pipe_ops = {
 	.pipe_init  = push0_pipe_init,
 	.pipe_fini  = push0_pipe_fini,
 	.pipe_start = push0_pipe_start,
+	.pipe_close = push0_pipe_close,
 	.pipe_stop  = push0_pipe_stop,
 };
 

--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -61,7 +61,6 @@ pub0_sock_fini(void *arg)
 {
 	pub0_sock *s = arg;
 
-	nni_aio_stop(s->aio_getq);
 	nni_aio_fini(s->aio_getq);
 	nni_mtx_fini(&s->mtx);
 	NNI_FREE_STRUCT(s);
@@ -103,13 +102,18 @@ pub0_sock_close(void *arg)
 {
 	pub0_sock *s = arg;
 
-	nni_aio_abort(s->aio_getq, NNG_ECLOSED);
+	nni_aio_close(s->aio_getq);
 }
 
 static void
 pub0_pipe_fini(void *arg)
 {
 	pub0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -169,9 +173,9 @@ pub0_pipe_stop(void *arg)
 	pub0_pipe *p = arg;
 	pub0_sock *s = p->pub;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
 
 	nni_msgq_close(p->sendq);
 

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -102,6 +102,8 @@ static void
 sub0_pipe_fini(void *arg)
 {
 	sub0_pipe *p = arg;
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_recv);
@@ -143,8 +145,8 @@ sub0_pipe_stop(void *arg)
 {
 	sub0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_recv);
 }
 
 static void

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -102,8 +102,6 @@ static void
 sub0_pipe_fini(void *arg)
 {
 	sub0_pipe *p = arg;
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_recv);
@@ -141,12 +139,21 @@ sub0_pipe_start(void *arg)
 }
 
 static void
-sub0_pipe_stop(void *arg)
+sub0_pipe_close(void *arg)
 {
 	sub0_pipe *p = arg;
 
 	nni_aio_close(p->aio_putq);
 	nni_aio_close(p->aio_recv);
+}
+
+static void
+sub0_pipe_stop(void *arg)
+{
+	sub0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
 }
 
 static void
@@ -340,6 +347,7 @@ static nni_proto_pipe_ops sub0_pipe_ops = {
 	.pipe_init  = sub0_pipe_init,
 	.pipe_fini  = sub0_pipe_fini,
 	.pipe_start = sub0_pipe_start,
+	.pipe_close = sub0_pipe_close,
 	.pipe_stop  = sub0_pipe_stop,
 };
 

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -302,6 +302,9 @@ rep0_pipe_fini(void *arg)
 {
 	rep0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
 	NNI_FREE_STRUCT(p);
@@ -354,6 +357,9 @@ rep0_pipe_stop(void *arg)
 	rep0_sock *s = p->rep;
 	rep0_ctx * ctx;
 
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+
 	nni_mtx_lock(&s->lk);
 	while ((ctx = nni_list_first(&p->sendq)) != NULL) {
 		nni_aio *aio;
@@ -375,9 +381,6 @@ rep0_pipe_stop(void *arg)
 	}
 	nni_idhash_remove(s->pipes, nni_pipe_id(p->pipe));
 	nni_mtx_unlock(&s->lk);
-
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
 }
 
 static void

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -358,6 +358,10 @@ rep0_pipe_close(void *arg)
 	nni_aio_close(p->aio_recv);
 
 	nni_mtx_lock(&s->lk);
+	if (nni_list_active(&s->recvpipes, p)) {
+		nni_list_remove(&s->recvpipes, p);
+	}
+
 	while ((ctx = nni_list_first(&p->sendq)) != NULL) {
 		nni_aio *aio;
 		nni_msg *msg;

--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -190,6 +190,9 @@ req0_pipe_fini(void *arg)
 {
 	req0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
 	NNI_FREE_STRUCT(p);
@@ -249,11 +252,8 @@ req0_pipe_stop(void *arg)
 	req0_sock *s = p->req;
 	req0_ctx * ctx;
 
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-
-	// At this point there should not be any further AIOs running.
-	// Further, any completion tasks have completed.
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_send);
 
 	nni_mtx_lock(&s->mtx);
 	// This removes the node from either busypipes or readypipes.

--- a/src/protocol/reqrep0/xreq.c
+++ b/src/protocol/reqrep0/xreq.c
@@ -93,6 +93,10 @@ static void
 xreq0_pipe_fini(void *arg)
 {
 	xreq0_pipe *p = arg;
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_putq);
@@ -144,13 +148,10 @@ xreq0_pipe_stop(void *arg)
 {
 	xreq0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-
-	// At this point there should not be any further AIOs running.
-	// Further, any completion tasks have completed.
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_send);
 }
 
 // For raw mode we can just let the pipes "contend" via getq to get a

--- a/src/protocol/reqrep0/xreq.c
+++ b/src/protocol/reqrep0/xreq.c
@@ -93,10 +93,6 @@ static void
 xreq0_pipe_fini(void *arg)
 {
 	xreq0_pipe *p = arg;
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_putq);
@@ -145,6 +141,17 @@ xreq0_pipe_start(void *arg)
 
 static void
 xreq0_pipe_stop(void *arg)
+{
+	xreq0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+}
+
+static void
+xreq0_pipe_close(void *arg)
 {
 	xreq0_pipe *p = arg;
 
@@ -278,6 +285,7 @@ static nni_proto_pipe_ops xreq0_pipe_ops = {
 	.pipe_init  = xreq0_pipe_init,
 	.pipe_fini  = xreq0_pipe_fini,
 	.pipe_start = xreq0_pipe_start,
+	.pipe_close = xreq0_pipe_close,
 	.pipe_stop  = xreq0_pipe_stop,
 };
 

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -294,6 +294,8 @@ static void
 resp0_pipe_fini(void *arg)
 {
 	resp0_pipe *p = arg;
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -351,6 +353,9 @@ resp0_pipe_stop(void *arg)
 	resp0_sock *s = p->psock;
 	resp0_ctx * ctx;
 
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+
 	nni_mtx_lock(&s->mtx);
 	while ((ctx = nni_list_first(&p->sendq)) != NULL) {
 		nni_aio *aio;
@@ -370,9 +375,6 @@ resp0_pipe_stop(void *arg)
 	}
 	nni_idhash_remove(s->pipes, p->id);
 	nni_mtx_unlock(&s->mtx);
-
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
 }
 
 static void

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -287,9 +287,6 @@ static void
 surv0_pipe_fini(void *arg)
 {
 	surv0_pipe *p = arg;
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -341,7 +338,7 @@ surv0_pipe_start(void *arg)
 }
 
 static void
-surv0_pipe_stop(void *arg)
+surv0_pipe_close(void *arg)
 {
 	surv0_pipe *p = arg;
 	surv0_sock *s = p->sock;
@@ -357,6 +354,17 @@ surv0_pipe_stop(void *arg)
 		nni_list_remove(&s->pipes, p);
 	}
 	nni_mtx_unlock(&s->mtx);
+}
+
+static void
+surv0_pipe_stop(void *arg)
+{
+	surv0_pipe *p = arg;
+
+	surv0_pipe_close(p);
+	nni_aio_wait(p->aio_getq);
+	nni_aio_wait(p->aio_send);
+	nni_aio_wait(p->aio_recv);
 }
 
 static void
@@ -535,6 +543,7 @@ static nni_proto_pipe_ops surv0_pipe_ops = {
 	.pipe_init  = surv0_pipe_init,
 	.pipe_fini  = surv0_pipe_fini,
 	.pipe_start = surv0_pipe_start,
+	.pipe_close = surv0_pipe_close,
 	.pipe_stop  = surv0_pipe_stop,
 };
 

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -287,6 +287,9 @@ static void
 surv0_pipe_fini(void *arg)
 {
 	surv0_pipe *p = arg;
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -343,9 +346,9 @@ surv0_pipe_stop(void *arg)
 	surv0_pipe *p = arg;
 	surv0_sock *s = p->sock;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
 
 	nni_msgq_close(p->sendq);
 

--- a/src/protocol/survey0/xsurvey.c
+++ b/src/protocol/survey0/xsurvey.c
@@ -111,11 +111,6 @@ xsurv0_pipe_fini(void *arg)
 {
 	xsurv0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
-
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -170,7 +165,7 @@ xsurv0_pipe_start(void *arg)
 }
 
 static void
-xsurv0_pipe_stop(void *arg)
+xsurv0_pipe_close(void *arg)
 {
 	xsurv0_pipe *p = arg;
 	xsurv0_sock *s = p->psock;
@@ -187,6 +182,18 @@ xsurv0_pipe_stop(void *arg)
 		nni_list_remove(&s->pipes, p);
 	}
 	nni_mtx_unlock(&s->mtx);
+}
+
+static void
+xsurv0_pipe_stop(void *arg)
+{
+	xsurv0_pipe *p = arg;
+
+	xsurv0_pipe_close(p);
+	nni_aio_wait(p->aio_getq);
+	nni_aio_wait(p->aio_send);
+	nni_aio_wait(p->aio_recv);
+	nni_aio_wait(p->aio_putq);
 }
 
 static void
@@ -342,6 +349,7 @@ static nni_proto_pipe_ops xsurv0_pipe_ops = {
 	.pipe_init  = xsurv0_pipe_init,
 	.pipe_fini  = xsurv0_pipe_fini,
 	.pipe_start = xsurv0_pipe_start,
+	.pipe_close = xsurv0_pipe_close,
 	.pipe_stop  = xsurv0_pipe_stop,
 };
 

--- a/src/protocol/survey0/xsurvey.c
+++ b/src/protocol/survey0/xsurvey.c
@@ -61,7 +61,6 @@ xsurv0_sock_fini(void *arg)
 {
 	xsurv0_sock *s = arg;
 
-	nni_aio_stop(s->aio_getq);
 	nni_aio_fini(s->aio_getq);
 	nni_mtx_fini(&s->mtx);
 	NNI_FREE_STRUCT(s);
@@ -104,13 +103,18 @@ xsurv0_sock_close(void *arg)
 {
 	xsurv0_sock *s = arg;
 
-	nni_aio_abort(s->aio_getq, NNG_ECLOSED);
+	nni_aio_close(s->aio_getq);
 }
 
 static void
 xsurv0_pipe_fini(void *arg)
 {
 	xsurv0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -171,10 +175,10 @@ xsurv0_pipe_stop(void *arg)
 	xsurv0_pipe *p = arg;
 	xsurv0_sock *s = p->psock;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
 
 	nni_msgq_close(p->sendq);
 

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -110,22 +110,27 @@ http_close(nni_http_conn *conn)
 	}
 
 	conn->closed = true;
-	if (nni_list_first(&conn->wrq)) {
-		nni_aio_abort(conn->wr_aio, NNG_ECLOSED);
-		// Abort all operations except the one in flight.
-		while ((aio = nni_list_last(&conn->wrq)) !=
-		    nni_list_first(&conn->wrq)) {
-			nni_aio_list_remove(aio);
-			nni_aio_finish_error(aio, NNG_ECLOSED);
-		}
+
+	nni_aio_close(conn->wr_aio);
+	nni_aio_close(conn->rd_aio);
+
+	if ((aio = conn->rd_uaio) != NULL) {
+		conn->rd_uaio = NULL;
+		nni_aio_finish_error(aio, NNG_ECLOSED);
 	}
-	if (nni_list_first(&conn->rdq)) {
-		nni_aio_abort(conn->rd_aio, NNG_ECLOSED);
-		while ((aio = nni_list_last(&conn->rdq)) !=
-		    nni_list_first(&conn->rdq)) {
-			nni_aio_list_remove(aio);
-			nni_aio_finish_error(aio, NNG_ECLOSED);
-		}
+	if ((aio = conn->wr_uaio) != NULL) {
+		conn->wr_uaio = NULL;
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+	}
+
+	// Abort all operations except the one in flight.
+	while ((aio = nni_list_first(&conn->wrq)) != NULL) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+	}
+	while ((aio = nni_list_first(&conn->rdq)) != NULL) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
 	}
 
 	if (conn->sock != NULL) {
@@ -657,6 +662,8 @@ nni_http_tls_verified(nni_http_conn *conn)
 void
 nni_http_conn_fini(nni_http_conn *conn)
 {
+	nni_aio_stop(conn->wr_aio);
+	nni_aio_stop(conn->rd_aio);
 	nni_mtx_lock(&conn->mtx);
 	http_close(conn);
 	if ((conn->sock != NULL) && (conn->fini != NULL)) {
@@ -664,8 +671,6 @@ nni_http_conn_fini(nni_http_conn *conn)
 		conn->sock = NULL;
 	}
 	nni_mtx_unlock(&conn->mtx);
-	nni_aio_stop(conn->wr_aio);
-	nni_aio_stop(conn->rd_aio);
 	nni_aio_fini(conn->wr_aio);
 	nni_aio_fini(conn->rd_aio);
 	nni_free(conn->rd_buf, conn->rd_bufsz);

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -229,12 +229,6 @@ http_sconn_reap(void *arg)
 }
 
 static void
-http_sconn_fini(http_sconn *sc)
-{
-	nni_reap(&sc->reap, http_sconn_reap, sc);
-}
-
-static void
 http_sconn_close_locked(http_sconn *sc)
 {
 	nni_http_conn *conn;
@@ -245,15 +239,15 @@ http_sconn_close_locked(http_sconn *sc)
 	NNI_ASSERT(!sc->finished);
 
 	sc->closed = true;
-	nni_aio_abort(sc->rxaio, NNG_ECLOSED);
-	nni_aio_abort(sc->txaio, NNG_ECLOSED);
-	nni_aio_abort(sc->txdataio, NNG_ECLOSED);
-	nni_aio_abort(sc->cbaio, NNG_ECLOSED);
+	nni_aio_close(sc->rxaio);
+	nni_aio_close(sc->txaio);
+	nni_aio_close(sc->txdataio);
+	nni_aio_close(sc->cbaio);
 
 	if ((conn = sc->conn) != NULL) {
 		nni_http_conn_close(conn);
 	}
-	http_sconn_fini(sc);
+	nni_reap(&sc->reap, http_sconn_reap, sc);
 }
 
 static void

--- a/src/supplemental/tls/mbedtls/tls.c
+++ b/src/supplemental/tls/mbedtls/tls.c
@@ -748,6 +748,9 @@ nni_tls_close(nni_tls *tp)
 {
 	nni_aio *aio;
 
+	nni_aio_close(tp->tcp_send);
+	nni_aio_close(tp->tcp_recv);
+
 	nni_mtx_lock(&tp->lk);
 	tp->tls_closed = true;
 

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -198,7 +198,7 @@ nni_inproc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	}
 
 	ep->mode  = mode;
-	ep->proto = nni_sock_proto(sock);
+	ep->proto = nni_sock_proto_id(sock);
 	NNI_LIST_INIT(&ep->clients, nni_inproc_ep, node);
 	nni_aio_list_init(&ep->aios);
 
@@ -442,7 +442,7 @@ static nni_tran_pipe_option nni_inproc_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_inproc_pipe_ops = {
+static nni_tran_pipe_ops nni_inproc_pipe_ops = {
 	.p_fini    = nni_inproc_pipe_fini,
 	.p_send    = nni_inproc_pipe_send,
 	.p_recv    = nni_inproc_pipe_recv,
@@ -458,7 +458,7 @@ static nni_tran_ep_option nni_inproc_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_inproc_ep_ops = {
+static nni_tran_ep_ops nni_inproc_ep_ops = {
 	.ep_init    = nni_inproc_ep_init,
 	.ep_fini    = nni_inproc_ep_fini,
 	.ep_connect = nni_inproc_ep_connect,

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -634,7 +634,7 @@ nni_ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 		nni_ipc_ep_fini(ep);
 		return (rv);
 	}
-	ep->proto = nni_sock_proto(sock);
+	ep->proto = nni_sock_proto_id(sock);
 
 	*epp = ep;
 	return (0);
@@ -863,7 +863,7 @@ static nni_tran_pipe_option nni_ipc_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_ipc_pipe_ops = {
+static nni_tran_pipe_ops nni_ipc_pipe_ops = {
 	.p_fini    = nni_ipc_pipe_fini,
 	.p_start   = nni_ipc_pipe_start,
 	.p_send    = nni_ipc_pipe_send,
@@ -904,7 +904,7 @@ static nni_tran_ep_option nni_ipc_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_ipc_ep_ops = {
+static nni_tran_ep_ops nni_ipc_ep_ops = {
 	.ep_init    = nni_ipc_ep_init,
 	.ep_fini    = nni_ipc_ep_fini,
 	.ep_connect = nni_ipc_ep_connect,

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -81,6 +81,10 @@ nni_ipc_pipe_close(void *arg)
 {
 	nni_ipc_pipe *pipe = arg;
 
+	nni_aio_close(pipe->rxaio);
+	nni_aio_close(pipe->txaio);
+	nni_aio_close(pipe->negaio);
+
 	nni_plat_ipc_pipe_close(pipe->ipp);
 }
 
@@ -645,7 +649,7 @@ nni_ipc_ep_close(void *arg)
 	nni_plat_ipc_ep_close(ep->iep);
 	nni_mtx_unlock(&ep->mtx);
 
-	nni_aio_stop(ep->aio);
+	nni_aio_close(ep->aio);
 }
 
 static int

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -654,7 +654,7 @@ nni_tcp_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 		nni_tcp_ep_fini(ep);
 		return (rv);
 	}
-	ep->proto     = nni_sock_proto(sock);
+	ep->proto     = nni_sock_proto_id(sock);
 	ep->mode      = mode;
 	ep->nodelay   = true;
 	ep->keepalive = false;
@@ -888,7 +888,7 @@ static nni_tran_pipe_option nni_tcp_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_tcp_pipe_ops = {
+static nni_tran_pipe_ops nni_tcp_pipe_ops = {
 	.p_fini    = nni_tcp_pipe_fini,
 	.p_start   = nni_tcp_pipe_start,
 	.p_send    = nni_tcp_pipe_send,
@@ -929,7 +929,7 @@ static nni_tran_ep_option nni_tcp_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_tcp_ep_ops = {
+static nni_tran_ep_ops nni_tcp_ep_ops = {
 	.ep_init    = nni_tcp_ep_init,
 	.ep_fini    = nni_tcp_ep_fini,
 	.ep_connect = nni_tcp_ep_connect,

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -81,9 +81,13 @@ nni_tcp_tran_fini(void)
 static void
 nni_tcp_pipe_close(void *arg)
 {
-	nni_tcp_pipe *pipe = arg;
+	nni_tcp_pipe *p = arg;
 
-	nni_plat_tcp_pipe_close(pipe->tpp);
+	nni_aio_close(p->rxaio);
+	nni_aio_close(p->txaio);
+	nni_aio_close(p->negaio);
+
+	nni_plat_tcp_pipe_close(p->tpp);
 }
 
 static void
@@ -668,7 +672,7 @@ nni_tcp_ep_close(void *arg)
 	nni_plat_tcp_ep_close(ep->tep);
 	nni_mtx_unlock(&ep->mtx);
 
-	nni_aio_stop(ep->aio);
+	nni_aio_close(ep->aio);
 }
 
 static int

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -676,7 +676,7 @@ nni_tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 			return (rv);
 		}
 	}
-	ep->proto    = nni_sock_proto(sock);
+	ep->proto    = nni_sock_proto_id(sock);
 	ep->authmode = authmode;
 
 	*epp = ep;
@@ -1016,7 +1016,7 @@ static nni_tran_pipe_option nni_tls_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_tls_pipe_ops = {
+static nni_tran_pipe_ops nni_tls_pipe_ops = {
 	.p_fini    = nni_tls_pipe_fini,
 	.p_start   = nni_tls_pipe_start,
 	.p_send    = nni_tls_pipe_send,
@@ -1087,7 +1087,7 @@ static nni_tran_ep_option nni_tls_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_tls_ep_ops = {
+static nni_tran_ep_ops nni_tls_ep_ops = {
 	.ep_init    = nni_tls_ep_init,
 	.ep_fini    = nni_tls_ep_fini,
 	.ep_connect = nni_tls_ep_connect,

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -91,6 +91,10 @@ nni_tls_pipe_close(void *arg)
 {
 	nni_tls_pipe *p = arg;
 
+	nni_aio_close(p->rxaio);
+	nni_aio_close(p->txaio);
+	nni_aio_close(p->negaio);
+
 	nni_tls_close(p->tls);
 }
 

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -195,6 +195,9 @@ ws_pipe_close(void *arg)
 {
 	ws_pipe *p = arg;
 
+	nni_aio_close(p->rxaio);
+	nni_aio_close(p->txaio);
+
 	nni_mtx_lock(&p->mtx);
 	nni_ws_close(p->ws);
 	nni_mtx_unlock(&p->mtx);

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -572,7 +572,7 @@ static nni_tran_pipe_option ws_pipe_options[] = {
 	}
 };
 
-static nni_tran_pipe ws_pipe_ops = {
+static nni_tran_pipe_ops ws_pipe_ops = {
 	.p_fini    = ws_pipe_fini,
 	.p_send    = ws_pipe_send,
 	.p_recv    = ws_pipe_recv,
@@ -734,8 +734,8 @@ ws_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	nni_aio_list_init(&ep->aios);
 
 	ep->mode   = mode;
-	ep->lproto = nni_sock_proto(sock);
-	ep->rproto = nni_sock_peer(sock);
+	ep->lproto = nni_sock_proto_id(sock);
+	ep->rproto = nni_sock_peer_id(sock);
 
 	if (mode == NNI_EP_MODE_DIAL) {
 		pname = nni_sock_peer_name(sock);
@@ -779,7 +779,7 @@ ws_tran_fini(void)
 {
 }
 
-static nni_tran_ep ws_ep_ops = {
+static nni_tran_ep_ops ws_ep_ops = {
 	.ep_init    = ws_ep_init,
 	.ep_fini    = ws_ep_fini,
 	.ep_connect = ws_ep_connect,
@@ -999,7 +999,7 @@ static nni_tran_ep_option wss_ep_options[] = {
 	},
 };
 
-static nni_tran_ep wss_ep_ops = {
+static nni_tran_ep_ops wss_ep_ops = {
 	.ep_init    = ws_ep_init,
 	.ep_fini    = ws_ep_fini,
 	.ep_connect = ws_ep_connect,

--- a/src/transport/zerotier/zerotier.c
+++ b/src/transport/zerotier/zerotier.c
@@ -2170,7 +2170,7 @@ zt_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	ep->ze_ping_time  = zt_ping_time;
 	ep->ze_conn_time  = zt_conn_time;
 	ep->ze_conn_tries = zt_conn_tries;
-	ep->ze_proto      = nni_sock_proto(sock);
+	ep->ze_proto      = nni_sock_proto_id(sock);
 
 	nni_aio_list_init(&ep->ze_aios);
 
@@ -2858,7 +2858,7 @@ static nni_tran_pipe_option zt_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe zt_pipe_ops = {
+static nni_tran_pipe_ops zt_pipe_ops = {
 	.p_fini    = zt_pipe_fini,
 	.p_start   = zt_pipe_start,
 	.p_send    = zt_pipe_send,
@@ -2953,7 +2953,7 @@ static nni_tran_ep_option zt_ep_options[] = {
 	},
 };
 
-static nni_tran_ep zt_ep_ops = {
+static nni_tran_ep_ops zt_ep_ops = {
 	.ep_init    = zt_ep_init,
 	.ep_fini    = zt_ep_fini,
 	.ep_connect = zt_ep_connect,

--- a/tests/reqstress.c
+++ b/tests/reqstress.c
@@ -157,6 +157,7 @@ req_client(void *arg)
 		}
 
 		if ((rv = nng_sendmsg(req, msg, 0)) != 0) {
+			nng_msg_free(msg);
 			error(c, "sendmsg", rv);
 			return;
 		}
@@ -169,6 +170,7 @@ req_client(void *arg)
 
 		if (strcmp(nng_msg_body(msg), buf) != 0) {
 			error(c, "mismatched message", NNG_EINTERNAL);
+			nng_msg_free(msg);
 			return;
 		}
 
@@ -226,7 +228,22 @@ reqrep_test(int ntests)
 }
 
 Main({
-	int i;
+	int   i;
+	int   tmo;
+	char *str;
+
+	atexit(nng_fini);
+
+	if (((str = ConveyGetEnv("STRESSTIME")) == NULL) ||
+	    ((tmo = atoi(str)) < 1)) {
+		tmo = 30;
+	}
+	// We have to keep this relatively low by default because some
+	// platforms don't support large numbers of threads.
+	if (((str = ConveyGetEnv("STRESSCASES")) == NULL) ||
+	    ((ncases = atoi(str)) < 1)) {
+		ncases = 32;
+	}
 
 	// Each run should truly be random.
 	srand((int) time(NULL));
@@ -234,10 +251,6 @@ Main({
 	// Reduce the likelihood of address in use conflicts between
 	// subsequent runs.
 	next_port += (rand() % 100) * 100;
-
-	// We have to keep this relatively low because some platforms
-	// don't support large numbers of threads.
-	ncases = 32;
 
 	i = ncases;
 
@@ -251,8 +264,8 @@ Main({
 		i -= x;
 	}
 
-	dprintf("WAITING for 30 sec...\n");
-	nng_msleep(30000); // sleep 30 sec
+	dprintf("WAITING for %d sec...\n", tmo);
+	nng_msleep(tmo * 1000); // sleep 30 sec
 	nng_closeall();
 
 	Test("Req/Rep Stress", {


### PR DESCRIPTION
This actually introduces an nni_aio_close() API that causes
nni_aio_begin to return NNG_ECLOSED, while scheduling a callback
on the AIO to do an NNG_ECLOSED as well.  This should be called
in non-blocking close() contexts instead of nni_aio_stop(), and
the cases where we call nni_aio_fini() multiple times are updated
updated to add nni_aio_stop() calls on all "interlinked" aios before
finalizing them.

Furthermore, we call nni_aio_close() as soon as practical in the
close path.  This closes an annoying race condition where the
callback from a lower subsystem could wind up rescheduling an
operation that we wanted to abort.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
