### PR TITLE
More endpoint termination hardening.

### DIFF
--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -94,12 +94,12 @@ nni_ep_destroy(nni_ep *ep)
 		nni_idhash_remove(nni_eps, ep->ep_id);
 	}
 
-	nni_sock_ep_remove(ep->ep_sock, ep);
-
 	nni_aio_stop(ep->ep_acc_aio);
 	nni_aio_stop(ep->ep_con_aio);
 	nni_aio_stop(ep->ep_con_syn);
 	nni_aio_stop(ep->ep_tmo_aio);
+
+	nni_sock_ep_remove(ep->ep_sock, ep);
 
 	nni_aio_fini(ep->ep_acc_aio);
 	nni_aio_fini(ep->ep_con_aio);
@@ -247,10 +247,10 @@ nni_ep_shutdown(nni_ep *ep)
 	nni_mtx_unlock(&ep->ep_mtx);
 
 	// Abort any remaining in-flight operations.
-	nni_aio_close(ep->ep_acc_aio);
-	nni_aio_close(ep->ep_con_aio);
-	nni_aio_close(ep->ep_con_syn);
-	nni_aio_close(ep->ep_tmo_aio);
+	nni_aio_stop(ep->ep_acc_aio);
+	nni_aio_stop(ep->ep_con_aio);
+	nni_aio_stop(ep->ep_con_syn);
+	nni_aio_stop(ep->ep_tmo_aio);
 
 	// Stop the underlying transport.
 	ep->ep_ops.ep_close(ep->ep_data);

--- a/tests/message.c
+++ b/tests/message.c
@@ -18,7 +18,6 @@ TestMain("Message Tests", {
 	nng_msg *msg;
 
 	Convey("Given an empty message", {
-
 		So(nng_msg_alloc(&msg, 0) == 0);
 
 		Reset({ nng_msg_free(msg); });
@@ -217,7 +216,6 @@ TestMain("Message Tests", {
 				So(nng_msg_trim_u32(msg, &v) == NNG_EINVAL);
 				So(nng_msg_trim_u32(msg, &v) == NNG_EINVAL);
 			});
-
 		});
 
 		Convey("Uint32 header operations work", {
@@ -249,8 +247,6 @@ TestMain("Message Tests", {
 				So(nng_msg_header_trim_u32(msg, &v) ==
 				    NNG_EINVAL);
 			});
-
 		});
-
 	});
 })


### PR DESCRIPTION
We had seen some very low frequency crashes in websocket shut down,
which I think were attributable to not actually ensuring that we had
stopped the endpoint upper side before asking the transport to close.
This closes the top half a bit more aggressively, hoepfully fixing
the last known race.

(Testing thus far has been unsuccessful in reproducing the problem
with this change.)

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
