### PR TITLE
Compathdrs

### DIFF
--- a/docs/man/nng_compat.3compat.adoc
+++ b/docs/man/nng_compat.3compat.adoc
@@ -17,19 +17,32 @@ nng_compat - compatibility with nanomsg 1.0
 
 [source, c]
 ----
-#include <nn/nn.h>
+#include <nanomsg/nn.h>
+
+#include <nanomsg/bus.h>
+#include <nanomsg/pair.h>
+#include <nanomsg/pipeline.h>
+#include <nanomsg/pubsub.h>
+#include <nanomsg/reqrep.h>
+#include <nanomsg/survey.h>
+
+#include <nanomsg/inproc.h>
+#include <nanomsg/ipc.h>
+#include <nanomsg/tcp.h>
+#include <nanomsg/ws.h>
 ----
 
 == DESCRIPTION
 
+(((compatibility layer)))
 The <<nng.7#,_nng_>> library provides source-level compatibility for
 most _nanomsg_ 1.0 applications.
 
-IMPORTANT: This is intended to faciliate converting legacy applications to
+IMPORTANT: This is intended to faciliate converting ((legacy applications)) to
 use the _nng_ library.
 New applications should use the newer <<nng.7#,_nng_>> API instead.
 
-Applications making use of this ((compatibility layer)) must take care
+Applications making use of this must take care
 to link with <<libnng.3#,_libnng_>> instead of _libnn_.
 
 TIP: While not recommended for long term use, the value returned by
@@ -45,11 +58,38 @@ NOTE: While reasonable efforts have been made to provide for compatibility,
 some things may behave differently, and some less common parts of the
 _nanomsg_ 1.0 API are not supported at this time, including certain
 options and the statistics API.
+See the <<Caveats>> section below.
 
-TIP: If an installation of the older _nanomsg_ library is present on
-the build system, it may be necessary to provide a different search
-path for header files to ensure that the compatibility definitions are
-used in compilation.
+=== Compiling
+
+When compiling legacy _nanomsg_ applications, it will generally be
+necessary to change the include search path to add the "`compat`" subdirectory
+of the directory where headers were installed.
+For example, if _nng_ is installed in `$prefix`, then header files will
+normally be located in `$prefix/include/nng`.
+In this case, to build legacy _nanomsg_ apps against _nng_ you would
+add `$prefix/include/nng/compat` to your compiler's search path.
+
+Alternatively, you can change your source code so that `#include` statements
+referring to `<nanomsg>` instead refer to `<nng/compat/nanomsg>`.
+For example, instead of:
+
+[source,c]
+----
+#include <nanomsg/nn.h>
+#include <nanomsg/reqrep.h>
+----
+
+you would have this:
+
+[source,c]
+----
+#include <nng/compat/nanomsg/nn.h>
+#include <nng/compat/nanomsg/reqrep.h>
+----
+
+Legacy applications built using these methods should be linked against _libnng_
+instead of _libnn_, just like any other _nng_ application.
 
 === Functions
 
@@ -109,51 +149,46 @@ ifdef::backend-pdf[]
 |===
 endif::[]
 
-There are a few caveats, that should be kept in mind.
+=== Caveats
 
-NOTE: Socket numbers can be quite large.
-The legacy _libnanomsg_ attempted to reuse socket numbers, like
-file descriptors in UNIX systems.
-The _nng_ library avoids this to prevent accidental reuse or
-collision after a descriptor is closed.
-Consequently, socket numbers can become quite large, and should
-probably not be used for array indices.
+The following caveats apply when using the legacy API with _nng_.
 
-NOTE: The following options (`nn_getsockopt`) are unsupported:
-`NN_SNDPRIO`, `NN_RCVPRIO`, `NN_IPV4ONLY`.
-The priority options may be supported in the future, when
-the underlying capability is present in _nng_.
+* Socket numbers can be quite large.
+  The legacy _libnanomsg_ attempted to reuse socket numbers, like
+  file descriptors in UNIX systems.
+  The _nng_ library avoids this to prevent accidental reuse or
+  collision after a descriptor is closed.
+  Consequently, socket numbers can become quite large, and should
+  probably not be used for array indices.
 
-NOTE: Access to statistics using this legacy API
-(`<<nn_get_statistic.3compat#,nn_get_statistic()>>`) is unsupported.
+* The following options (`nn_getsockopt`) are unsupported:
+  `NN_SNDPRIO`, `NN_RCVPRIO`, `NN_IPV4ONLY`.
+  The priority options may be supported in the future, when
+  the underlying capability is present in _nng_.
 
-NOTE: Some transports can support longer URLs than legacy _libnanomsg_ can.
-It is a good idea to use short pathnames in URLs if interoperability
-is a concern.
+* Access to statistics using this legacy API
+  (`<<nn_get_statistic.3compat#,nn_get_statistic()>>`) is unsupported.
 
-NOTE: Only absolute paths are supported in `ipc://` URLs.
-For example, `ipc:///tmp/mysocket` is acceptable, but `ipc://mysocket` is not.
+* Some transports can support longer URLs than legacy _libnanomsg_ can.
+  It is a good idea to use short pathnames in URLs if interoperability
+  is a concern.
 
-NOTE: Some transports are unusable from this mode.
-In particular, this legacy API offers no way to configure
-TLS parameters that are required for use.
+* Only absolute paths are supported in `ipc://` URLs.
+  For example, `ipc:///tmp/mysocket` is acceptable, but `ipc://mysocket` is not.
 
-NOTE: ABI versioning is not supported.
-We don't offer the `NN_VERSION_` macros.  Sorry.
+* The WebSocket transport in this implementation (`ws://` URLs)
+  only supports BINARY frames.
 
-NOTE: Runtime symbol information is not implemented.
-Specifically, there is no `nn_symbol()` function yet.
-(This may be addressed later if there is a need.)
+* Some newer transports are unusable from this mode.
+  In particular, this legacy API offers no way to configure
+  TLS or ZeroTier parameters that may be required for use.
 
-IMPORTANT: The `nn_term()` function is destructive and should be avoided.
-This function closes down all sockets, and really there is no good
-reason to ever use it.
-Removal from existing code is advised.
-(Keep track of sockets and close them explicitly if necessary.)
+* ABI versioning of the compatibility layer is not supported,
+  and the `NN_VERSION_` macros are not present.
 
-IMPORTANT: It *is* possible at present to intermix sockets between the new and
-the old APIs, but this is not a guaranteed feature, and should only
-be used temporarily to facilitate transitioning code to the new APIs.
+* Runtime symbol information is not implemented.
+  Specifically, there is no `nn_symbol()` function yet.
+  (This may be addressed later if there is a need.)
 
 == SEE ALSO
 

--- a/docs/man/nngcat.1.adoc
+++ b/docs/man/nngcat.1.adoc
@@ -186,28 +186,9 @@ more than one peer on a given connection.
 
 === Receive Options
 
-Data messages received can be formatted in different ways.  These
-options can only be specified when using a protocol that receives messages.
-
-*--format*=_FORMAT_::
-  Format data as indicated.  The _FORMAT_ can be any of: +
-  `no`:::
-    No output at all.
-  `raw`:::
-    Raw output, every byte received is sent to standard output.
-  `ascii`:::
-    ((ASCII)) safe, printable ASCII is emitted verbatim, with other bytes
-    substituted with `.` (period).
-  `quoted`:::
-    Messages are printed as ((quoted)) strings, using C language conventions.
-  `hex`:::
-    (((hex))) Messages are printed as quoted strings, with every byte appearing
-    as an escaped hexadecimal value, such as `\x2E`.
-  `msgpack`:::
-    (((msgpack)))
-    (((MessagePack)))
-    Messages are emitted as https://msgpack.org[MessagePack] "bin format"
-    (byte arrays).
+Data messages received can be formatted in different ways.
+These options can only be specified when using a protocol that
+receives messages.
 
 *-A, --ascii*::
   The same as specifying *--format*=`ascii`.
@@ -233,6 +214,25 @@ options can only be specified when using a protocol that receives messages.
   Messages larger than this will be discarded.
   The default is 1048576 (1 MB).
   To eliminate any restriction, use 0.
+
+*--format*=_FORMAT_::
+  Format data as indicated.  The _FORMAT_ can be any of:
+
+`no`::: No output at all.
+
+`raw`::: Raw output, every byte received is sent to standard output.
+
+`ascii`::: ((ASCII)) safe, printable ASCII is emitted verbatim, with other
+bytes substituted with `.` (period).
+
+`quoted`:::  Messages are printed as ((quoted)) strings, using C language
+conventions.
+
+`hex`::: (((hex))) Messages are printed as quoted strings, with every byte appearing as an escaped hexadecimal value, such as `\x2E`.
+
+`msgpack`::: (((msgpack)))(((MessagePack)))
+Messages are emitted as https://msgpack.org[MessagePack] "bin format"
+(byte arrays).
 
 === Transmit Options
 

--- a/src/compat/nanomsg/CMakeLists.txt
+++ b/src/compat/nanomsg/CMakeLists.txt
@@ -9,7 +9,18 @@
 #
 
 set(COMPAT_SOURCES compat/nanomsg/nn.c)
-set(COMPAT_HEADERS compat/nanomsg/nn.h)
+set(COMPAT_HEADERS compat/nanomsg/nn.h
+        compat/nanomsg/bus.h
+        compat/nanomsg/inproc.h
+        compat/nanomsg/ipc.h
+        compat/nanomsg/pair.h
+        compat/nanomsg/pipeline.h
+        compat/nanomsg/pubsub.h
+        compat/nanomsg/reqrep.h
+        compat/nanomsg/survey.h
+        compat/nanomsg/tcp.h
+        compat/nanomsg/ws.h
+)
 
 set(NNG_SOURCES ${NNG_SOURCES} ${COMPAT_SOURCES} PARENT_SCOPE)
 set(NNG_HEADERS ${NNG_HEADERS} ${COMPAT_HEADERS} PARENT_SCOPE)

--- a/src/compat/nanomsg/bus.h
+++ b/src/compat/nanomsg/bus.h
@@ -1,0 +1,33 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_BUS_H
+#define NNG_COMPAT_BUS_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// BUS sockopt level.
+#define NN_PROTO_BUS 7
+#define NN_BUS (NN_PROTO_BUS * 16 + 0)
+
+// BUS has no options.
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_BUS_H

--- a/src/compat/nanomsg/inproc.h
+++ b/src/compat/nanomsg/inproc.h
@@ -1,0 +1,31 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_INPROC_H
+#define NNG_COMPAT_INPROC_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// inproc sockopt level.
+// There are no inproc tunables.
+#define NN_INPROC (-1)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_INPROC_H

--- a/src/compat/nanomsg/ipc.h
+++ b/src/compat/nanomsg/ipc.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_IPC_H
+#define NNG_COMPAT_IPC_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// IPC sockopt level.
+#define NN_IPC (-2)
+
+// IPC options.  Note that these are not currently supported.
+// IPC_SEC_ATTR works quite differently in NNG, and must be
+// configured using the new API.  The buffer sizing options are
+// not supported at all.  None of these were ever documente, and
+// are offered here only for source compatibility.
+#define NN_IPC_SEC_ATTR 1
+#define NN_IPC_OUTBUFSZ 2
+#define NN_IPC_INBUFSZ 3
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_IPC_H

--- a/src/compat/nanomsg/nn.c
+++ b/src/compat/nanomsg/nn.c
@@ -9,6 +9,22 @@
 //
 
 #include "nn.h"
+
+// transports
+#include "inproc.h"
+#include "ipc.h"
+#include "tcp.h"
+#include "ws.h"
+
+// protocols
+#include "bus.h"
+#include "pair.h"
+#include "pipeline.h"
+#include "pubsub.h"
+#include "reqrep.h"
+#include "survey.h"
+
+// underlying NNG headers
 #include "nng.h"
 #include "protocol/bus0/bus.h"
 #include "protocol/pair0/pair.h"

--- a/src/compat/nanomsg/nn.h
+++ b/src/compat/nanomsg/nn.h
@@ -8,12 +8,12 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#ifndef NNG_COMPAT_H
-#define NNG_COMPAT_H
+#ifndef NNG_COMPAT_NN_H
+#define NNG_COMPAT_NN_H
 
 // This header contains interfaces that are intended to offer compatibility
 // with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
-// and consumers should only use thse if they are porting software that
+// and consumers should only use these if they are porting software that
 // previously used nanomsg.  New programs should use the nng native APIs.
 
 // Note that compatibility promises are limited to public portions of the
@@ -62,27 +62,6 @@ extern "C" {
 
 #define AF_SP			1
 #define AF_SP_RAW		2
-
-// Protocol stuff
-#define NN_PROTO_PAIR		1
-#define NN_PROTO_PUBSUB		2
-#define NN_PROTO_REQREP		3
-#define NN_PROTO_PIPELINE	5
-#define NN_PROTO_SURVEY		6
-#define NN_PROTO_BUS		7
-
-#define NN_PAIR			(NN_PROTO_PAIR * 16 + 0)
-#define NN_PAIR_v0		(NN_PROTO_PAIR * 16 + 0)
-#define NN_PAIR_V1		(NN_PROTO_PAIR * 16 + 1)
-#define NN_PUB			(NN_PROTO_PUBSUB * 16 + 0)
-#define NN_SUB			(NN_PROTO_PUBSUB * 16 + 1)
-#define NN_REQ			(NN_PROTO_REQREP * 16 + 0)
-#define NN_REP			(NN_PROTO_REQREP * 16 + 1)
-#define NN_PUSH			(NN_PROTO_PIPELINE * 16 + 0)
-#define NN_PULL			(NN_PROTO_PIPELINE * 16 + 1)
-#define NN_SURVEYOR		(NN_PROTO_SURVEY * 16 + 2)
-#define NN_RESPONDENT		(NN_PROTO_SURVEY * 16 + 3)
-#define NN_BUS			(NN_PROTO_BUS * 16 + 0)
 
 #define NN_SOCKADDR_MAX		128
 #define NN_SOL_SOCKET		0
@@ -223,26 +202,6 @@ extern "C" {
 #define NN_RCVMAXSIZE		16
 #define NN_MAXTTL		17
 
-// Protocol-specific options.  To simplify thins we encode the protocol
-// level in the option.
-#define NN_SUB_SUBSCRIBE		(NN_SUB * 16 + 1)
-#define NN_SUB_UNSUBSCRIBE		(NN_SUB * 16 + 2)
-#define NN_REQ_RESEND_IVL		(NN_REQ * 16 + 1)
-#define NN_SURVEYOR_DEADLINE		(NN_SURVEYOR * 16 + 1)
-
-// Level options for tranports
-#define NN_INPROC			(-1)
-#define NN_IPC				(-2)
-#define NN_IPC_SEC_ATTR			1
-#define NN_IPC_OUTBUFSZ			2
-#define NN_IPC_INBUFSZ			3
-#define NN_TCP				(-3)
-#define NN_TCP_NODELAY			1
-#define NN_WS				(-4)
-#define NN_WS_MSG_TYPE			1
-#define NN_WS_MSG_TYPE_TEXT		1
-#define NN_WS_MSG_TYPE_BINARY		2
-
 // from this point on formatting is fine
 // clang-format on
 
@@ -319,4 +278,4 @@ NN_DECL void        nn_term(void);
 }
 #endif
 
-#endif // NNG_COMPAT_H
+#endif // NNG_COMPAT_NN_H

--- a/src/compat/nanomsg/pair.h
+++ b/src/compat/nanomsg/pair.h
@@ -1,0 +1,39 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_PAIR_H
+#define NNG_COMPAT_PAIR_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// PAIR sockopt level.
+#define NN_PROTO_PAIR 1
+#define NN_PAIR (NN_PROTO_PAIR * 16 + 0)
+
+// These are technically "new", and not available in nanomsg, but
+// offered here as a transition aid.  If you want to use the advanced
+// PAIRv1 options (POLYAMOROUS mode) you still need to use the new API.
+#define NN_PAIR_v0 (NN_PROTO_PAIR * 16 + 0)
+#define NN_PAIR_V1 (NN_PROTO_PAIR * 16 + 1)
+
+// PAIR has no options.
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_PAIR_H

--- a/src/compat/nanomsg/pipeline.h
+++ b/src/compat/nanomsg/pipeline.h
@@ -1,0 +1,34 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_PIPELINE_H
+#define NNG_COMPAT_PIPELINE_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// PUSH and PULL sockopt level.
+#define NN_PROTO_PIPELINE 5
+#define NN_PUSH (NN_PROTO_PIPELINE * 16 + 0)
+#define NN_PULL (NN_PROTO_PIPELINE * 16 + 1)
+
+// PUSH and PULL have no options.
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_PIPELINE_H

--- a/src/compat/nanomsg/pubsub.h
+++ b/src/compat/nanomsg/pubsub.h
@@ -1,0 +1,36 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_PUBSUB_H
+#define NNG_COMPAT_PUBSUB_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// PUB and SUB sockopt level.
+#define NN_PROTO_PUBSUB 2
+#define NN_PUB (NN_PROTO_PUBSUB * 16 + 0)
+#define NN_SUB (NN_PROTO_PUBSUB * 16 + 1)
+
+// SUB options.  (PUB has none.)
+#define NN_SUB_SUBSCRIBE (NN_SUB * 16 + 1)
+#define NN_SUB_UNSUBSCRIBE (NN_SUB * 16 + 2)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_PUBSUB_H

--- a/src/compat/nanomsg/reqrep.h
+++ b/src/compat/nanomsg/reqrep.h
@@ -1,0 +1,35 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_REQREP_H
+#define NNG_COMPAT_REQREP_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// REQ and REP sockopt level.
+#define NN_PROTO_REQREP 3
+#define NN_REQ (NN_PROTO_REQREP * 16 + 0)
+#define NN_REP (NN_PROTO_REQREP * 16 + 1)
+
+// REQ options.  (REP has none.)
+#define NN_REQ_RESEND_IVL (NN_REQ * 16 + 1)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_REQREP_H

--- a/src/compat/nanomsg/survey.h
+++ b/src/compat/nanomsg/survey.h
@@ -1,0 +1,36 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_SURVEY_H
+#define NNG_COMPAT_SURVEY_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// SURVEYOR and RESPONDENT sockopt level.
+#define NN_PROTO_SURVEY 6
+#define NN_SURVEYOR (NN_PROTO_SURVEY * 16 + 2)
+#define NN_RESPONDENT (NN_PROTO_SURVEY * 16 + 3)
+
+// SURVEYOR options.  (RESPONDENT has none.)
+
+#define NN_SURVEYOR_DEADLINE (NN_SURVEYOR * 16 + 1)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_SURVEY_H

--- a/src/compat/nanomsg/tcp.h
+++ b/src/compat/nanomsg/tcp.h
@@ -1,0 +1,33 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_TCP_H
+#define NNG_COMPAT_TCP_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// TCP sockopt level.
+#define NN_TCP (-3)
+
+// TCP options.
+#define NN_TCP_NODELAY 1
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_TCP_H

--- a/src/compat/nanomsg/ws.h
+++ b/src/compat/nanomsg/ws.h
@@ -1,0 +1,41 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef NNG_COMPAT_WS_H
+#define NNG_COMPAT_WS_H
+
+// This header contains interfaces that are intended to offer compatibility
+// with nanomsg v1.0.  These are not the "preferred" interfaces for nng,
+// and consumers should only use these if they are porting software that
+// previously used nanomsg.  New programs should use the nng native APIs.
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// WS sockopt level.
+#define NN_WS (-4)
+
+// WS options.
+
+// Note that while legacy libnanomsg had *some* support for text messages,
+// NNG only supports binary.  Binary types are required to pass protocol
+// headers with NNG and nanomsg in any event.  This means that the NNG
+// WebSocket support will not be compatible with some very old browsers.
+#define NN_WS_MSG_TYPE 1
+
+#define NN_WS_MSG_TYPE_TEXT 0x1
+#define NN_WS_MSG_TYPE_BINARY 0x2
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // NNG_COMPAT_WS_H

--- a/tests/compat_block.c
+++ b/tests/compat_block.c
@@ -21,6 +21,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
 #include "compat_testutil.h"
 
 /*  This test checks whether blocking on send/recv works as expected. */

--- a/tests/compat_bug777.c
+++ b/tests/compat_bug777.c
@@ -22,6 +22,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
 #include "compat_testutil.h"
 
 int main (NN_UNUSED int argc, NN_UNUSED const char *argv[])

--- a/tests/compat_bus.c
+++ b/tests/compat_bus.c
@@ -21,6 +21,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/bus.h>
 #include "compat_testutil.h"
 
 #define SOCKET_ADDRESS_A "inproc://a"

--- a/tests/compat_cmsg.c
+++ b/tests/compat_cmsg.c
@@ -23,6 +23,9 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/tcp.h>
+#include <nanomsg/reqrep.h>
+
 #include "compat_testutil.h"
 
 int main (int argc, const char *argv[])

--- a/tests/compat_device.c
+++ b/tests/compat_device.c
@@ -22,6 +22,10 @@
  */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/bus.h>
+#include <nanomsg/pair.h>
+#include <nanomsg/pipeline.h>
+#include <nanomsg/inproc.h>
 #include "compat_testutil.h"
 
 #define SOCKET_ADDRESS_A    "inproc://a"

--- a/tests/compat_iovec.c
+++ b/tests/compat_iovec.c
@@ -21,6 +21,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
 
 #include "compat_testutil.h"
 

--- a/tests/compat_msg.c
+++ b/tests/compat_msg.c
@@ -24,6 +24,8 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
+
 #include "compat_testutil.h"
 
 #include <string.h>

--- a/tests/compat_options.c
+++ b/tests/compat_options.c
@@ -11,6 +11,7 @@
 #include "convey.h"
 
 #include "compat/nanomsg/nn.h"
+#include "compat/nanomsg/reqrep.h"
 
 #include "compat_testutil.h"
 

--- a/tests/compat_pair.c
+++ b/tests/compat_pair.c
@@ -21,6 +21,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
 
 #include "compat_testutil.h"
 

--- a/tests/compat_pipeline.c
+++ b/tests/compat_pipeline.c
@@ -22,6 +22,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/pipeline.h>
 #include "compat_testutil.h"
 
 #define SOCKET_ADDRESS "inproc://a"

--- a/tests/compat_poll.c
+++ b/tests/compat_poll.c
@@ -34,6 +34,8 @@
 #endif
 #include "compat_testutil.h"
 #include <nanomsg/nn.h>
+#include <nanomsg/pair.h>
+#include <nanomsg/inproc.h>
 
 /*  Test of polling via NN_SNDFD/NN_RCVFD mechanism. */
 

--- a/tests/compat_reqrep.c
+++ b/tests/compat_reqrep.c
@@ -23,6 +23,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/reqrep.h>
 
 #include "compat_testutil.h"
 

--- a/tests/compat_reqttl.c
+++ b/tests/compat_reqttl.c
@@ -24,6 +24,8 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/reqrep.h>
+#include <nanomsg/tcp.h>
 
 #include "compat_testutil.h"
 

--- a/tests/compat_shutdown.c
+++ b/tests/compat_shutdown.c
@@ -22,6 +22,8 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/tcp.h>
+#include <nanomsg/reqrep.h>
 #include "compat_testutil.h"
 
 int main (int argc, const char *argv[])

--- a/tests/compat_survey.c
+++ b/tests/compat_survey.c
@@ -22,6 +22,7 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/survey.h>
 
 #include "compat_testutil.h"
 

--- a/tests/compat_surveyttl.c
+++ b/tests/compat_surveyttl.c
@@ -24,6 +24,8 @@
 */
 
 #include <nanomsg/nn.h>
+#include <nanomsg/survey.h>
+#include <nanomsg/tcp.h>
 
 #include "compat_testutil.h"
 

--- a/tests/compat_testutil.h
+++ b/tests/compat_testutil.h
@@ -28,8 +28,8 @@
 // it for validating the compatibility features of nanomsg.   As much as
 // possible we want to run tests from the nanomsg test suite unmodified.
 
-#ifndef TESTUTIL_H_INCLUDED
-#define TESTUTIL_H_INCLUDED
+#ifndef COMPAT_TESTUTIL_H_INCLUDED
+#define COMPAT_TESTUTIL_H_INCLUDED
 
 #include <assert.h>
 #include <stdio.h>
@@ -80,4 +80,4 @@ struct nn_thread {
 extern int nn_thread_init(struct nn_thread *, void (*)(void *), void *);
 extern void nn_thread_term(struct nn_thread *);
 
-#endif // TESTUTIL_H_INCLUDED
+#endif // COMPAT_TESTUTIL_H_INCLUDED


### PR DESCRIPTION
This fixes #457, but it also changes the documentation to make improvements in the nng_compat
manual page, and to fix layout errors in the nngcat page when viewed on a kindle.