### PR TITLE
fixes #419 want to nni_aio_stop without blocking

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -42,6 +42,12 @@ extern void nni_aio_fini(nni_aio *);
 // use nni_aio_cancel instead.)
 extern void nni_aio_stop(nni_aio *);
 
+// nni_aio_close closes the aio for further activity. It aborts any in-progress
+// transaction (if it can), and future calls nni_aio_begin or nni_aio_schedule
+// with both result in NNG_ECLOSED. The expectation is that protocols call this
+// for all their aios in a stop routine, before calling fini on any of them.
+extern void nni_aio_close(nni_aio *);
+
 // nni_aio_set_data sets user data.  This should only be done by the
 // consumer, initiating the I/O.  The intention is to be able to store
 // additional data for use when the operation callback is executed.

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -45,9 +45,9 @@ typedef struct nni_ctx              nni_ctx;
 typedef struct nni_ep               nni_ep;
 typedef struct nni_pipe             nni_pipe;
 typedef struct nni_tran             nni_tran;
-typedef struct nni_tran_ep          nni_tran_ep;
+typedef struct nni_tran_ep_ops      nni_tran_ep_ops;
 typedef struct nni_tran_ep_option   nni_tran_ep_option;
-typedef struct nni_tran_pipe        nni_tran_pipe;
+typedef struct nni_tran_pipe_ops    nni_tran_pipe_ops;
 typedef struct nni_tran_pipe_option nni_tran_pipe_option;
 
 typedef struct nni_proto_ctx_option  nni_proto_ctx_option;

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -120,8 +120,8 @@ nni_device_init(nni_device_data **dp, nni_sock *s1, nni_sock *s2)
 	if ((s1 == NULL) || (s2 == NULL)) {
 		return (NNG_EINVAL);
 	}
-	if ((nni_sock_peer(s1) != nni_sock_proto(s2)) ||
-	    (nni_sock_peer(s2) != nni_sock_proto(s1))) {
+	if ((nni_sock_peer_id(s1) != nni_sock_proto_id(s2)) ||
+	    (nni_sock_peer_id(s2) != nni_sock_proto_id(s1))) {
 		return (NNG_EINVAL);
 	}
 

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -249,10 +249,10 @@ nni_ep_shutdown(nni_ep *ep)
 	nni_mtx_unlock(&ep->ep_mtx);
 
 	// Abort any remaining in-flight operations.
-	nni_aio_abort(ep->ep_acc_aio, NNG_ECLOSED);
-	nni_aio_abort(ep->ep_con_aio, NNG_ECLOSED);
-	nni_aio_abort(ep->ep_con_syn, NNG_ECLOSED);
-	nni_aio_abort(ep->ep_tmo_aio, NNG_ECLOSED);
+	nni_aio_close(ep->ep_acc_aio);
+	nni_aio_close(ep->ep_con_aio);
+	nni_aio_close(ep->ep_con_syn);
+	nni_aio_close(ep->ep_tmo_aio);
 
 	// Stop the underlying transport.
 	ep->ep_ops.ep_close(ep->ep_data);
@@ -276,10 +276,10 @@ nni_ep_close(nni_ep *ep)
 
 	nni_ep_shutdown(ep);
 
-	nni_aio_stop(ep->ep_acc_aio);
-	nni_aio_stop(ep->ep_con_aio);
-	nni_aio_stop(ep->ep_con_syn);
-	nni_aio_stop(ep->ep_tmo_aio);
+	nni_aio_close(ep->ep_acc_aio);
+	nni_aio_close(ep->ep_con_aio);
+	nni_aio_close(ep->ep_con_syn);
+	nni_aio_close(ep->ep_tmo_aio);
 
 	nni_mtx_lock(&ep->ep_mtx);
 	NNI_LIST_FOREACH (&ep->ep_pipes, p) {

--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -15,30 +15,30 @@
 #include <string.h>
 
 struct nni_ep {
-	nni_tran_ep   ep_ops;  // transport ops
-	nni_tran *    ep_tran; // transport pointer
-	void *        ep_data; // transport private
-	uint64_t      ep_id;   // endpoint id
-	nni_list_node ep_node; // per socket list
-	nni_sock *    ep_sock;
-	nni_url *     ep_url;
-	int           ep_mode;
-	int           ep_started;
-	int           ep_closed;  // full shutdown
-	int           ep_closing; // close pending (waiting on refcnt)
-	int           ep_refcnt;
-	bool          ep_tmo_run;
-	nni_mtx       ep_mtx;
-	nni_cv        ep_cv;
-	nni_list      ep_pipes;
-	nni_aio *     ep_acc_aio;
-	nni_aio *     ep_con_aio;
-	nni_aio *     ep_con_syn;  // used for sync connect
-	nni_aio *     ep_tmo_aio;  // backoff timer
-	nni_duration  ep_maxrtime; // maximum time for reconnect
-	nni_duration  ep_currtime; // current time for reconnect
-	nni_duration  ep_inirtime; // initial time for reconnect
-	nni_time      ep_conntime; // time of last good connect
+	nni_tran_ep_ops ep_ops;  // transport ops
+	nni_tran *      ep_tran; // transport pointer
+	void *          ep_data; // transport private
+	uint64_t        ep_id;   // endpoint id
+	nni_list_node   ep_node; // per socket list
+	nni_sock *      ep_sock;
+	nni_url *       ep_url;
+	int             ep_mode;
+	int             ep_started;
+	int             ep_closed;  // full shutdown
+	int             ep_closing; // close pending (waiting on refcnt)
+	int             ep_refcnt;
+	bool            ep_tmo_run;
+	nni_mtx         ep_mtx;
+	nni_cv          ep_cv;
+	nni_list        ep_pipes;
+	nni_aio *       ep_acc_aio;
+	nni_aio *       ep_con_aio;
+	nni_aio *       ep_con_syn;  // used for sync connect
+	nni_aio *       ep_tmo_aio;  // backoff timer
+	nni_duration    ep_maxrtime; // maximum time for reconnect
+	nni_duration    ep_currtime; // current time for reconnect
+	nni_duration    ep_inirtime; // initial time for reconnect
+	nni_time        ep_conntime; // time of last good connect
 };
 
 // Functionality related to end points.

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -205,7 +205,7 @@ nni_pipe_close(nni_pipe *p)
 	nni_mtx_unlock(&p->p_mtx);
 
 	// abort any pending negotiation/start process.
-	nni_aio_abort(p->p_start_aio, NNG_ECLOSED);
+	nni_aio_close(p->p_start_aio);
 }
 
 bool

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -65,7 +65,6 @@ extern int nni_pipe_getopt(nni_pipe *, const char *, void *, size_t *, int);
 // nni_pipe_get_proto_data gets the protocol private data set with the
 // nni_pipe_set_proto_data function.  No locking is performed.
 extern void *nni_pipe_get_proto_data(nni_pipe *);
-extern void  nni_pipe_set_proto_data(nni_pipe *, void *);
 
 // nni_pipe_sock_list_init initializes a list of pipes, to be used by
 // a per-socket list.

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -20,10 +20,13 @@ extern int         nni_sock_open(nni_sock **, const nni_proto *);
 extern void        nni_sock_close(nni_sock *);
 extern void        nni_sock_closeall(void);
 extern int         nni_sock_shutdown(nni_sock *);
-extern uint16_t    nni_sock_proto(nni_sock *);
-extern uint16_t    nni_sock_peer(nni_sock *);
+extern uint16_t    nni_sock_proto_id(nni_sock *);
+extern uint16_t    nni_sock_peer_id(nni_sock *);
 extern const char *nni_sock_proto_name(nni_sock *);
 extern const char *nni_sock_peer_name(nni_sock *);
+extern void *      nni_sock_proto_data(nni_sock *);
+
+extern struct nni_proto_pipe_ops *nni_sock_proto_pipe_ops(nni_sock *);
 
 extern int nni_sock_setopt(
     nni_sock *, const char *, const void *, size_t, int);

--- a/src/core/transport.c
+++ b/src/core/transport.c
@@ -118,7 +118,7 @@ nni_tran_chkopt(const char *name, const void *v, size_t sz, int typ)
 
 	nni_mtx_lock(&nni_tran_lk);
 	NNI_LIST_FOREACH (&nni_tran_list, t) {
-		const nni_tran_ep *       ep;
+		const nni_tran_ep_ops *   ep;
 		const nni_tran_ep_option *eo;
 
 		// Generally we look for endpoint options.

--- a/src/core/transport.h
+++ b/src/core/transport.h
@@ -23,10 +23,10 @@ struct nni_tran {
 	const char *tran_scheme;
 
 	// tran_ep links our endpoint-specific operations.
-	const nni_tran_ep *tran_ep;
+	const nni_tran_ep_ops *tran_ep;
 
 	// tran_pipe links our pipe-specific operations.
-	const nni_tran_pipe *tran_pipe;
+	const nni_tran_pipe_ops *tran_pipe;
 
 	// tran_init, if not NULL, is called once during library
 	// initialization.
@@ -77,7 +77,7 @@ struct nni_tran_ep_option {
 // For a given endpoint, the framework holds a lock so that each entry
 // point is run exclusively of the others. (Transports must still guard
 // against any asynchronous operations they manage themselves, though.)
-struct nni_tran_ep {
+struct nni_tran_ep_ops {
 	// ep_init creates a vanilla endpoint. The value created is
 	// used for the first argument for all other endpoint functions.
 	int (*ep_init)(void **, nni_url *, nni_sock *, int);
@@ -128,7 +128,7 @@ struct nni_tran_pipe_option {
 // with socket locks held, so it is forbidden for the transport to call
 // back into the socket at this point.  (Which is one reason pointers back
 // to socket or even enclosing pipe state, are not provided.)
-struct nni_tran_pipe {
+struct nni_tran_pipe_ops {
 	// p_fini destroys the pipe.  This should clean up all local
 	// resources, including closing files and freeing memory, used by
 	// the pipe.  After this call returns, the system will not make

--- a/src/protocol/bus0/bus.c
+++ b/src/protocol/bus0/bus.c
@@ -111,7 +111,7 @@ bus0_sock_close(void *arg)
 }
 
 static void
-bus0_pipe_fini(void *arg)
+bus0_pipe_stop(void *arg)
 {
 	bus0_pipe *p = arg;
 
@@ -119,6 +119,12 @@ bus0_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_putq);
+}
+
+static void
+bus0_pipe_fini(void *arg)
+{
+	bus0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -172,7 +178,7 @@ bus0_pipe_start(void *arg)
 }
 
 static void
-bus0_pipe_stop(void *arg)
+bus0_pipe_close(void *arg)
 {
 	bus0_pipe *p = arg;
 	bus0_sock *s = p->psock;
@@ -354,6 +360,7 @@ static nni_proto_pipe_ops bus0_pipe_ops = {
 	.pipe_init  = bus0_pipe_init,
 	.pipe_fini  = bus0_pipe_fini,
 	.pipe_start = bus0_pipe_start,
+	.pipe_close = bus0_pipe_close,
 	.pipe_stop  = bus0_pipe_stop,
 };
 

--- a/src/protocol/bus0/bus.c
+++ b/src/protocol/bus0/bus.c
@@ -67,7 +67,6 @@ bus0_sock_fini(void *arg)
 {
 	bus0_sock *s = arg;
 
-	nni_aio_stop(s->aio_getq);
 	nni_aio_fini(s->aio_getq);
 	nni_mtx_fini(&s->mtx);
 	NNI_FREE_STRUCT(s);
@@ -108,13 +107,18 @@ bus0_sock_close(void *arg)
 {
 	bus0_sock *s = arg;
 
-	nni_aio_abort(s->aio_getq, NNG_ECLOSED);
+	nni_aio_close(s->aio_getq);
 }
 
 static void
 bus0_pipe_fini(void *arg)
 {
 	bus0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -173,12 +177,11 @@ bus0_pipe_stop(void *arg)
 	bus0_pipe *p = arg;
 	bus0_sock *s = p->psock;
 
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
 	nni_msgq_close(p->sendq);
-
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
 
 	nni_mtx_lock(&s->mtx);
 	if (nni_list_active(&s->pipes, p)) {

--- a/src/protocol/pair0/pair.c
+++ b/src/protocol/pair0/pair.c
@@ -78,7 +78,7 @@ pair0_sock_fini(void *arg)
 }
 
 static void
-pair0_pipe_fini(void *arg)
+pair0_pipe_stop(void *arg)
 {
 	pair0_pipe *p = arg;
 
@@ -86,6 +86,12 @@ pair0_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_putq);
 	nni_aio_stop(p->aio_getq);
+}
+
+static void
+pair0_pipe_fini(void *arg)
+{
+	pair0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -140,7 +146,7 @@ pair0_pipe_start(void *arg)
 }
 
 static void
-pair0_pipe_stop(void *arg)
+pair0_pipe_close(void *arg)
 {
 	pair0_pipe *p = arg;
 	pair0_sock *s = p->psock;
@@ -254,6 +260,7 @@ static nni_proto_pipe_ops pair0_pipe_ops = {
 	.pipe_init  = pair0_pipe_init,
 	.pipe_fini  = pair0_pipe_fini,
 	.pipe_start = pair0_pipe_start,
+	.pipe_close = pair0_pipe_close,
 	.pipe_stop  = pair0_pipe_stop,
 };
 

--- a/src/protocol/pair0/pair.c
+++ b/src/protocol/pair0/pair.c
@@ -82,6 +82,11 @@ pair0_pipe_fini(void *arg)
 {
 	pair0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_getq);
+
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_putq);
@@ -140,10 +145,10 @@ pair0_pipe_stop(void *arg)
 	pair0_pipe *p = arg;
 	pair0_sock *s = p->psock;
 
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_getq);
 
 	nni_mtx_lock(&s->mtx);
 	if (s->ppipe == p) {

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -120,6 +120,12 @@ static void
 pair1_pipe_fini(void *arg)
 {
 	pair1_pipe *p = arg;
+
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_getq);
+
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_putq);
@@ -203,16 +209,17 @@ pair1_pipe_stop(void *arg)
 	pair1_pipe *p = arg;
 	pair1_sock *s = p->psock;
 
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_getq);
+
 	nni_mtx_lock(&s->mtx);
 	nni_idhash_remove(s->pipes, nni_pipe_id(p->npipe));
 	nni_list_node_remove(&p->node);
 	nni_mtx_unlock(&s->mtx);
 
 	nni_msgq_close(p->sendq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_getq);
 }
 
 static void
@@ -405,7 +412,8 @@ pair1_sock_open(void *arg)
 static void
 pair1_sock_close(void *arg)
 {
-	NNI_ARG_UNUSED(arg);
+	pair1_sock *s = arg;
+	nni_aio_close(s->aio_getq);
 }
 
 static int

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -117,7 +117,7 @@ pair1_sock_init_raw(void **sp, nni_sock *nsock)
 }
 
 static void
-pair1_pipe_fini(void *arg)
+pair1_pipe_stop(void *arg)
 {
 	pair1_pipe *p = arg;
 
@@ -125,6 +125,12 @@ pair1_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_putq);
 	nni_aio_stop(p->aio_getq);
+}
+
+static void
+pair1_pipe_fini(void *arg)
+{
+	pair1_pipe *p = arg;
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -204,7 +210,7 @@ pair1_pipe_start(void *arg)
 }
 
 static void
-pair1_pipe_stop(void *arg)
+pair1_pipe_close(void *arg)
 {
 	pair1_pipe *p = arg;
 	pair1_sock *s = p->psock;
@@ -472,6 +478,7 @@ static nni_proto_pipe_ops pair1_pipe_ops = {
 	.pipe_init  = pair1_pipe_init,
 	.pipe_fini  = pair1_pipe_fini,
 	.pipe_start = pair1_pipe_start,
+	.pipe_close = pair1_pipe_close,
 	.pipe_stop  = pair1_pipe_stop,
 };
 

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -68,12 +68,18 @@ pull0_sock_fini(void *arg)
 }
 
 static void
-pull0_pipe_fini(void *arg)
+pull0_pipe_stop(void *arg)
 {
 	pull0_pipe *p = arg;
 
 	nni_aio_stop(p->putq_aio);
 	nni_aio_stop(p->recv_aio);
+}
+
+static void
+pull0_pipe_fini(void *arg)
+{
+	pull0_pipe *p = arg;
 
 	nni_aio_fini(p->putq_aio);
 	nni_aio_fini(p->recv_aio);
@@ -113,7 +119,7 @@ pull0_pipe_start(void *arg)
 }
 
 static void
-pull0_pipe_stop(void *arg)
+pull0_pipe_close(void *arg)
 {
 	pull0_pipe *p = arg;
 
@@ -201,6 +207,7 @@ static nni_proto_pipe_ops pull0_pipe_ops = {
 	.pipe_init  = pull0_pipe_init,
 	.pipe_fini  = pull0_pipe_fini,
 	.pipe_start = pull0_pipe_start,
+	.pipe_close = pull0_pipe_close,
 	.pipe_stop  = pull0_pipe_stop,
 };
 

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -72,6 +72,9 @@ pull0_pipe_fini(void *arg)
 {
 	pull0_pipe *p = arg;
 
+	nni_aio_stop(p->putq_aio);
+	nni_aio_stop(p->recv_aio);
+
 	nni_aio_fini(p->putq_aio);
 	nni_aio_fini(p->recv_aio);
 	NNI_FREE_STRUCT(p);
@@ -114,8 +117,8 @@ pull0_pipe_stop(void *arg)
 {
 	pull0_pipe *p = arg;
 
-	nni_aio_stop(p->putq_aio);
-	nni_aio_stop(p->recv_aio);
+	nni_aio_close(p->putq_aio);
+	nni_aio_close(p->recv_aio);
 }
 
 static void

--- a/src/protocol/pipeline0/push.c
+++ b/src/protocol/pipeline0/push.c
@@ -83,13 +83,19 @@ push0_sock_close(void *arg)
 }
 
 static void
-push0_pipe_fini(void *arg)
+push0_pipe_stop(void *arg)
 {
 	push0_pipe *p = arg;
 
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_getq);
+}
+
+static void
+push0_pipe_fini(void *arg)
+{
+	push0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
@@ -140,7 +146,7 @@ push0_pipe_start(void *arg)
 }
 
 static void
-push0_pipe_stop(void *arg)
+push0_pipe_close(void *arg)
 {
 	push0_pipe *p = arg;
 
@@ -218,6 +224,7 @@ static nni_proto_pipe_ops push0_pipe_ops = {
 	.pipe_init  = push0_pipe_init,
 	.pipe_fini  = push0_pipe_fini,
 	.pipe_start = push0_pipe_start,
+	.pipe_close = push0_pipe_close,
 	.pipe_stop  = push0_pipe_stop,
 };
 

--- a/src/protocol/pipeline0/push.c
+++ b/src/protocol/pipeline0/push.c
@@ -87,6 +87,10 @@ push0_pipe_fini(void *arg)
 {
 	push0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_getq);
+
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_getq);
@@ -140,9 +144,9 @@ push0_pipe_stop(void *arg)
 {
 	push0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_getq);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_getq);
 }
 
 static void

--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -106,12 +106,19 @@ pub0_sock_close(void *arg)
 }
 
 static void
-pub0_pipe_fini(void *arg)
+pub0_pipe_stop(void *arg)
 {
 	pub0_pipe *p = arg;
+
 	nni_aio_stop(p->aio_getq);
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
+}
+
+static void
+pub0_pipe_fini(void *arg)
+{
+	pub0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -167,7 +174,7 @@ pub0_pipe_start(void *arg)
 }
 
 static void
-pub0_pipe_stop(void *arg)
+pub0_pipe_close(void *arg)
 {
 	pub0_pipe *p = arg;
 	pub0_sock *s = p->pub;
@@ -293,6 +300,7 @@ static nni_proto_pipe_ops pub0_pipe_ops = {
 	.pipe_init  = pub0_pipe_init,
 	.pipe_fini  = pub0_pipe_fini,
 	.pipe_start = pub0_pipe_start,
+	.pipe_close = pub0_pipe_close,
 	.pipe_stop  = pub0_pipe_stop,
 };
 

--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -61,7 +61,6 @@ pub0_sock_fini(void *arg)
 {
 	pub0_sock *s = arg;
 
-	nni_aio_stop(s->aio_getq);
 	nni_aio_fini(s->aio_getq);
 	nni_mtx_fini(&s->mtx);
 	NNI_FREE_STRUCT(s);
@@ -103,13 +102,17 @@ pub0_sock_close(void *arg)
 {
 	pub0_sock *s = arg;
 
-	nni_aio_abort(s->aio_getq, NNG_ECLOSED);
+	nni_aio_close(s->aio_getq);
 }
 
 static void
 pub0_pipe_fini(void *arg)
 {
 	pub0_pipe *p = arg;
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -169,9 +172,9 @@ pub0_pipe_stop(void *arg)
 	pub0_pipe *p = arg;
 	pub0_sock *s = p->pub;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
 
 	nni_msgq_close(p->sendq);
 

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -102,6 +102,8 @@ static void
 sub0_pipe_fini(void *arg)
 {
 	sub0_pipe *p = arg;
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_recv);
@@ -143,8 +145,8 @@ sub0_pipe_stop(void *arg)
 {
 	sub0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_recv);
 }
 
 static void

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -99,11 +99,18 @@ sub0_sock_close(void *arg)
 }
 
 static void
+sub0_pipe_stop(void *arg)
+{
+	sub0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
+}
+
+static void
 sub0_pipe_fini(void *arg)
 {
 	sub0_pipe *p = arg;
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_recv);
@@ -141,7 +148,7 @@ sub0_pipe_start(void *arg)
 }
 
 static void
-sub0_pipe_stop(void *arg)
+sub0_pipe_close(void *arg)
 {
 	sub0_pipe *p = arg;
 
@@ -340,6 +347,7 @@ static nni_proto_pipe_ops sub0_pipe_ops = {
 	.pipe_init  = sub0_pipe_init,
 	.pipe_fini  = sub0_pipe_fini,
 	.pipe_start = sub0_pipe_start,
+	.pipe_close = sub0_pipe_close,
 	.pipe_stop  = sub0_pipe_stop,
 };
 

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -297,11 +297,18 @@ rep0_sock_close(void *arg)
 }
 
 static void
+rep0_pipe_stop(void *arg)
+{
+	rep0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+}
+
+static void
 rep0_pipe_fini(void *arg)
 {
 	rep0_pipe *p = arg;
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -349,7 +356,7 @@ rep0_pipe_start(void *arg)
 }
 
 static void
-rep0_pipe_stop(void *arg)
+rep0_pipe_close(void *arg)
 {
 	rep0_pipe *p = arg;
 	rep0_sock *s = p->rep;
@@ -649,6 +656,7 @@ static nni_proto_pipe_ops rep0_pipe_ops = {
 	.pipe_init  = rep0_pipe_init,
 	.pipe_fini  = rep0_pipe_fini,
 	.pipe_start = rep0_pipe_start,
+	.pipe_close = rep0_pipe_close,
 	.pipe_stop  = rep0_pipe_stop,
 };
 

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -300,6 +300,8 @@ static void
 rep0_pipe_fini(void *arg)
 {
 	rep0_pipe *p = arg;
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -353,8 +355,8 @@ rep0_pipe_stop(void *arg)
 	rep0_sock *s = p->rep;
 	rep0_ctx * ctx;
 
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
 
 	nni_mtx_lock(&s->lk);
 	if (nni_list_active(&s->recvpipes, p)) {

--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -186,11 +186,18 @@ req0_sock_fini(void *arg)
 }
 
 static void
+req0_pipe_stop(void *arg)
+{
+	req0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+}
+
+static void
 req0_pipe_fini(void *arg)
 {
 	req0_pipe *p = arg;
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
 
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
@@ -245,7 +252,7 @@ req0_pipe_start(void *arg)
 }
 
 static void
-req0_pipe_stop(void *arg)
+req0_pipe_close(void *arg)
 {
 	req0_pipe *p = arg;
 	req0_sock *s = p->req;
@@ -836,6 +843,7 @@ static nni_proto_pipe_ops req0_pipe_ops = {
 	.pipe_init  = req0_pipe_init,
 	.pipe_fini  = req0_pipe_fini,
 	.pipe_start = req0_pipe_start,
+	.pipe_close = req0_pipe_close,
 	.pipe_stop  = req0_pipe_stop,
 };
 

--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -189,6 +189,8 @@ static void
 req0_pipe_fini(void *arg)
 {
 	req0_pipe *p = arg;
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
 
 	nni_aio_fini(p->aio_recv);
 	nni_aio_fini(p->aio_send);
@@ -249,11 +251,8 @@ req0_pipe_stop(void *arg)
 	req0_sock *s = p->req;
 	req0_ctx * ctx;
 
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-
-	// At this point there should not be any further AIOs running.
-	// Further, any completion tasks have completed.
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_send);
 
 	nni_mtx_lock(&s->mtx);
 	// This removes the node from either busypipes or readypipes.

--- a/src/protocol/reqrep0/xrep.c
+++ b/src/protocol/reqrep0/xrep.c
@@ -111,7 +111,7 @@ xrep0_sock_close(void *arg)
 }
 
 static void
-xrep0_pipe_fini(void *arg)
+xrep0_pipe_stop(void *arg)
 {
 	xrep0_pipe *p = arg;
 
@@ -119,6 +119,12 @@ xrep0_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_putq);
+}
+
+static void
+xrep0_pipe_fini(void *arg)
+{
+	xrep0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -182,7 +188,7 @@ xrep0_pipe_start(void *arg)
 }
 
 static void
-xrep0_pipe_stop(void *arg)
+xrep0_pipe_close(void *arg)
 {
 	xrep0_pipe *p = arg;
 	xrep0_sock *s = p->rep;
@@ -393,6 +399,7 @@ static nni_proto_pipe_ops xrep0_pipe_ops = {
 	.pipe_init  = xrep0_pipe_init,
 	.pipe_fini  = xrep0_pipe_fini,
 	.pipe_start = xrep0_pipe_start,
+	.pipe_close = xrep0_pipe_close,
 	.pipe_stop  = xrep0_pipe_stop,
 };
 

--- a/src/protocol/reqrep0/xreq.c
+++ b/src/protocol/reqrep0/xreq.c
@@ -94,6 +94,11 @@ xreq0_pipe_fini(void *arg)
 {
 	xreq0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_putq);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_send);
+
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_recv);
@@ -144,13 +149,10 @@ xreq0_pipe_stop(void *arg)
 {
 	xreq0_pipe *p = arg;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_putq);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_send);
-
-	// At this point there should not be any further AIOs running.
-	// Further, any completion tasks have completed.
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_putq);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_send);
 }
 
 // For raw mode we can just let the pipes "contend" via getq to get a

--- a/src/protocol/reqrep0/xreq.c
+++ b/src/protocol/reqrep0/xreq.c
@@ -90,7 +90,7 @@ xreq0_sock_fini(void *arg)
 }
 
 static void
-xreq0_pipe_fini(void *arg)
+xreq0_pipe_stop(void *arg)
 {
 	xreq0_pipe *p = arg;
 
@@ -98,6 +98,12 @@ xreq0_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_putq);
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_send);
+}
+
+static void
+xreq0_pipe_fini(void *arg)
+{
+	xreq0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_putq);
@@ -145,7 +151,7 @@ xreq0_pipe_start(void *arg)
 }
 
 static void
-xreq0_pipe_stop(void *arg)
+xreq0_pipe_close(void *arg)
 {
 	xreq0_pipe *p = arg;
 
@@ -279,6 +285,7 @@ static nni_proto_pipe_ops xreq0_pipe_ops = {
 	.pipe_init  = xreq0_pipe_init,
 	.pipe_fini  = xreq0_pipe_fini,
 	.pipe_start = xreq0_pipe_start,
+	.pipe_close = xreq0_pipe_close,
 	.pipe_stop  = xreq0_pipe_stop,
 };
 

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -290,12 +290,18 @@ resp0_sock_close(void *arg)
 }
 
 static void
-resp0_pipe_fini(void *arg)
+resp0_pipe_stop(void *arg)
 {
 	resp0_pipe *p = arg;
 
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
+}
+
+static void
+resp0_pipe_fini(void *arg)
+{
+	resp0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -347,7 +353,7 @@ resp0_pipe_start(void *arg)
 }
 
 static void
-resp0_pipe_stop(void *arg)
+resp0_pipe_close(void *arg)
 {
 	resp0_pipe *p = arg;
 	resp0_sock *s = p->psock;
@@ -629,6 +635,7 @@ static nni_proto_pipe_ops resp0_pipe_ops = {
 	.pipe_init  = resp0_pipe_init,
 	.pipe_fini  = resp0_pipe_fini,
 	.pipe_start = resp0_pipe_start,
+	.pipe_close = resp0_pipe_close,
 	.pipe_stop  = resp0_pipe_stop,
 };
 

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -294,6 +294,9 @@ resp0_pipe_fini(void *arg)
 {
 	resp0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
 	NNI_FREE_STRUCT(p);
@@ -350,6 +353,9 @@ resp0_pipe_stop(void *arg)
 	resp0_sock *s = p->psock;
 	resp0_ctx * ctx;
 
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+
 	nni_mtx_lock(&s->mtx);
 	while ((ctx = nni_list_first(&p->sendq)) != NULL) {
 		nni_aio *aio;
@@ -369,9 +375,6 @@ resp0_pipe_stop(void *arg)
 	}
 	nni_idhash_remove(s->pipes, p->id);
 	nni_mtx_unlock(&s->mtx);
-
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
 }
 
 static void

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -284,13 +284,19 @@ surv0_sock_close(void *arg)
 }
 
 static void
-surv0_pipe_fini(void *arg)
+surv0_pipe_stop(void *arg)
 {
 	surv0_pipe *p = arg;
 
 	nni_aio_stop(p->aio_getq);
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
+}
+
+static void
+surv0_pipe_fini(void *arg)
+{
+	surv0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -342,7 +348,7 @@ surv0_pipe_start(void *arg)
 }
 
 static void
-surv0_pipe_stop(void *arg)
+surv0_pipe_close(void *arg)
 {
 	surv0_pipe *p = arg;
 	surv0_sock *s = p->sock;
@@ -536,6 +542,7 @@ static nni_proto_pipe_ops surv0_pipe_ops = {
 	.pipe_init  = surv0_pipe_init,
 	.pipe_fini  = surv0_pipe_fini,
 	.pipe_start = surv0_pipe_start,
+	.pipe_close = surv0_pipe_close,
 	.pipe_stop  = surv0_pipe_stop,
 };
 

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -288,6 +288,10 @@ surv0_pipe_fini(void *arg)
 {
 	surv0_pipe *p = arg;
 
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
 	nni_aio_fini(p->aio_recv);
@@ -343,9 +347,9 @@ surv0_pipe_stop(void *arg)
 	surv0_pipe *p = arg;
 	surv0_sock *s = p->sock;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
 
 	nni_msgq_close(p->sendq);
 

--- a/src/protocol/survey0/xrespond.c
+++ b/src/protocol/survey0/xrespond.c
@@ -110,7 +110,7 @@ xresp0_sock_close(void *arg)
 }
 
 static void
-xresp0_pipe_fini(void *arg)
+xresp0_pipe_stop(void *arg)
 {
 	xresp0_pipe *p = arg;
 
@@ -118,6 +118,12 @@ xresp0_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_getq);
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
+}
+
+static void
+xresp0_pipe_fini(void *arg)
+{
+	xresp0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_putq);
 	nni_aio_fini(p->aio_getq);
@@ -174,7 +180,7 @@ xresp0_pipe_start(void *arg)
 }
 
 static void
-xresp0_pipe_stop(void *arg)
+xresp0_pipe_close(void *arg)
 {
 	xresp0_pipe *p = arg;
 	xresp0_sock *s = p->psock;
@@ -371,6 +377,7 @@ static nni_proto_pipe_ops xresp0_pipe_ops = {
 	.pipe_init  = xresp0_pipe_init,
 	.pipe_fini  = xresp0_pipe_fini,
 	.pipe_start = xresp0_pipe_start,
+	.pipe_close = xresp0_pipe_close,
 	.pipe_stop  = xresp0_pipe_stop,
 };
 

--- a/src/protocol/survey0/xsurvey.c
+++ b/src/protocol/survey0/xsurvey.c
@@ -107,7 +107,7 @@ xsurv0_sock_close(void *arg)
 }
 
 static void
-xsurv0_pipe_fini(void *arg)
+xsurv0_pipe_stop(void *arg)
 {
 	xsurv0_pipe *p = arg;
 
@@ -115,6 +115,12 @@ xsurv0_pipe_fini(void *arg)
 	nni_aio_stop(p->aio_send);
 	nni_aio_stop(p->aio_recv);
 	nni_aio_stop(p->aio_putq);
+}
+
+static void
+xsurv0_pipe_fini(void *arg)
+{
+	xsurv0_pipe *p = arg;
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -170,7 +176,7 @@ xsurv0_pipe_start(void *arg)
 }
 
 static void
-xsurv0_pipe_stop(void *arg)
+xsurv0_pipe_close(void *arg)
 {
 	xsurv0_pipe *p = arg;
 	xsurv0_sock *s = p->psock;
@@ -342,6 +348,7 @@ static nni_proto_pipe_ops xsurv0_pipe_ops = {
 	.pipe_init  = xsurv0_pipe_init,
 	.pipe_fini  = xsurv0_pipe_fini,
 	.pipe_start = xsurv0_pipe_start,
+	.pipe_close = xsurv0_pipe_close,
 	.pipe_stop  = xsurv0_pipe_stop,
 };
 

--- a/src/protocol/survey0/xsurvey.c
+++ b/src/protocol/survey0/xsurvey.c
@@ -61,7 +61,6 @@ xsurv0_sock_fini(void *arg)
 {
 	xsurv0_sock *s = arg;
 
-	nni_aio_stop(s->aio_getq);
 	nni_aio_fini(s->aio_getq);
 	nni_mtx_fini(&s->mtx);
 	NNI_FREE_STRUCT(s);
@@ -104,13 +103,18 @@ xsurv0_sock_close(void *arg)
 {
 	xsurv0_sock *s = arg;
 
-	nni_aio_abort(s->aio_getq, NNG_ECLOSED);
+	nni_aio_close(s->aio_getq);
 }
 
 static void
 xsurv0_pipe_fini(void *arg)
 {
 	xsurv0_pipe *p = arg;
+
+	nni_aio_stop(p->aio_getq);
+	nni_aio_stop(p->aio_send);
+	nni_aio_stop(p->aio_recv);
+	nni_aio_stop(p->aio_putq);
 
 	nni_aio_fini(p->aio_getq);
 	nni_aio_fini(p->aio_send);
@@ -171,10 +175,10 @@ xsurv0_pipe_stop(void *arg)
 	xsurv0_pipe *p = arg;
 	xsurv0_sock *s = p->psock;
 
-	nni_aio_stop(p->aio_getq);
-	nni_aio_stop(p->aio_send);
-	nni_aio_stop(p->aio_recv);
-	nni_aio_stop(p->aio_putq);
+	nni_aio_close(p->aio_getq);
+	nni_aio_close(p->aio_send);
+	nni_aio_close(p->aio_recv);
+	nni_aio_close(p->aio_putq);
 
 	nni_msgq_close(p->sendq);
 

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -229,12 +229,6 @@ http_sconn_reap(void *arg)
 }
 
 static void
-http_sconn_fini(http_sconn *sc)
-{
-	nni_reap(&sc->reap, http_sconn_reap, sc);
-}
-
-static void
 http_sconn_close_locked(http_sconn *sc)
 {
 	nni_http_conn *conn;
@@ -245,15 +239,15 @@ http_sconn_close_locked(http_sconn *sc)
 	NNI_ASSERT(!sc->finished);
 
 	sc->closed = true;
-	nni_aio_abort(sc->rxaio, NNG_ECLOSED);
-	nni_aio_abort(sc->txaio, NNG_ECLOSED);
-	nni_aio_abort(sc->txdataio, NNG_ECLOSED);
-	nni_aio_abort(sc->cbaio, NNG_ECLOSED);
+	nni_aio_close(sc->rxaio);
+	nni_aio_close(sc->txaio);
+	nni_aio_close(sc->txdataio);
+	nni_aio_close(sc->cbaio);
 
 	if ((conn = sc->conn) != NULL) {
 		nni_http_conn_close(conn);
 	}
-	http_sconn_fini(sc);
+	nni_reap(&sc->reap, http_sconn_reap, sc);
 }
 
 static void

--- a/src/supplemental/tls/mbedtls/tls.c
+++ b/src/supplemental/tls/mbedtls/tls.c
@@ -761,6 +761,9 @@ nni_tls_close(nni_tls *tp)
 {
 	nni_aio *aio;
 
+	nni_aio_close(tp->tcp_send);
+	nni_aio_close(tp->tcp_recv);
+
 	nni_mtx_lock(&tp->lk);
 	tp->tls_closed = true;
 

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -407,14 +407,15 @@ ws_close_cb(void *arg)
 	nni_ws *ws = arg;
 	ws_msg *wm;
 
+	nni_aio_close(ws->txaio);
+	nni_aio_close(ws->rxaio);
+	nni_aio_close(ws->httpaio);
+
 	// Either we sent a close frame, or we didn't.  Either way,
 	// we are done, and its time to abort everything else.
 	nni_mtx_lock(&ws->mtx);
 
 	nni_http_conn_close(ws->http);
-	nni_aio_abort(ws->txaio, NNG_ECLOSED);
-	nni_aio_abort(ws->rxaio, NNG_ECLOSED);
-	nni_aio_abort(ws->httpaio, NNG_ECLOSED);
 
 	// This list (receive) should be empty.
 	while ((wm = nni_list_first(&ws->rxmsgs)) != NULL) {
@@ -464,8 +465,8 @@ ws_close(nni_ws *ws, uint16_t code)
 	// pending connect request.
 	if (!ws->closed) {
 		// ABORT connection negotiation.
-		nni_aio_abort(ws->connaio, NNG_ECLOSED);
-		nni_aio_abort(ws->httpaio, NNG_ECLOSED);
+		nni_aio_close(ws->connaio);
+		nni_aio_close(ws->httpaio);
 		ws_send_close(ws, code);
 	}
 

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -198,7 +198,7 @@ nni_inproc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	}
 
 	ep->mode  = mode;
-	ep->proto = nni_sock_proto(sock);
+	ep->proto = nni_sock_proto_id(sock);
 	NNI_LIST_INIT(&ep->clients, nni_inproc_ep, node);
 	nni_aio_list_init(&ep->aios);
 
@@ -452,7 +452,7 @@ static nni_tran_pipe_option nni_inproc_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_inproc_pipe_ops = {
+static nni_tran_pipe_ops nni_inproc_pipe_ops = {
 	.p_fini    = nni_inproc_pipe_fini,
 	.p_send    = nni_inproc_pipe_send,
 	.p_recv    = nni_inproc_pipe_recv,
@@ -468,7 +468,7 @@ static nni_tran_ep_option nni_inproc_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_inproc_ep_ops = {
+static nni_tran_ep_ops nni_inproc_ep_ops = {
 	.ep_init    = nni_inproc_ep_init,
 	.ep_fini    = nni_inproc_ep_fini,
 	.ep_connect = nni_inproc_ep_connect,

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -648,7 +648,7 @@ nni_ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 		nni_ipc_ep_fini(ep);
 		return (rv);
 	}
-	ep->proto = nni_sock_proto(sock);
+	ep->proto = nni_sock_proto_id(sock);
 
 	*epp = ep;
 	return (0);
@@ -887,7 +887,7 @@ static nni_tran_pipe_option nni_ipc_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_ipc_pipe_ops = {
+static nni_tran_pipe_ops nni_ipc_pipe_ops = {
 	.p_fini    = nni_ipc_pipe_fini,
 	.p_start   = nni_ipc_pipe_start,
 	.p_send    = nni_ipc_pipe_send,
@@ -928,7 +928,7 @@ static nni_tran_ep_option nni_ipc_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_ipc_ep_ops = {
+static nni_tran_ep_ops nni_ipc_ep_ops = {
 	.ep_init    = nni_ipc_ep_init,
 	.ep_fini    = nni_ipc_ep_fini,
 	.ep_connect = nni_ipc_ep_connect,

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -81,6 +81,10 @@ nni_ipc_pipe_close(void *arg)
 {
 	nni_ipc_pipe *pipe = arg;
 
+	nni_aio_close(pipe->rxaio);
+	nni_aio_close(pipe->txaio);
+	nni_aio_close(pipe->negaio);
+
 	nni_plat_ipc_pipe_close(pipe->ipp);
 }
 
@@ -655,11 +659,11 @@ nni_ipc_ep_close(void *arg)
 {
 	nni_ipc_ep *ep = arg;
 
+	nni_aio_close(ep->aio);
+
 	nni_mtx_lock(&ep->mtx);
 	nni_plat_ipc_ep_close(ep->iep);
 	nni_mtx_unlock(&ep->mtx);
-
-	nni_aio_stop(ep->aio);
 }
 
 static int

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -670,7 +670,7 @@ nni_tcp_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 		nni_tcp_ep_fini(ep);
 		return (rv);
 	}
-	ep->proto     = nni_sock_proto(sock);
+	ep->proto     = nni_sock_proto_id(sock);
 	ep->mode      = mode;
 	ep->nodelay   = true;
 	ep->keepalive = false;
@@ -914,7 +914,7 @@ static nni_tran_pipe_option nni_tcp_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_tcp_pipe_ops = {
+static nni_tran_pipe_ops nni_tcp_pipe_ops = {
 	.p_fini    = nni_tcp_pipe_fini,
 	.p_start   = nni_tcp_pipe_start,
 	.p_send    = nni_tcp_pipe_send,
@@ -955,7 +955,7 @@ static nni_tran_ep_option nni_tcp_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_tcp_ep_ops = {
+static nni_tran_ep_ops nni_tcp_ep_ops = {
 	.ep_init    = nni_tcp_ep_init,
 	.ep_fini    = nni_tcp_ep_fini,
 	.ep_connect = nni_tcp_ep_connect,

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -81,9 +81,13 @@ nni_tcp_tran_fini(void)
 static void
 nni_tcp_pipe_close(void *arg)
 {
-	nni_tcp_pipe *pipe = arg;
+	nni_tcp_pipe *p = arg;
 
-	nni_plat_tcp_pipe_close(pipe->tpp);
+	nni_aio_close(p->rxaio);
+	nni_aio_close(p->txaio);
+	nni_aio_close(p->negaio);
+
+	nni_plat_tcp_pipe_close(p->tpp);
 }
 
 static void
@@ -680,11 +684,11 @@ nni_tcp_ep_close(void *arg)
 {
 	nni_tcp_ep *ep = arg;
 
+	nni_aio_close(ep->aio);
+
 	nni_mtx_lock(&ep->mtx);
 	nni_plat_tcp_ep_close(ep->tep);
 	nni_mtx_unlock(&ep->mtx);
-
-	nni_aio_stop(ep->aio);
 }
 
 static int

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -91,6 +91,10 @@ nni_tls_pipe_close(void *arg)
 {
 	nni_tls_pipe *p = arg;
 
+	nni_aio_close(p->rxaio);
+	nni_aio_close(p->txaio);
+	nni_aio_close(p->negaio);
+
 	nni_tls_close(p->tls);
 }
 
@@ -699,11 +703,11 @@ nni_tls_ep_close(void *arg)
 {
 	nni_tls_ep *ep = arg;
 
+	nni_aio_close(ep->aio);
+
 	nni_mtx_lock(&ep->mtx);
 	nni_plat_tcp_ep_close(ep->tep);
 	nni_mtx_unlock(&ep->mtx);
-
-	nni_aio_stop(ep->aio);
 }
 
 static int

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -691,7 +691,7 @@ nni_tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 			return (rv);
 		}
 	}
-	ep->proto    = nni_sock_proto(sock);
+	ep->proto    = nni_sock_proto_id(sock);
 	ep->authmode = authmode;
 
 	*epp = ep;
@@ -1040,7 +1040,7 @@ static nni_tran_pipe_option nni_tls_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe nni_tls_pipe_ops = {
+static nni_tran_pipe_ops nni_tls_pipe_ops = {
 	.p_fini    = nni_tls_pipe_fini,
 	.p_start   = nni_tls_pipe_start,
 	.p_send    = nni_tls_pipe_send,
@@ -1111,7 +1111,7 @@ static nni_tran_ep_option nni_tls_ep_options[] = {
 	},
 };
 
-static nni_tran_ep nni_tls_ep_ops = {
+static nni_tran_ep_ops nni_tls_ep_ops = {
 	.ep_init    = nni_tls_ep_init,
 	.ep_fini    = nni_tls_ep_fini,
 	.ep_connect = nni_tls_ep_connect,

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -591,7 +591,7 @@ static nni_tran_pipe_option ws_pipe_options[] = {
 	}
 };
 
-static nni_tran_pipe ws_pipe_ops = {
+static nni_tran_pipe_ops ws_pipe_ops = {
 	.p_fini    = ws_pipe_fini,
 	.p_send    = ws_pipe_send,
 	.p_recv    = ws_pipe_recv,
@@ -756,8 +756,8 @@ ws_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	nni_aio_list_init(&ep->aios);
 
 	ep->mode   = mode;
-	ep->lproto = nni_sock_proto(sock);
-	ep->rproto = nni_sock_peer(sock);
+	ep->lproto = nni_sock_proto_id(sock);
+	ep->rproto = nni_sock_peer_id(sock);
 
 	if (mode == NNI_EP_MODE_DIAL) {
 		pname = nni_sock_peer_name(sock);
@@ -801,7 +801,7 @@ ws_tran_fini(void)
 {
 }
 
-static nni_tran_ep ws_ep_ops = {
+static nni_tran_ep_ops ws_ep_ops = {
 	.ep_init    = ws_ep_init,
 	.ep_fini    = ws_ep_fini,
 	.ep_connect = ws_ep_connect,
@@ -1021,7 +1021,7 @@ static nni_tran_ep_option wss_ep_options[] = {
 	},
 };
 
-static nni_tran_ep wss_ep_ops = {
+static nni_tran_ep_ops wss_ep_ops = {
 	.ep_init    = ws_ep_init,
 	.ep_fini    = ws_ep_fini,
 	.ep_connect = ws_ep_connect,

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -205,6 +205,9 @@ ws_pipe_close(void *arg)
 {
 	ws_pipe *p = arg;
 
+	nni_aio_close(p->rxaio);
+	nni_aio_close(p->txaio);
+
 	nni_mtx_lock(&p->mtx);
 	nni_ws_close(p->ws);
 	nni_mtx_unlock(&p->mtx);
@@ -689,6 +692,9 @@ static void
 ws_ep_close(void *arg)
 {
 	ws_ep *ep = arg;
+
+	nni_aio_close(ep->accaio);
+	nni_aio_close(ep->connaio);
 
 	if (ep->mode == NNI_EP_MODE_LISTEN) {
 		nni_ws_listener_close(ep->listener);

--- a/src/transport/zerotier/zerotier.c
+++ b/src/transport/zerotier/zerotier.c
@@ -2182,7 +2182,7 @@ zt_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	ep->ze_ping_time  = zt_ping_time;
 	ep->ze_conn_time  = zt_conn_time;
 	ep->ze_conn_tries = zt_conn_tries;
-	ep->ze_proto      = nni_sock_proto(sock);
+	ep->ze_proto      = nni_sock_proto_id(sock);
 
 	nni_aio_list_init(&ep->ze_aios);
 
@@ -2888,7 +2888,7 @@ static nni_tran_pipe_option zt_pipe_options[] = {
 	},
 };
 
-static nni_tran_pipe zt_pipe_ops = {
+static nni_tran_pipe_ops zt_pipe_ops = {
 	.p_fini    = zt_pipe_fini,
 	.p_start   = zt_pipe_start,
 	.p_send    = zt_pipe_send,
@@ -2983,7 +2983,7 @@ static nni_tran_ep_option zt_ep_options[] = {
 	},
 };
 
-static nni_tran_ep zt_ep_ops = {
+static nni_tran_ep_ops zt_ep_ops = {
 	.ep_init    = zt_ep_init,
 	.ep_fini    = zt_ep_fini,
 	.ep_connect = zt_ep_connect,


### PR DESCRIPTION
This actually introduces an nni_aio_close() API that causes
nni_aio_begin to return NNG_ECLOSED, while scheduling a callback
on the AIO to do an NNG_ECLOSED as well.  This should be called
in non-blocking close() contexts instead of nni_aio_stop(), and
the cases where we call nni_aio_fini() multiple times are updated
updated to add nni_aio_stop() calls on all "interlinked" aios before
finalizing them.

Furthermore, we call nni_aio_close() as soon as practical in the
close path.  This closes an annoying race condition where the
callback from a lower subsystem could wind up rescheduling an
operation that we wanted to abort.
