### PR TITLE
fixes #32 autoscale based on CPUs available

### DIFF
--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -190,6 +190,10 @@ extern int nni_plat_init(int (*)(void));
 // will be called until nni_platform_init is called.
 extern void nni_plat_fini(void);
 
+// nni_plat_ncpu returns the number of logical CPUs on the system.  This is
+// used to scale the number of independent threads started.
+extern int nni_plat_ncpu(void);
+
 //
 // TCP Support.
 //

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -261,11 +261,14 @@ nni_task_fini(nni_task *task)
 int
 nni_taskq_sys_init(void)
 {
-	int rv;
+	int nthrs;
 
-	// XXX: Make the "16" = NCPUs * 2
-	rv = nni_taskq_init(&nni_taskq_systq, 16);
-	return (rv);
+	nthrs = nni_plat_ncpu() * 2;
+	if (nthrs < 2) {
+		nthrs = 2;
+	}
+
+	return (nni_taskq_init(&nni_taskq_systq, nthrs));
 }
 
 void

--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -336,4 +336,16 @@ nni_plat_fini(void)
 	pthread_mutex_unlock(&nni_plat_init_lock);
 }
 
+int
+nni_plat_ncpu(void)
+{
+	// POSIX specifies sysconf exists, but not the value
+	// _SC_NPROCESSORS_ONLN.  Nonetheless, everybody implements it.
+	// If you don't we'll assume you only have a single logical CPU.
+#ifdef _SC_NPROCESSORS_ONLN
+	return (sysconf(_SC_NPROCESSORS_ONLN));
+#else
+	return (1);
+#endif
+}
 #endif // NNG_PLATFORM_POSIX

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -148,6 +148,15 @@ nni_plat_thr_is_self(nni_plat_thr *thr)
 static LONG plat_inited = 0;
 
 int
+nni_plat_ncpu(void)
+{
+	SYSTEM_INFO info;
+
+	GetSystemInfo(&info);
+	return ((int) (info.dwNumberOfProcessors));
+}
+
+int
 nni_plat_init(int (*helper)(void))
 {
 	int            rv   = 0;


### PR DESCRIPTION
This should work on both Windows and the most common POSIX
variants.  We will create at least two threads for running
completions, but there are numerous other threads in the code.
