### PR TITLE
fixes #533 nni_aio_begin should not dispatch task on NNG_ECLOSED.

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -337,6 +337,11 @@ nni_aio_begin(nni_aio *aio)
 		nni_mtx_unlock(&nni_aio_lk);
 		return (NNG_ECANCELED);
 	}
+	if (aio->a_closed) {
+		aio->a_result = NNG_ECLOSED;
+		nni_mtx_unlock(&nni_aio_lk);
+		return (NNG_ECLOSED);
+	}
 	aio->a_result      = 0;
 	aio->a_count       = 0;
 	aio->a_prov_cancel = NULL;
@@ -345,14 +350,6 @@ nni_aio_begin(nni_aio *aio)
 		aio->a_outputs[i] = NULL;
 	}
 	nni_task_prep(aio->a_task);
-	if (aio->a_closed) {
-		aio->a_result = NNG_ECLOSED;
-		aio->a_expire = NNI_TIME_NEVER;
-		aio->a_sleep  = false;
-		nni_mtx_unlock(&nni_aio_lk);
-		nni_task_dispatch(aio->a_task);
-		return (NNG_ECLOSED);
-	}
 	nni_mtx_unlock(&nni_aio_lk);
 	return (0);
 }


### PR DESCRIPTION
This changes nni_aio_begin so that it immediately terminates when
it encounters aio->a_closed, much like it does for aio->a_stop.
The semantic for nni_aio_close() is supposed to be like nni_aio_stop(),
but without blocking.

I suspect that this might be responsible for use-after-free bugs that
seem to have been rearing their head lately.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
