### PR TITLE
fixes #431 hang in taskq_wait

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -387,7 +387,8 @@ nni_aio_abort(nni_aio *aio, int rv)
 	nni_aio_cancelfn cancelfn;
 
 	nni_mtx_lock(&nni_aio_lk);
-	cancelfn = aio->a_prov_cancel;
+	cancelfn           = aio->a_prov_cancel;
+	aio->a_prov_cancel = NULL;
 	nni_mtx_unlock(&nni_aio_lk);
 
 	// Stop any I/O at the provider level.

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -110,6 +110,9 @@ nni_pipe_destroy(nni_pipe *p)
 	if (p->p_proto_data != NULL) {
 		p->p_proto_ops.pipe_stop(p->p_proto_data);
 	}
+	if ((p->p_tran_data != NULL) && (p->p_tran_ops.p_stop != NULL)) {
+		p->p_tran_ops.p_stop(p->p_tran_data);
+	}
 
 	// We have exclusive access at this point, so we can check if
 	// we are still on any lists.

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -170,6 +170,7 @@ nni_task_dispatch(nni_task *task)
 	nni_mtx_lock(&task->task_mtx);
 	task->task_sched = true;
 	task->task_run   = false;
+	task->task_exec  = false;
 	task->task_done  = false;
 	nni_mtx_unlock(&task->task_mtx);
 
@@ -201,6 +202,7 @@ nni_task_exec(nni_task *task)
 	task->task_exec  = true;
 	task->task_sched = false;
 	task->task_done  = false;
+	task->task_run   = false;
 	nni_mtx_unlock(&task->task_mtx);
 
 	task->task_cb(task->task_arg);

--- a/src/core/transport.h
+++ b/src/core/transport.h
@@ -102,8 +102,12 @@ struct nni_tran_ep_ops {
 	void (*ep_accept)(void *, nni_aio *);
 
 	// ep_close stops the endpoint from operating altogether.  It does
-	// not affect pipes that have already been created.
+	// not affect pipes that have already been created.  It is nonblocking.
 	void (*ep_close)(void *);
+
+	// ep_stop stops the endpoint, and *waits* for any outstanding
+	// aio operations to complete.
+	void (*ep_stop)(void *);
 
 	// ep_options is an array of endpoint options.  The final element must
 	// have a NULL name. If this member is NULL, then no transport specific
@@ -141,6 +145,11 @@ struct nni_tran_pipe_ops {
 	// will not be access by the "socket" until the pipe has indicated
 	// its readiness by finishing the aio.
 	void (*p_start)(void *, nni_aio *);
+
+	// p_stop stops the pipe, waiting for any callbacks that are
+	// outstanding to complete.  This is done before tearing down
+	// resources with p_fini.
+	void (*p_stop)(void *);
 
 	// p_aio_send queues the message for transmit.  If this fails, then
 	// the caller may try again with the same message (or free it).  If

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -89,13 +89,19 @@ nni_ipc_pipe_close(void *arg)
 }
 
 static void
-nni_ipc_pipe_fini(void *arg)
+nni_ipc_pipe_stop(void *arg)
 {
 	nni_ipc_pipe *pipe = arg;
 
 	nni_aio_stop(pipe->rxaio);
 	nni_aio_stop(pipe->txaio);
 	nni_aio_stop(pipe->negaio);
+}
+
+static void
+nni_ipc_pipe_fini(void *arg)
+{
+	nni_ipc_pipe *pipe = arg;
 
 	nni_aio_fini(pipe->rxaio);
 	nni_aio_fini(pipe->txaio);
@@ -890,6 +896,7 @@ static nni_tran_pipe_option nni_ipc_pipe_options[] = {
 static nni_tran_pipe_ops nni_ipc_pipe_ops = {
 	.p_fini    = nni_ipc_pipe_fini,
 	.p_start   = nni_ipc_pipe_start,
+	.p_stop    = nni_ipc_pipe_stop,
 	.p_send    = nni_ipc_pipe_send,
 	.p_recv    = nni_ipc_pipe_recv,
 	.p_close   = nni_ipc_pipe_close,

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -91,13 +91,19 @@ nni_tcp_pipe_close(void *arg)
 }
 
 static void
-nni_tcp_pipe_fini(void *arg)
+nni_tcp_pipe_stop(void *arg)
 {
 	nni_tcp_pipe *p = arg;
 
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
 	nni_aio_stop(p->negaio);
+}
+
+static void
+nni_tcp_pipe_fini(void *arg)
+{
+	nni_tcp_pipe *p = arg;
 
 	nni_aio_fini(p->rxaio);
 	nni_aio_fini(p->txaio);
@@ -917,6 +923,7 @@ static nni_tran_pipe_option nni_tcp_pipe_options[] = {
 static nni_tran_pipe_ops nni_tcp_pipe_ops = {
 	.p_fini    = nni_tcp_pipe_fini,
 	.p_start   = nni_tcp_pipe_start,
+	.p_stop    = nni_tcp_pipe_stop,
 	.p_send    = nni_tcp_pipe_send,
 	.p_recv    = nni_tcp_pipe_recv,
 	.p_close   = nni_tcp_pipe_close,

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -99,13 +99,19 @@ nni_tls_pipe_close(void *arg)
 }
 
 static void
-nni_tls_pipe_fini(void *arg)
+nni_tls_pipe_stop(void *arg)
 {
 	nni_tls_pipe *p = arg;
 
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
 	nni_aio_stop(p->negaio);
+}
+
+static void
+nni_tls_pipe_fini(void *arg)
+{
+	nni_tls_pipe *p = arg;
 
 	nni_aio_fini(p->rxaio);
 	nni_aio_fini(p->txaio);
@@ -1043,6 +1049,7 @@ static nni_tran_pipe_option nni_tls_pipe_options[] = {
 static nni_tran_pipe_ops nni_tls_pipe_ops = {
 	.p_fini    = nni_tls_pipe_fini,
 	.p_start   = nni_tls_pipe_start,
+	.p_stop    = nni_tls_pipe_stop,
 	.p_send    = nni_tls_pipe_send,
 	.p_recv    = nni_tls_pipe_recv,
 	.p_close   = nni_tls_pipe_close,

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -183,12 +183,18 @@ ws_pipe_send(void *arg, nni_aio *aio)
 }
 
 static void
-ws_pipe_fini(void *arg)
+ws_pipe_stop(void *arg)
 {
 	ws_pipe *p = arg;
 
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
+}
+
+static void
+ws_pipe_fini(void *arg)
+{
+	ws_pipe *p = arg;
 
 	nni_aio_fini(p->rxaio);
 	nni_aio_fini(p->txaio);
@@ -593,6 +599,7 @@ static nni_tran_pipe_option ws_pipe_options[] = {
 
 static nni_tran_pipe_ops ws_pipe_ops = {
 	.p_fini    = ws_pipe_fini,
+	.p_stop    = ws_pipe_stop,
 	.p_send    = ws_pipe_send,
 	.p_recv    = ws_pipe_recv,
 	.p_close   = ws_pipe_close,


### PR DESCRIPTION
fixes #429 async websocket reap leads to crash

This tightens up the code for shutdown, ensuring that transport
callbacks are completely stopped before advancing to the next step
of teardown of transport pipes or endpoints.

It also fixes a problem where task_wait would sometimes get "stuck"
as tasks transitioned between asynch and synchronous completions.

Finally, it saves a few cycles by only calling a cancellation callback
once during cancellation of an aio.
