### PR TITLE
fixes #445 crash in taskq_thread

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -315,7 +315,6 @@ nni_aio_begin(nni_aio *aio)
 	nni_mtx_lock(&nni_aio_lk);
 	// We should not reschedule anything at this point.
 	if (aio->a_stop) {
-		nni_task_unprep(aio->a_task);
 		aio->a_result = NNG_ECANCELED;
 		nni_mtx_unlock(&nni_aio_lk);
 		return (NNG_ECANCELED);

--- a/src/core/taskq.h
+++ b/src/core/taskq.h
@@ -31,13 +31,12 @@ extern void nni_task_dispatch(nni_task *);
 // doubt, use nni_task_dispatch instead.)
 extern void nni_task_exec(nni_task *);
 
-// nni_task_prep and nni_task_unprep are used by and exclusively for the aio
-// framework.  nni_task_prep marks the task as "scheduled" without actually
+// nni_task_prep is used by and exclusively for the aio framework.
+// nni_task_prep marks the task as "scheduled" without actually
 // dispatching anything to it yet; nni_task_wait will block waiting for the
 // task to complete normally (after a call to nni_task_dispatch or
-// nni_task_exec), or for nni_task_unprep to be called.
+// nni_task_exec).
 extern void nni_task_prep(nni_task *);
-extern void nni_task_unprep(nni_task *);
 
 extern void nni_task_wait(nni_task *);
 extern int  nni_task_init(nni_task **, nni_taskq *, nni_cb, void *);


### PR DESCRIPTION
This changes the array of flags, which was confusing, brittle, and
racy, into a much simpler reference (busy) count on the task structures.
This allows us to support certain kinds of "reentrant" dispatching,
where either a synchronous or asynchronous task can reschedule / dispatch
itself.  The new code also helps reduce certain lock pressure, as a bonus.

