### PR TITLE
fixes #436 fix for 429 incomplete (ws ep crash)

### DIFF
--- a/src/core/endpt.c
+++ b/src/core/endpt.c
@@ -94,12 +94,12 @@ nni_ep_destroy(nni_ep *ep)
 		nni_idhash_remove(nni_eps, ep->ep_id);
 	}
 
-	nni_sock_ep_remove(ep->ep_sock, ep);
-
 	nni_aio_stop(ep->ep_acc_aio);
 	nni_aio_stop(ep->ep_con_aio);
 	nni_aio_stop(ep->ep_con_syn);
 	nni_aio_stop(ep->ep_tmo_aio);
+
+	nni_sock_ep_remove(ep->ep_sock, ep);
 
 	nni_aio_fini(ep->ep_acc_aio);
 	nni_aio_fini(ep->ep_con_aio);
@@ -247,10 +247,10 @@ nni_ep_shutdown(nni_ep *ep)
 	nni_mtx_unlock(&ep->ep_mtx);
 
 	// Abort any remaining in-flight operations.
-	nni_aio_close(ep->ep_acc_aio);
-	nni_aio_close(ep->ep_con_aio);
-	nni_aio_close(ep->ep_con_syn);
-	nni_aio_close(ep->ep_tmo_aio);
+	nni_aio_stop(ep->ep_acc_aio);
+	nni_aio_stop(ep->ep_con_aio);
+	nni_aio_stop(ep->ep_con_syn);
+	nni_aio_stop(ep->ep_tmo_aio);
 
 	// Stop the underlying transport.
 	ep->ep_ops.ep_close(ep->ep_data);

--- a/src/supplemental/http/http_client.c
+++ b/src/supplemental/http/http_client.c
@@ -246,7 +246,7 @@ nni_http_client_connect(nni_http_client *c, nni_aio *aio)
 		return;
 	}
 	nni_mtx_lock(&c->mtx);
-	if ((rv = nni_aio_schedule(aio, http_connect_cancel, aio)) != 0) {
+	if ((rv = nni_aio_schedule(aio, http_connect_cancel, c)) != 0) {
 		nni_mtx_unlock(&c->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;

--- a/tests/message.c
+++ b/tests/message.c
@@ -18,7 +18,6 @@ TestMain("Message Tests", {
 	nng_msg *msg;
 
 	Convey("Given an empty message", {
-
 		So(nng_msg_alloc(&msg, 0) == 0);
 
 		Reset({ nng_msg_free(msg); });
@@ -217,7 +216,6 @@ TestMain("Message Tests", {
 				So(nng_msg_trim_u32(msg, &v) == NNG_EINVAL);
 				So(nng_msg_trim_u32(msg, &v) == NNG_EINVAL);
 			});
-
 		});
 
 		Convey("Uint32 header operations work", {
@@ -249,8 +247,6 @@ TestMain("Message Tests", {
 				So(nng_msg_header_trim_u32(msg, &v) ==
 				    NNG_EINVAL);
 			});
-
 		});
-
 	});
 })


### PR DESCRIPTION
While here, there is a little more endpoint termination hardening.
Running this code base seems to not incur any faults beyond the very
rare TCP port conflict that can occur from our random port selection
in the test suite.

