### PR TITLE
fixes #462 mode_t missing during compilation

### DIFF
--- a/src/platform/posix/posix_aio.h
+++ b/src/platform/posix/posix_aio.h
@@ -20,6 +20,8 @@
 #include "core/nng_impl.h"
 #include "posix_pollq.h"
 
+#include <sys/types.h> // needed for mode_t
+
 typedef struct nni_posix_pipedesc nni_posix_pipedesc;
 typedef struct nni_posix_epdesc   nni_posix_epdesc;
 


### PR DESCRIPTION
On Alpine Linux, this was noticed.  Obviously sys/types.h needs to be present for almost any non-trivial program on Linux or POSIX systems.