### PR TITLE
fixes #449 Want more flexible pipe events

### DIFF
--- a/docs/man/nng_pipe_notify.3.adoc
+++ b/docs/man/nng_pipe_notify.3.adoc
@@ -19,40 +19,55 @@ nng_pipe_notify - register pipe notification callback
 ----
 #include <nng/nng.h>
 
-typedef enum {
-        NNG_PIPE_ADD,
-        NNG_PIPE_REM,
-} nng_pipe_action;
+enum {
+        NNG_PIPE_EV_ADD_PRE,
+        NNG_PIPE_EV_ADD_POST,
+        NNG_PIPE_EV_REM_POST,
+};
 
-typedef void (*nng_pipe_cb)(nng_pipe, nng_pipe_action, void *);
+typedef void (*nng_pipe_cb)(nng_pipe, int, void *);
 
-int nng_pipe_notify(nng_socket s, nng_pipe_cb cb, void *arg);
+int nng_pipe_notify(nng_socket s, int ev, nng_pipe_cb cb, void *arg);
 ----
 
 == DESCRIPTION
 
 The `nng_pipe_notify()` function registers the callback function _cb_
-to be called whenever a <<nng_pipe.5#,pipe>> is added to or removed from the
-socket _s_.
+to be called whenever a <<nng_pipe.5#,pipe>> the pipe event specified by
+_ev_ occurs on the socket _s_.
+The callback _cb_ will be passed _arg_ as its final argument.
 
-The function _cb_ will be called with the action `NNG_PIPE_ADD` just before
-a pipe is added to the socket (as a result of a connection being established).
-The final argument passed will be the argument _arg_ that was specified when
-the function was registered.
+A different callback may be supplied for each event.
+Each event may have at most one callback registered.
+Registering a callback implicitly unregisters any previously registered.
 
-The function _cb_ will also be called with the action `NNG_PIPE_REM` when
-the pipe is being removed from the socket for any reason.
-This will also use the same argument _arg_.
+The following pipe events are supported:
 
-NOTE: Only one callback can be registered for a given socket. 
-Subsequent calls to `nng_pipe_notify()` on the same socket will overwrite
-any prior registration.
+`NNG_PIPE_EV_ADD_PRE`:: This event occurs after a connection and negotiation
+has completed, but before the pipe is added to the socket.
+If the pipe is closed (using `<<nng_pipe_close.3#,nng_pipe_close()>>`) at
+this point, the socket will never see the pipe, and no further events will
+occur for the given pipe.
 
-TIP: The callback _cb_ may reject a pipe for any reason by simply closing
+`NNG_PIPE_EV_ADD_POST`:: This event occurs after the pipe is fully added to
+the socket.
+Prior to this time, it is not possible to communicate over the pipe with
+the socket.
+
+`NNG_PIPE_EV_REM_POST`:: This event occurs after the pipe has been removed
+from the socket.
+The underlying transport may be closed at this point, and it is not
+possible communicate using this pipe.
+
+TIP: The callback _cb_ may close a pipe for any reason by simply closing
 it using `<<nng_pipe_close.3#,nng_pipe_close()>>`.
-This might be done, for example, if the remote peer is not authorized to
-access this session, based on values determined with the aid of
-`<<nng_pipe_getopt.3#,nng_pipe_getopt()>>`.
+This might be done before the pipe is added to the socket (during
+`NNG_PIPE_EV_ADD_PRE`), for example, if the remote peer is not authorized.
+
+TIP: It is possible to register the same _cb_ and _arg_ for different events
+by calling this function separately for different values of _ev_.
+
+NOTE: This function ignores invalid values for _ev_.
 
 == RETURN VALUES
 

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -44,7 +44,6 @@ extern uint32_t nni_sock_id(nni_sock *);
 // a pipe could wind up orphaned.
 extern int  nni_sock_pipe_add(nni_sock *, nni_pipe *);
 extern void nni_sock_pipe_remove(nni_sock *, nni_pipe *);
-extern int  nni_sock_pipe_start(nni_sock *, nni_pipe *);
 
 extern int  nni_sock_ep_add(nni_sock *, nni_ep *);
 extern void nni_sock_ep_remove(nni_sock *, nni_ep *);
@@ -71,8 +70,13 @@ extern uint32_t nni_sock_flags(nni_sock *);
 // one of the only cases (the only?) where the socket core understands
 // the public data types.  (Other solutions might exist, but they require
 // keeping extra state to support conversion between public and internal
-// types.)
-extern void nni_sock_set_pipe_cb(nni_sock *sock, nng_pipe_cb, void *);
+// types.)  The second argument is a mask of events for which the callback
+// should be executed.
+extern void nni_sock_set_pipe_cb(nni_sock *sock, int, nng_pipe_cb, void *);
+
+extern void nni_sock_run_pipe_cb(nni_sock *sock, int, uint32_t);
+
+extern bool nni_sock_closing(nni_sock *sock);
 
 // nni_ctx_open is used to open/create a new context structure.
 // Contexts are not supported by most protocols, but for those that do,

--- a/src/nng.c
+++ b/src/nng.c
@@ -1015,7 +1015,7 @@ nng_getopt_string(nng_socket s, const char *name, char **valp)
 }
 
 int
-nng_pipe_notify(nng_socket s, nng_pipe_cb cb, void *arg)
+nng_pipe_notify(nng_socket s, int ev, nng_pipe_cb cb, void *arg)
 {
 	int       rv;
 	nni_sock *sock;
@@ -1027,7 +1027,7 @@ nng_pipe_notify(nng_socket s, nng_pipe_cb cb, void *arg)
 		return (rv);
 	}
 
-	nni_sock_set_pipe_cb(sock, cb, arg);
+	nni_sock_set_pipe_cb(sock, ev, cb, arg);
 	nni_sock_rele(sock);
 	return (0);
 }

--- a/src/nng.h
+++ b/src/nng.h
@@ -223,12 +223,18 @@ NNG_DECL int nng_getopt_ptr(nng_socket, const char *, void **);
 // Only one callback can be set on a given socket, and there is no way
 // to retrieve the old value.
 typedef enum {
-	NNG_PIPE_ADD, // Pipe added to socket
-	NNG_PIPE_REM  // Pipe removed from socket
-} nng_pipe_action;
+	NNG_PIPE_EV_ADD_PRE,  // Called just before pipe added to socket
+	NNG_PIPE_EV_ADD_POST, // Called just after pipe added to socket
+	NNG_PIPE_EV_REM_POST, // Called just after poipe removed from socket
+	NNG_PIPE_EV_NUM,      // Used internally, must be last.
+} nng_pipe_ev;
 
-typedef void (*nng_pipe_cb)(nng_pipe, nng_pipe_action, void *);
-NNG_DECL int nng_pipe_notify(nng_socket, nng_pipe_cb, void *);
+typedef void (*nng_pipe_cb)(nng_pipe, int, void *);
+
+// nng_pipe_notify registers a callback to be executed when the
+// given event is triggered.  To watch for different events, register
+// multiple times.  Each event can have at most one callback registered.
+NNG_DECL int nng_pipe_notify(nng_socket, int, nng_pipe_cb, void *);
 
 // nng_getopt_string is special -- it allocates a string to hold the
 // resulting string, which should be freed with nng_strfree when it is

--- a/src/protocol/bus0/bus.c
+++ b/src/protocol/bus0/bus.c
@@ -193,6 +193,11 @@ bus0_pipe_start(void *arg)
 	bus0_pipe *p = arg;
 	bus0_sock *s = p->psock;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_BUS_V0) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	nni_mtx_lock(&s->mtx);
 	nni_list_append(&s->pipes, p);
 	nni_mtx_unlock(&s->mtx);

--- a/src/protocol/pair0/pair.c
+++ b/src/protocol/pair0/pair.c
@@ -129,6 +129,11 @@ pair0_pipe_start(void *arg)
 	pair0_pipe *p = arg;
 	pair0_sock *s = p->psock;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_PAIR_V0) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	nni_mtx_lock(&s->mtx);
 	if (s->ppipe != NULL) {
 		nni_mtx_unlock(&s->mtx);

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -173,6 +173,11 @@ pair1_pipe_start(void *arg)
 	uint32_t    id;
 	int         rv;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_PAIR_V1) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	id = nni_pipe_id(p->npipe);
 	nni_mtx_lock(&s->mtx);
 	if ((rv = nni_idhash_insert(s->pipes, id, p)) != 0) {

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -112,6 +112,11 @@ pull0_pipe_start(void *arg)
 {
 	pull0_pipe *p = arg;
 
+	if (nni_pipe_peer(p->pipe) != NNI_PROTO_PUSH_V0) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	// Start the pending pull...
 	nni_pipe_recv(p->pipe, p->recv_aio);
 

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -143,6 +143,11 @@ sub0_pipe_start(void *arg)
 {
 	sub0_pipe *p = arg;
 
+	if (nni_pipe_peer(p->pipe) != NNI_PROTO_PUB_V0) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	nni_pipe_recv(p->pipe, p->aio_recv);
 	return (0);
 }

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -346,6 +346,11 @@ rep0_pipe_start(void *arg)
 	rep0_sock *s = p->rep;
 	int        rv;
 
+	if (nni_pipe_peer(p->pipe) != NNI_PROTO_REQ_V0) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	if ((rv = nni_idhash_insert(s->pipes, nni_pipe_id(p->pipe), p)) != 0) {
 		return (rv);
 	}

--- a/src/protocol/reqrep0/xrep.c
+++ b/src/protocol/reqrep0/xrep.c
@@ -178,6 +178,11 @@ xrep0_pipe_start(void *arg)
 	xrep0_sock *s = p->rep;
 	int         rv;
 
+	if (nni_pipe_peer(p->pipe) != NNI_PROTO_REQ_V0) {
+		// Peer protocol mismatch.
+		return (NNG_EPROTO);
+	}
+
 	if ((rv = nni_idhash_insert(s->pipes, nni_pipe_id(p->pipe), p)) != 0) {
 		return (rv);
 	}

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -341,6 +341,10 @@ resp0_pipe_start(void *arg)
 	resp0_sock *s = p->psock;
 	int         rv;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_SURVEYOR_V0) {
+		return (NNG_EPROTO);
+	}
+
 	nni_mtx_lock(&s->mtx);
 	rv = nni_idhash_insert(s->pipes, p->id, p);
 	nni_mtx_unlock(&s->mtx);

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -338,6 +338,10 @@ surv0_pipe_start(void *arg)
 	surv0_pipe *p = arg;
 	surv0_sock *s = p->sock;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_RESPONDENT_V0) {
+		return (NNG_EPROTO);
+	}
+
 	nni_mtx_lock(&s->mtx);
 	nni_list_append(&s->pipes, p);
 	nni_mtx_unlock(&s->mtx);

--- a/src/protocol/survey0/xrespond.c
+++ b/src/protocol/survey0/xrespond.c
@@ -164,6 +164,10 @@ xresp0_pipe_start(void *arg)
 	xresp0_sock *s = p->psock;
 	int          rv;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_SURVEYOR_V0) {
+		return (NNG_EPROTO);
+	}
+
 	p->id = nni_pipe_id(p->npipe);
 
 	nni_mtx_lock(&s->mtx);

--- a/src/protocol/survey0/xsurvey.c
+++ b/src/protocol/survey0/xsurvey.c
@@ -166,6 +166,10 @@ xsurv0_pipe_start(void *arg)
 	xsurv0_pipe *p = arg;
 	xsurv0_sock *s = p->psock;
 
+	if (nni_pipe_peer(p->npipe) != NNI_PROTO_RESPONDENT_V0) {
+		return (NNG_EPROTO);
+	}
+
 	nni_mtx_lock(&s->mtx);
 	nni_list_append(&s->pipes, p);
 	nni_mtx_unlock(&s->mtx);

--- a/tests/pipe.c
+++ b/tests/pipe.c
@@ -27,27 +27,48 @@ struct testcase {
 	nng_dialer   d;
 	nng_listener l;
 	nng_pipe     p;
-	int          add;
+	int          add_pre;
+	int          add_post;
 	int          rem;
 	int          err;
+	int          rej;
+	nng_mtx *    lk;
 };
 
+static int
+getval(struct testcase *t, int *vp)
+{
+	int rv;
+	nng_mtx_lock(t->lk);
+	rv = *vp;
+	nng_mtx_unlock(t->lk);
+	return (rv);
+}
+
 void
-notify(nng_pipe p, nng_pipe_action act, void *arg)
+notify(nng_pipe p, int act, void *arg)
 {
 	struct testcase *t = arg;
 
+	nng_mtx_lock(t->lk);
 	if ((nng_socket_id(nng_pipe_socket(p)) != nng_socket_id(t->s)) ||
 	    (nng_listener_id(nng_pipe_listener(p)) != nng_listener_id(t->l)) ||
 	    (nng_dialer_id(nng_pipe_dialer(p)) != nng_dialer_id(t->d))) {
 		t->err++;
+		nng_mtx_unlock(t->lk);
 		return;
 	}
+	if (t->add_post > t->add_pre) {
+		t->err++;
+	}
 	switch (act) {
-	case NNG_PIPE_ADD:
-		t->add++;
+	case NNG_PIPE_EV_ADD_PRE:
+		t->add_pre++;
 		break;
-	case NNG_PIPE_REM:
+	case NNG_PIPE_EV_ADD_POST:
+		t->add_post++;
+		break;
+	case NNG_PIPE_EV_REM_POST:
 		t->rem++;
 		break;
 	default:
@@ -55,6 +76,21 @@ notify(nng_pipe p, nng_pipe_action act, void *arg)
 		return;
 	}
 	t->p = p;
+	nng_mtx_unlock(t->lk);
+}
+
+void
+reject(nng_pipe p, int act, void *arg)
+{
+	struct testcase *t = arg;
+	notify(p, act, arg);
+
+	nng_mtx_lock(t->lk);
+	if (!t->rej) {
+		nng_pipe_close(p);
+		t->rej++;
+	}
+	nng_mtx_unlock(t->lk);
 }
 
 char       addr[64];
@@ -70,16 +106,30 @@ TestMain("Pipe notify works", {
 
 		memset(&pull, 0, sizeof(pull));
 		memset(&push, 0, sizeof(push));
+		So(nng_mtx_alloc(&push.lk) == 0);
+		So(nng_mtx_alloc(&pull.lk) == 0);
 		So(nng_push_open(&push.s) == 0);
 		So(nng_pull_open(&pull.s) == 0);
 
 		Reset({
 			nng_close(push.s);
 			nng_close(pull.s);
+			nng_mtx_free(push.lk);
+			nng_mtx_free(pull.lk);
 		});
 
-		So(nng_pipe_notify(push.s, notify, &push) == 0);
-		So(nng_pipe_notify(pull.s, notify, &pull) == 0);
+		So(nng_pipe_notify(
+		       push.s, NNG_PIPE_EV_ADD_PRE, notify, &push) == 0);
+		So(nng_pipe_notify(
+		       push.s, NNG_PIPE_EV_ADD_POST, notify, &push) == 0);
+		So(nng_pipe_notify(
+		       push.s, NNG_PIPE_EV_REM_POST, notify, &push) == 0);
+		So(nng_pipe_notify(
+		       pull.s, NNG_PIPE_EV_ADD_PRE, notify, &pull) == 0);
+		So(nng_pipe_notify(
+		       pull.s, NNG_PIPE_EV_ADD_POST, notify, &pull) == 0);
+		So(nng_pipe_notify(
+		       pull.s, NNG_PIPE_EV_REM_POST, notify, &pull) == 0);
 
 		So(nng_setopt_ms(push.s, NNG_OPT_RECONNMINT, 10) == 0);
 		So(nng_setopt_ms(push.s, NNG_OPT_RECONNMAXT, 10) == 0);
@@ -92,12 +142,14 @@ TestMain("Pipe notify works", {
 			So(nng_listener_start(pull.l, 0) == 0);
 			So(nng_dialer_start(push.d, 0) == 0);
 			nng_msleep(100);
-			So(pull.add == 1);
-			So(pull.rem == 0);
-			So(pull.err == 0);
-			So(push.add == 1);
-			So(push.rem == 0);
-			So(push.err == 0);
+			So(getval(&pull, &pull.add_pre) == 1);
+			So(getval(&pull, &pull.add_post) == 1);
+			So(getval(&pull, &pull.rem) == 0);
+			So(getval(&pull, &pull.err) == 0);
+			So(getval(&push, &push.add_pre) == 1);
+			So(getval(&push, &push.add_post) == 1);
+			So(getval(&push, &push.rem) == 0);
+			So(getval(&push, &push.err) == 0);
 			Convey("We can send a frame", {
 				nng_msg *msg;
 
@@ -114,17 +166,20 @@ TestMain("Pipe notify works", {
 			});
 
 			Convey("Reconnection works", {
-				So(pull.add == 1);
+				So(getval(&pull, &pull.add_pre) == 1);
+				So(getval(&pull, &pull.add_post) == 1);
 				nng_pipe_close(pull.p);
 				nng_msleep(200);
 
-				So(pull.err == 0);
-				So(pull.rem == 1);
-				So(pull.add == 2);
+				So(getval(&pull, &pull.err) == 0);
+				So(getval(&pull, &pull.rem) == 1);
+				So(getval(&pull, &pull.add_pre) == 2);
+				So(getval(&pull, &pull.add_post) == 2);
 
-				So(push.err == 0);
-				So(push.rem == 1);
-				So(push.add == 2);
+				So(getval(&push, &push.err) == 0);
+				So(getval(&push, &push.rem) == 1);
+				So(getval(&push, &push.add_pre) == 2);
+				So(getval(&push, &push.add_post) == 2);
 
 				Convey("They still exchange frames", {
 					nng_msg *msg;
@@ -144,6 +199,26 @@ TestMain("Pipe notify works", {
 					    nng_pipe_id(pull.p));
 				});
 			});
+		});
+
+		Convey("Reject works", {
+			So(nng_pipe_notify(pull.s, NNG_PIPE_EV_ADD_PRE, reject,
+			       &pull) == 0);
+			So(nng_listener_create(&pull.l, pull.s, addr) == 0);
+			So(nng_dialer_create(&push.d, push.s, addr) == 0);
+			So(nng_listener_id(pull.l) > 0);
+			So(nng_dialer_id(push.d) > 0);
+			So(nng_listener_start(pull.l, 0) == 0);
+			So(nng_dialer_start(push.d, 0) == 0);
+			nng_msleep(100);
+			So(getval(&pull, &pull.add_pre) == 2);
+			So(getval(&pull, &pull.add_post) == 1);
+			So(getval(&pull, &pull.rem) == 1);
+			So(getval(&pull, &pull.err) == 0);
+			So(getval(&push, &push.add_pre) == 2);
+			So(getval(&push, &push.add_post) == 2);
+			So(getval(&push, &push.rem) == 1);
+			So(getval(&push, &push.err) == 0);
 		});
 	});
 })


### PR DESCRIPTION
This changes the signature of nng_pipe_notify(), and the associated
events.  The documentation is updated to reflect this.

We have also broken the lock up so that we don't hold the master
socket lock for some of these things, which may have beneficial
impact on performance.
