### PR TITLE
fixes #540 nni_ep_opttype serves no purpose

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -40,22 +40,20 @@ typedef struct nng_event  nni_event;
 typedef struct nng_notify nni_notify;
 
 // These are our own names.
-typedef struct nni_socket           nni_sock;
-typedef struct nni_ctx              nni_ctx;
-typedef struct nni_ep               nni_ep;
-typedef struct nni_pipe             nni_pipe;
-typedef struct nni_tran             nni_tran;
-typedef struct nni_tran_ep_ops      nni_tran_ep_ops;
-typedef struct nni_tran_ep_option   nni_tran_ep_option;
-typedef struct nni_tran_pipe_ops    nni_tran_pipe_ops;
-typedef struct nni_tran_pipe_option nni_tran_pipe_option;
+typedef struct nni_socket        nni_sock;
+typedef struct nni_ctx           nni_ctx;
+typedef struct nni_ep            nni_ep;
+typedef struct nni_pipe          nni_pipe;
+typedef struct nni_tran          nni_tran;
+typedef struct nni_tran_option   nni_tran_option;
+typedef struct nni_tran_ep_ops   nni_tran_ep_ops;
+typedef struct nni_tran_pipe_ops nni_tran_pipe_ops;
 
-typedef struct nni_proto_ctx_option  nni_proto_ctx_option;
-typedef struct nni_proto_ctx_ops     nni_proto_ctx_ops;
-typedef struct nni_proto_sock_ops    nni_proto_sock_ops;
-typedef struct nni_proto_pipe_ops    nni_proto_pipe_ops;
-typedef struct nni_proto_sock_option nni_proto_sock_option;
-typedef struct nni_proto             nni_proto;
+typedef struct nni_proto_option   nni_proto_option;
+typedef struct nni_proto_ctx_ops  nni_proto_ctx_ops;
+typedef struct nni_proto_sock_ops nni_proto_sock_ops;
+typedef struct nni_proto_pipe_ops nni_proto_pipe_ops;
+typedef struct nni_proto          nni_proto;
 
 typedef struct nni_plat_mtx nni_mtx;
 typedef struct nni_plat_cv  nni_cv;
@@ -140,7 +138,7 @@ typedef struct {
 
 // Types.  These are used to provide more structured access to options
 // (and maybe later statistics).  For now these are internal only.
-enum nni_type {
+typedef enum nni_opt_type {
 	NNI_TYPE_OPAQUE,
 	NNI_TYPE_BOOL,
 	NNI_TYPE_INT32,
@@ -152,6 +150,6 @@ enum nni_type {
 	NNI_TYPE_STRING,
 	NNI_TYPE_SOCKADDR,
 	NNI_TYPE_POINTER,
-};
+} nni_opt_type;
 
 #endif // CORE_DEFS_H

--- a/src/core/endpt.h
+++ b/src/core/endpt.h
@@ -26,12 +26,14 @@ extern void      nni_ep_close(nni_ep *);
 extern int       nni_ep_dial(nni_ep *, int);
 extern int       nni_ep_listen(nni_ep *, int);
 extern void      nni_ep_list_init(nni_list *);
-extern int  nni_ep_setopt(nni_ep *, const char *, const void *, size_t, int);
-extern int  nni_ep_getopt(nni_ep *, const char *, void *, size_t *, int);
-extern int  nni_ep_opttype(nni_ep *, const char *, int *);
-extern int  nni_ep_pipe_add(nni_ep *ep, nni_pipe *);
-extern void nni_ep_pipe_remove(nni_ep *, nni_pipe *);
-extern int  nni_ep_mode(nni_ep *);
+extern int       nni_ep_pipe_add(nni_ep *ep, nni_pipe *);
+extern void      nni_ep_pipe_remove(nni_ep *, nni_pipe *);
+extern int       nni_ep_mode(nni_ep *);
+
+extern int nni_ep_setopt(
+    nni_ep *, const char *, const void *, size_t, nni_opt_type);
+extern int nni_ep_getopt(
+    nni_ep *, const char *, void *, size_t *, nni_opt_type);
 
 // Endpoint modes.  Currently used by transports.  Remove this when we make
 // transport dialers and listeners explicit.

--- a/src/core/options.c
+++ b/src/core/options.c
@@ -14,11 +14,11 @@
 #include <string.h>
 
 int
-nni_copyin_ms(nni_duration *dp, const void *v, size_t sz, int typ)
+nni_copyin_ms(nni_duration *dp, const void *v, size_t sz, nni_opt_type t)
 {
 	nni_duration dur;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_DURATION:
 		dur = *(nng_duration *) v;
 		break;
@@ -35,22 +35,28 @@ nni_copyin_ms(nni_duration *dp, const void *v, size_t sz, int typ)
 	if (dur < -1) {
 		return (NNG_EINVAL);
 	}
-	*dp = dur;
+	if (dp != NULL) {
+		*dp = dur;
+	}
 	return (0);
 }
 
 int
-nni_copyin_bool(bool *bp, const void *v, size_t sz, int typ)
+nni_copyin_bool(bool *bp, const void *v, size_t sz, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_BOOL:
-		*bp = *(bool *) v;
+		if (bp != NULL) {
+			*bp = *(bool *) v;
+		}
 		break;
 	case NNI_TYPE_OPAQUE:
 		if (sz != sizeof(bool)) {
 			return (NNG_EINVAL);
 		}
-		memcpy(bp, v, sz);
+		if (bp != NULL) {
+			memcpy(bp, v, sz);
+		}
 		break;
 	default:
 		return (NNG_EBADTYPE);
@@ -60,11 +66,12 @@ nni_copyin_bool(bool *bp, const void *v, size_t sz, int typ)
 }
 
 int
-nni_copyin_int(int *ip, const void *v, size_t sz, int minv, int maxv, int typ)
+nni_copyin_int(
+    int *ip, const void *v, size_t sz, int minv, int maxv, nni_opt_type t)
 {
 	int i;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_INT32:
 		i = *(int *) v;
 		break;
@@ -83,17 +90,19 @@ nni_copyin_int(int *ip, const void *v, size_t sz, int minv, int maxv, int typ)
 	if (i < minv) {
 		return (NNG_EINVAL);
 	}
-	*ip = i;
+	if (ip != NULL) {
+		*ip = i;
+	}
 	return (0);
 }
 
 int
-nni_copyin_size(
-    size_t *sp, const void *v, size_t sz, size_t minv, size_t maxv, int typ)
+nni_copyin_size(size_t *sp, const void *v, size_t sz, size_t minv, size_t maxv,
+    nni_opt_type t)
 {
 	size_t val;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_SIZE:
 		val = *(size_t *) v;
 		break;
@@ -111,16 +120,18 @@ nni_copyin_size(
 	if ((val > maxv) || (val < minv)) {
 		return (NNG_EINVAL);
 	}
-	*sp = val;
+	if (sp != NULL) {
+		*sp = val;
+	}
 	return (0);
 }
 
 int
-nni_copyin_ptr(void **pp, const void *v, size_t sz, int typ)
+nni_copyin_ptr(void **pp, const void *v, size_t sz, nni_opt_type t)
 {
 	void *p;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_POINTER:
 		p = *(void **) v;
 		break;
@@ -133,16 +144,18 @@ nni_copyin_ptr(void **pp, const void *v, size_t sz, int typ)
 	default:
 		return (NNG_EBADTYPE);
 	}
-	*pp = p;
+	if (pp != NULL) {
+		*pp = p;
+	}
 	return (0);
 }
 
 int
-nni_copyin_str(char *s, const void *v, size_t sz, size_t maxsz, int typ)
+nni_copyin_str(char *s, const void *v, size_t sz, size_t maxsz, nni_opt_type t)
 {
 	size_t z;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_STRING:
 		z = strlen(v) + 1;
 		NNI_ASSERT(sz == z);
@@ -158,16 +171,18 @@ nni_copyin_str(char *s, const void *v, size_t sz, size_t maxsz, int typ)
 	if (z > maxsz) {
 		return (NNG_EINVAL); // too long
 	}
-	memcpy(s, v, z);
+	if (s != NULL) {
+		memcpy(s, v, z);
+	}
 	return (0);
 }
 
 int
-nni_copyin_u64(uint64_t *up, const void *v, size_t sz, int typ)
+nni_copyin_u64(uint64_t *up, const void *v, size_t sz, nni_opt_type t)
 {
 	uint64_t u;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_UINT64:
 		u = *(uint64_t *) v;
 		break;
@@ -180,7 +195,9 @@ nni_copyin_u64(uint64_t *up, const void *v, size_t sz, int typ)
 	default:
 		return (NNG_EBADTYPE);
 	}
-	*up = u;
+	if (up != NULL) {
+		*up = u;
+	}
 	return (0);
 }
 
@@ -202,9 +219,9 @@ nni_copyout(const void *src, size_t srcsz, void *dst, size_t *dstszp)
 }
 
 int
-nni_copyout_bool(bool b, void *dst, size_t *szp, int typ)
+nni_copyout_bool(bool b, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_BOOL:
 		NNI_ASSERT(*szp == sizeof(b));
 		*(bool *) dst = b;
@@ -217,9 +234,9 @@ nni_copyout_bool(bool b, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_int(int i, void *dst, size_t *szp, int typ)
+nni_copyout_int(int i, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_INT32:
 		NNI_ASSERT(*szp == sizeof(i));
 		*(int *) dst = i;
@@ -232,9 +249,9 @@ nni_copyout_int(int i, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_ms(nng_duration d, void *dst, size_t *szp, int typ)
+nni_copyout_ms(nng_duration d, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_DURATION:
 		NNI_ASSERT(*szp == sizeof(d));
 		*(nng_duration *) dst = d;
@@ -247,9 +264,9 @@ nni_copyout_ms(nng_duration d, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_ptr(void *p, void *dst, size_t *szp, int typ)
+nni_copyout_ptr(void *p, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_POINTER:
 		NNI_ASSERT(*szp == sizeof(p));
 		*(void **) dst = p;
@@ -262,9 +279,9 @@ nni_copyout_ptr(void *p, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_size(size_t s, void *dst, size_t *szp, int typ)
+nni_copyout_size(size_t s, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_SIZE:
 		NNI_ASSERT(*szp == sizeof(s));
 		*(size_t *) dst = s;
@@ -277,9 +294,10 @@ nni_copyout_size(size_t s, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_sockaddr(const nng_sockaddr *sap, void *dst, size_t *szp, int typ)
+nni_copyout_sockaddr(
+    const nng_sockaddr *sap, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_SOCKADDR:
 		NNI_ASSERT(*szp == sizeof(*sap));
 		*(nng_sockaddr *) dst = *sap;
@@ -292,9 +310,9 @@ nni_copyout_sockaddr(const nng_sockaddr *sap, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_u64(uint64_t u, void *dst, size_t *szp, int typ)
+nni_copyout_u64(uint64_t u, void *dst, size_t *szp, nni_opt_type t)
 {
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_UINT64:
 		NNI_ASSERT(*szp == sizeof(u));
 		*(uint64_t *) dst = u;
@@ -307,11 +325,11 @@ nni_copyout_u64(uint64_t u, void *dst, size_t *szp, int typ)
 }
 
 int
-nni_copyout_str(const char *str, void *dst, size_t *szp, int typ)
+nni_copyout_str(const char *str, void *dst, size_t *szp, nni_opt_type t)
 {
 	char *s;
 
-	switch (typ) {
+	switch (t) {
 	case NNI_TYPE_STRING:
 		NNI_ASSERT(*szp == sizeof(char *));
 		if ((s = nni_strdup(str)) == NULL) {

--- a/src/core/options.h
+++ b/src/core/options.h
@@ -24,28 +24,29 @@
 // in their own option handling, centralizing the logic for dealing with
 // variable sized options.
 
-extern int nni_copyin_ms(nni_duration *, const void *, size_t, int);
-extern int nni_copyin_bool(bool *, const void *, size_t, int);
-extern int nni_copyin_int(int *, const void *, size_t, int, int, int);
+extern int nni_copyin_ms(nni_duration *, const void *, size_t, nni_opt_type);
+extern int nni_copyin_bool(bool *, const void *, size_t, nni_opt_type);
+extern int nni_copyin_int(int *, const void *, size_t, int, int, nni_opt_type);
 extern int nni_copyin_size(
-    size_t *, const void *, size_t, size_t, size_t, int);
-extern int nni_copyin_str(char *, const void *, size_t, size_t, int);
-extern int nni_copyin_ptr(void **, const void *, size_t, int);
-extern int nni_copyin_u64(uint64_t *, const void *, size_t, int);
+    size_t *, const void *, size_t, size_t, size_t, nni_opt_type);
+extern int nni_copyin_str(char *, const void *, size_t, size_t, nni_opt_type);
+extern int nni_copyin_ptr(void **, const void *, size_t, nni_opt_type);
+extern int nni_copyin_u64(uint64_t *, const void *, size_t, nni_opt_type);
 
 // nni_copyout_xxx copies out a type of the named value.  It assumes that
 // the type is aligned and the size correct, unless NNI_TYPE_OPAQUE is passed.
 extern int nni_copyout(const void *, size_t, void *, size_t *);
-extern int nni_copyout_bool(bool, void *, size_t *, int);
-extern int nni_copyout_int(int, void *, size_t *, int);
-extern int nni_copyout_ms(nng_duration, void *, size_t *, int);
-extern int nni_copyout_ptr(void *, void *, size_t *, int);
-extern int nni_copyout_size(size_t, void *, size_t *, int);
-extern int nni_copyout_sockaddr(const nng_sockaddr *, void *, size_t *, int);
-extern int nni_copyout_u64(uint64_t, void *, size_t *, int);
+extern int nni_copyout_bool(bool, void *, size_t *, nni_opt_type);
+extern int nni_copyout_int(int, void *, size_t *, nni_opt_type);
+extern int nni_copyout_ms(nng_duration, void *, size_t *, nni_opt_type);
+extern int nni_copyout_ptr(void *, void *, size_t *, nni_opt_type);
+extern int nni_copyout_size(size_t, void *, size_t *, nni_opt_type);
+extern int nni_copyout_sockaddr(
+    const nng_sockaddr *, void *, size_t *, nni_opt_type);
+extern int nni_copyout_u64(uint64_t, void *, size_t *, nni_opt_type);
 
 // nni_copyout_str copies out a string.  If the type is NNI_TYPE_STRING,
 // then it passes through a pointer, created by nni_strdup().
-extern int nni_copyout_str(const char *, void *, size_t *, int);
+extern int nni_copyout_str(const char *, void *, size_t *, nni_opt_type);
 
 #endif // CORE_OPTIONS_H

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -359,18 +359,19 @@ nni_pipe_create(nni_ep *ep, void *tdata)
 }
 
 int
-nni_pipe_getopt(nni_pipe *p, const char *name, void *val, size_t *szp, int typ)
+nni_pipe_getopt(
+    nni_pipe *p, const char *name, void *val, size_t *szp, nni_opt_type t)
 {
-	nni_tran_pipe_option *po;
+	nni_tran_option *o;
 
-	for (po = p->p_tran_ops.p_options; po && po->po_name; po++) {
-		if (strcmp(po->po_name, name) != 0) {
+	for (o = p->p_tran_ops.p_options; o && o->o_name; o++) {
+		if (strcmp(o->o_name, name) != 0) {
 			continue;
 		}
-		return (po->po_getopt(p->p_tran_data, val, szp, typ));
+		return (o->o_get(p->p_tran_data, val, szp, t));
 	}
 	// Maybe the endpoint knows?
-	return (nni_ep_getopt(p->p_ep, name, val, szp, typ));
+	return (nni_ep_getopt(p->p_ep, name, val, szp, t));
 }
 
 void

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -60,7 +60,8 @@ extern uint16_t nni_pipe_peer(nni_pipe *);
 
 // nni_pipe_getopt looks up the option.  The last argument is the type,
 // which.  If the type is NNI_TYPE_OPAQUE, then no format check is performed.
-extern int nni_pipe_getopt(nni_pipe *, const char *, void *, size_t *, int);
+extern int nni_pipe_getopt(
+    nni_pipe *, const char *, void *, size_t *, nni_opt_type);
 
 // nni_pipe_get_proto_data gets the protocol private data set with the
 // nni_pipe_set_proto_data function.  No locking is performed.

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -21,6 +21,13 @@
 // As a consequence, most of the concurrency in nng exists in the protocol
 // implementations.
 
+struct nni_proto_option {
+	const char *o_name;
+	int         o_type;
+	int (*o_get)(void *, void *, size_t *, nni_opt_type);
+	int (*o_set)(void *, const void *, size_t, nni_opt_type);
+};
+
 // nni_proto_pipe contains protocol-specific per-pipe operations.
 struct nni_proto_pipe_ops {
 	// pipe_init creates the protocol-specific per pipe data structure.
@@ -50,13 +57,6 @@ struct nni_proto_pipe_ops {
 	void (*pipe_stop)(void *);
 };
 
-struct nni_proto_ctx_option {
-	const char *co_name;
-	int         co_type;
-	int (*co_getopt)(void *, void *, size_t *, int);
-	int (*co_setopt)(void *, const void *, size_t, int);
-};
-
 struct nni_proto_ctx_ops {
 	// ctx_init creates a new context. The second argument is the
 	// protocol specific socket structure.
@@ -80,14 +80,7 @@ struct nni_proto_ctx_ops {
 	void (*ctx_drain)(void *, nni_aio *);
 
 	// ctx_options array.
-	nni_proto_ctx_option *ctx_options;
-};
-
-struct nni_proto_sock_option {
-	const char *pso_name;
-	int         pso_type;
-	int (*pso_getopt)(void *, void *, size_t *, int);
-	int (*pso_setopt)(void *, const void *, size_t, int);
+	nni_proto_option *ctx_options;
 };
 
 struct nni_proto_sock_ops {
@@ -130,7 +123,7 @@ struct nni_proto_sock_ops {
 	void (*sock_drain)(void *, nni_aio *);
 
 	// Options. Must not be NULL. Final entry should have NULL name.
-	nni_proto_sock_option *sock_options;
+	nni_proto_option *sock_options;
 };
 
 typedef struct nni_proto_id {

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -29,12 +29,13 @@ extern void *      nni_sock_proto_data(nni_sock *);
 extern struct nni_proto_pipe_ops *nni_sock_proto_pipe_ops(nni_sock *);
 
 extern int nni_sock_setopt(
-    nni_sock *, const char *, const void *, size_t, int);
-extern int  nni_sock_getopt(nni_sock *, const char *, void *, size_t *, int);
-extern int  nni_sock_recvmsg(nni_sock *, nni_msg **, int);
-extern int  nni_sock_sendmsg(nni_sock *, nni_msg *, int);
-extern void nni_sock_send(nni_sock *, nni_aio *);
-extern void nni_sock_recv(nni_sock *, nni_aio *);
+    nni_sock *, const char *, const void *, size_t, nni_opt_type);
+extern int nni_sock_getopt(
+    nni_sock *, const char *, void *, size_t *, nni_opt_type);
+extern int      nni_sock_recvmsg(nni_sock *, nni_msg **, int);
+extern int      nni_sock_sendmsg(nni_sock *, nni_msg *, int);
+extern void     nni_sock_send(nni_sock *, nni_aio *);
+extern void     nni_sock_recv(nni_sock *, nni_aio *);
 extern uint32_t nni_sock_id(nni_sock *);
 
 // nni_sock_pipe_add adds the pipe to the socket. It is called by
@@ -114,9 +115,11 @@ extern void nni_ctx_recv(nni_ctx *, nni_aio *);
 extern void nni_ctx_send(nni_ctx *, nni_aio *);
 
 // nni_ctx_getopt is used to get a context option.
-extern int nni_ctx_getopt(nni_ctx *, const char *, void *, size_t *, int);
+extern int nni_ctx_getopt(
+    nni_ctx *, const char *, void *, size_t *, nni_opt_type);
 
 // nni_ctx_setopt is used to set a context option.
-extern int nni_ctx_setopt(nni_ctx *, const char *, const void *, size_t, int);
+extern int nni_ctx_setopt(
+    nni_ctx *, const char *, const void *, size_t, nni_opt_type);
 
 #endif // CORE_SOCKET_H

--- a/src/core/transport.c
+++ b/src/core/transport.c
@@ -118,23 +118,23 @@ nni_tran_chkopt(const char *name, const void *v, size_t sz, int typ)
 
 	nni_mtx_lock(&nni_tran_lk);
 	NNI_LIST_FOREACH (&nni_tran_list, t) {
-		const nni_tran_ep_ops *   ep;
-		const nni_tran_ep_option *eo;
+		const nni_tran_ep_ops *ep;
+		const nni_tran_option *o;
 
 		// Generally we look for endpoint options.
 		ep = t->t_tran.tran_ep;
-		for (eo = ep->ep_options; eo && eo->eo_name != NULL; eo++) {
-			if (strcmp(name, eo->eo_name) != 0) {
+		for (o = ep->ep_options; o && o->o_name != NULL; o++) {
+			if (strcmp(name, o->o_name) != 0) {
 				continue;
 			}
-			if (eo->eo_setopt == NULL) {
+			if (o->o_set == NULL) {
 				nni_mtx_unlock(&nni_tran_lk);
 				return (NNG_EREADONLY);
 			}
-			if ((rv = eo->eo_setopt(NULL, v, sz, typ)) != 0) {
-				nni_mtx_unlock(&nni_tran_lk);
-				return (rv);
-			}
+
+			rv = (o->o_chk != NULL) ? o->o_chk(v, sz, typ) : 0;
+			nni_mtx_unlock(&nni_tran_lk);
+			return (rv);
 		}
 	}
 	nni_mtx_unlock(&nni_tran_lk);

--- a/src/core/transport.h
+++ b/src/core/transport.h
@@ -47,39 +47,44 @@ struct nni_tran {
 // older versions in the future.
 #define NNI_TRANSPORT_V0 0x54520000
 #define NNI_TRANSPORT_V1 0x54520001
-#define NNI_TRANSPORT_VERSION NNI_TRANSPORT_V1
+#define NNI_TRANSPORT_V2 0x54520002
+#define NNI_TRANSPORT_VERSION NNI_TRANSPORT_V2
 
-// Endpoint option handlers.
-struct nni_tran_ep_option {
-	// eo_name is the name of the option.
-	const char *eo_name;
+// Option handlers.
+struct nni_tran_option {
+	// o_name is the name of the option.
+	const char *o_name;
 
-	// eo_type is the type of the option.
-	int eo_type;
+	// o_type is the type of the option.
+	nni_opt_type o_type;
 
-	// eo_getopt retrieves the value of the option.
-	int (*eo_getopt)(void *, void *, size_t *, int);
+	// o_get retrieves the value of the option. The first argument is the
+	// dialer, listener, or pipe where the request is being made.
+	int (*o_get)(void *, void *, size_t *, nni_opt_type);
 
-	// eo_set sets the value of the option.  If the first argument
-	// (the endpoint) is NULL, then no actual set operation should be
-	// performed, but the option should be sanity tested for presence
-	// and size.  (This permits the core to validate that an option
-	// is reasonable and be set even before endpoints are created.)
-	int (*eo_setopt)(void *, const void *, size_t, int);
+	// o_set sets the value of the option.  The first argument is the
+	// dialer, listener, or pipe where the request is being made.
+	int (*o_set)(void *, const void *, size_t, nni_opt_type);
+
+	// o_chk checks to see if the proposed value is legal -- this is
+	// checks only the type, size, and generic range validation.  This
+	// function can be called before any transport objects are created.
+	int (*o_chk)(const void *, size_t, nni_opt_type);
 };
 
-// Endpoint operations are called by the socket in a protocol-independent
-// fashion.  The socket makes individual calls, which are expected to block
-// if appropriate (except for destroy), or run asynchronously if an aio
-// is provided. Endpoints are unable to call back into the socket, to prevent
-// recusive entry and deadlock.
+// Endpoint operations are called by the socket in a
+// protocol-independent fashion.  The socket makes individual calls,
+// which are expected to block if appropriate (except for destroy), or
+// run asynchronously if an aio is provided. Endpoints are unable to
+// call back into the socket, to prevent recusive entry and deadlock.
 //
 // For a given endpoint, the framework holds a lock so that each entry
 // point is run exclusively of the others. (Transports must still guard
 // against any asynchronous operations they manage themselves, though.)
 struct nni_tran_ep_ops {
 	// ep_init creates a vanilla endpoint. The value created is
-	// used for the first argument for all other endpoint functions.
+	// used for the first argument for all other endpoint
+	// functions.
 	int (*ep_init)(void **, nni_url *, nni_sock *, int);
 
 	// ep_fini frees the resources associated with the endpoint.
@@ -87,8 +92,8 @@ struct nni_tran_ep_ops {
 	void (*ep_fini)(void *);
 
 	// ep_connect establishes a connection.  It can return errors
-	// NNG_EACCESS, NNG_ECONNREFUSED, NNG_EBADADDR, NNG_ECONNFAILED,
-	// NNG_ETIMEDOUT, and NNG_EPROTO.
+	// NNG_EACCESS, NNG_ECONNREFUSED, NNG_EBADADDR,
+	// NNG_ECONNFAILED, NNG_ETIMEDOUT, and NNG_EPROTO.
 	void (*ep_connect)(void *, nni_aio *);
 
 	// ep_bind just does the bind() and listen() work,
@@ -101,45 +106,34 @@ struct nni_tran_ep_ops {
 	// ep_accept accepts an inbound connection.
 	void (*ep_accept)(void *, nni_aio *);
 
-	// ep_close stops the endpoint from operating altogether.  It does
-	// not affect pipes that have already been created.  It is nonblocking.
+	// ep_close stops the endpoint from operating altogether.  It
+	// does not affect pipes that have already been created.  It is
+	// nonblocking.
 	void (*ep_close)(void *);
 
-	// ep_options is an array of endpoint options.  The final element must
-	// have a NULL name. If this member is NULL, then no transport specific
-	// options are available.
-	nni_tran_ep_option *ep_options;
+	// ep_options is an array of endpoint options.  The final
+	// element must have a NULL name. If this member is NULL, then
+	// no transport specific options are available.
+	nni_tran_option *ep_options;
 };
 
-// Pipe option handlers.  We only have get for pipes; once a pipe is created
-// no options may be set on it.
-struct nni_tran_pipe_option {
-	// po_name is the name of the option.
-	const char *po_name;
-
-	// po_type is the type of the option.
-	int po_type;
-
-	// po_getopt retrieves the value of the option.
-	int (*po_getopt)(void *, void *, size_t *, int);
-};
-
-// Pipe operations are entry points called by the socket. These may be called
-// with socket locks held, so it is forbidden for the transport to call
-// back into the socket at this point.  (Which is one reason pointers back
-// to socket or even enclosing pipe state, are not provided.)
+// Pipe operations are entry points called by the socket. These may be
+// called with socket locks held, so it is forbidden for the transport
+// to call back into the socket at this point.  (Which is one reason
+// pointers back to socket or even enclosing pipe state, are not
+// provided.)
 struct nni_tran_pipe_ops {
 	// p_fini destroys the pipe.  This should clean up all local
-	// resources, including closing files and freeing memory, used by
-	// the pipe.  After this call returns, the system will not make
-	// further calls on the same pipe.
+	// resources, including closing files and freeing memory, used
+	// by the pipe.  After this call returns, the system will not
+	// make further calls on the same pipe.
 	void (*p_fini)(void *);
 
 	// p_start starts the pipe running.  This gives the transport a
-	// chance to hook into any transport specific negotiation phase.
-	// The pipe will not have its p_send or p_recv calls started, and
-	// will not be access by the "socket" until the pipe has indicated
-	// its readiness by finishing the aio.
+	// chance to hook into any transport specific negotiation
+	// phase. The pipe will not have its p_send or p_recv calls
+	// started, and will not be access by the "socket" until the
+	// pipe has indicated its readiness by finishing the aio.
 	void (*p_start)(void *, nni_aio *);
 
 	// p_stop stops the pipe, waiting for any callbacks that are
@@ -147,31 +141,31 @@ struct nni_tran_pipe_ops {
 	// resources with p_fini.
 	void (*p_stop)(void *);
 
-	// p_aio_send queues the message for transmit.  If this fails, then
-	// the caller may try again with the same message (or free it).  If
-	// the call succeeds, then the transport has taken ownership of the
-	// message, and the caller may not use it again.  The transport will
-	// have the responsibility to free the message (nng_msg_free()) when
-	// it is finished with it.
+	// p_aio_send queues the message for transmit.  If this fails,
+	// then the caller may try again with the same message (or free
+	// it).  If the call succeeds, then the transport has taken
+	// ownership of the message, and the caller may not use it
+	// again.  The transport will have the responsibility to free
+	// the message (nng_msg_free()) when it is finished with it.
 	void (*p_send)(void *, nni_aio *);
 
-	// p_recv schedules a message receive. This will be performed even for
-	// cases where no data is expected, to allow detection of a remote
-	// disconnect.
+	// p_recv schedules a message receive. This will be performed
+	// even for cases where no data is expected, to allow detection
+	// of a remote disconnect.
 	void (*p_recv)(void *, nni_aio *);
 
-	// p_close closes the pipe.  Further recv or send operations should
-	// return back NNG_ECLOSED.
+	// p_close closes the pipe.  Further recv or send operations
+	// should return back NNG_ECLOSED.
 	void (*p_close)(void *);
 
-	// p_peer returns the peer protocol. This may arrive in whatever
-	// transport specific manner is appropriate.
+	// p_peer returns the peer protocol. This may arrive in
+	// whatever transport specific manner is appropriate.
 	uint16_t (*p_peer)(void *);
 
-	// p_options is an array of pipe options.  The final element must have
-	// a NULL name. If this member is NULL, then no transport specific
-	// options are available.
-	nni_tran_pipe_option *p_options;
+	// p_options is an array of pipe options.  The final element
+	// must have a NULL name. If this member is NULL, then no
+	// transport specific options are available.
+	nni_tran_option *p_options;
 };
 
 // These APIs are used by the framework internally, and not for use by

--- a/src/protocol/bus0/bus.c
+++ b/src/protocol/bus0/bus.c
@@ -439,10 +439,10 @@ static nni_proto_pipe_ops bus0_pipe_ops = {
 	.pipe_stop  = bus0_pipe_stop,
 };
 
-static nni_proto_sock_option bus0_sock_options[] = {
+static nni_proto_option bus0_sock_options[] = {
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/pair0/pair.c
+++ b/src/protocol/pair0/pair.c
@@ -269,10 +269,10 @@ static nni_proto_pipe_ops pair0_pipe_ops = {
 	.pipe_stop  = pair0_pipe_stop,
 };
 
-static nni_proto_sock_option pair0_sock_options[] = {
+static nni_proto_option pair0_sock_options[] = {
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	}
 };
 

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -428,39 +428,39 @@ pair1_sock_close(void *arg)
 }
 
 static int
-pair1_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+pair1_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	pair1_sock *s = arg;
 	int         rv;
 	nni_mtx_lock(&s->mtx); // Have to be locked against recv cb.
-	rv = nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ);
+	rv = nni_copyin_int(&s->ttl, buf, sz, 1, 255, t);
 	nni_mtx_unlock(&s->mtx);
 	return (rv);
 }
 
 static int
-pair1_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+pair1_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	pair1_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static int
-pair1_sock_setopt_poly(void *arg, const void *buf, size_t sz, int typ)
+pair1_sock_set_poly(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	pair1_sock *s = arg;
 	int         rv;
 	nni_mtx_lock(&s->mtx);
-	rv = s->started ? NNG_ESTATE : nni_copyin_bool(&s->poly, buf, sz, typ);
+	rv = s->started ? NNG_ESTATE : nni_copyin_bool(&s->poly, buf, sz, t);
 	nni_mtx_unlock(&s->mtx);
 	return (rv);
 }
 
 static int
-pair1_sock_getopt_poly(void *arg, void *buf, size_t *szp, int typ)
+pair1_sock_get_poly(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	pair1_sock *s = arg;
-	return (nni_copyout_bool(s->poly, buf, szp, typ));
+	return (nni_copyout_bool(s->poly, buf, szp, t));
 }
 
 static void
@@ -487,22 +487,22 @@ static nni_proto_pipe_ops pair1_pipe_ops = {
 	.pipe_stop  = pair1_pipe_stop,
 };
 
-static nni_proto_sock_option pair1_sock_options[] = {
+static nni_proto_option pair1_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = pair1_sock_getopt_maxttl,
-	    .pso_setopt = pair1_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = pair1_sock_get_maxttl,
+	    .o_set  = pair1_sock_set_maxttl,
 	},
 	{
-	    .pso_name   = NNG_OPT_PAIR1_POLY,
-	    .pso_type   = NNI_TYPE_BOOL,
-	    .pso_getopt = pair1_sock_getopt_poly,
-	    .pso_setopt = pair1_sock_setopt_poly,
+	    .o_name = NNG_OPT_PAIR1_POLY,
+	    .o_type = NNI_TYPE_BOOL,
+	    .o_get  = pair1_sock_get_poly,
+	    .o_set  = pair1_sock_set_poly,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/pipeline0/pull.c
+++ b/src/protocol/pipeline0/pull.c
@@ -216,10 +216,10 @@ static nni_proto_pipe_ops pull0_pipe_ops = {
 	.pipe_stop  = pull0_pipe_stop,
 };
 
-static nni_proto_sock_option pull0_sock_options[] = {
+static nni_proto_option pull0_sock_options[] = {
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/pipeline0/push.c
+++ b/src/protocol/pipeline0/push.c
@@ -228,10 +228,10 @@ static nni_proto_pipe_ops push0_pipe_ops = {
 	.pipe_stop  = push0_pipe_stop,
 };
 
-static nni_proto_sock_option push0_sock_options[] = {
+static nni_proto_option push0_sock_options[] = {
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -304,10 +304,10 @@ static nni_proto_pipe_ops pub0_pipe_ops = {
 	.pipe_stop  = pub0_pipe_stop,
 };
 
-static nni_proto_sock_option pub0_sock_options[] = {
+static nni_proto_option pub0_sock_options[] = {
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -194,12 +194,12 @@ sub0_recv_cb(void *arg)
 // to replace this with a patricia trie, like old nanomsg had.
 
 static int
-sub0_subscribe(void *arg, const void *buf, size_t sz, int typ)
+sub0_subscribe(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	sub0_sock * s = arg;
 	sub0_topic *topic;
 	sub0_topic *newtopic;
-	NNI_ARG_UNUSED(typ);
+	NNI_ARG_UNUSED(t);
 
 	nni_mtx_lock(&s->lk);
 	NNI_LIST_FOREACH (&s->topics, topic) {
@@ -245,12 +245,12 @@ sub0_subscribe(void *arg, const void *buf, size_t sz, int typ)
 }
 
 static int
-sub0_unsubscribe(void *arg, const void *buf, size_t sz, int typ)
+sub0_unsubscribe(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	sub0_sock * s = arg;
 	sub0_topic *topic;
 	int         rv;
-	NNI_ARG_UNUSED(typ);
+	NNI_ARG_UNUSED(t);
 
 	nni_mtx_lock(&s->lk);
 	NNI_LIST_FOREACH (&s->topics, topic) {
@@ -348,22 +348,20 @@ static nni_proto_pipe_ops sub0_pipe_ops = {
 	.pipe_stop  = sub0_pipe_stop,
 };
 
-static nni_proto_sock_option sub0_sock_options[] = {
+static nni_proto_option sub0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_SUB_SUBSCRIBE,
-	    .pso_type   = NNI_TYPE_OPAQUE,
-	    .pso_getopt = NULL,
-	    .pso_setopt = sub0_subscribe,
+	    .o_name = NNG_OPT_SUB_SUBSCRIBE,
+	    .o_type = NNI_TYPE_OPAQUE,
+	    .o_set  = sub0_subscribe,
 	},
 	{
-	    .pso_name   = NNG_OPT_SUB_UNSUBSCRIBE,
-	    .pso_type   = NNI_TYPE_OPAQUE,
-	    .pso_getopt = NULL,
-	    .pso_setopt = sub0_unsubscribe,
+	    .o_name = NNG_OPT_SUB_UNSUBSCRIBE,
+	    .o_type = NNI_TYPE_OPAQUE,
+	    .o_set  = sub0_unsubscribe,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -605,23 +605,23 @@ drop:
 }
 
 static int
-rep0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+rep0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	rep0_sock *s = arg;
 
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-rep0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+rep0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	rep0_sock *s = arg;
 
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static int
-rep0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
+rep0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	rep0_sock *s = arg;
 	int        rv;
@@ -630,11 +630,11 @@ rep0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
 	if ((rv = nni_pollable_getfd(s->sendable, &fd)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static int
-rep0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
+rep0_sock_get_recvfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	rep0_sock *s = arg;
 	int        rv;
@@ -644,7 +644,7 @@ rep0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
 		return (rv);
 	}
 
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static void
@@ -680,28 +680,26 @@ static nni_proto_ctx_ops rep0_ctx_ops = {
 	.ctx_recv = rep0_ctx_recv,
 };
 
-static nni_proto_sock_option rep0_sock_options[] = {
+static nni_proto_option rep0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = rep0_sock_getopt_maxttl,
-	    .pso_setopt = rep0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = rep0_sock_get_maxttl,
+	    .o_set  = rep0_sock_set_maxttl,
 	},
 	{
-	    .pso_name   = NNG_OPT_RECVFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = rep0_sock_getopt_recvfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_RECVFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = rep0_sock_get_recvfd,
 	},
 	{
-	    .pso_name   = NNG_OPT_SENDFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = rep0_sock_getopt_sendfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_SENDFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = rep0_sock_get_sendfd,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -479,17 +479,17 @@ req0_ctx_fini(void *arg)
 }
 
 static int
-req0_ctx_setopt_resendtime(void *arg, const void *buf, size_t sz, int typ)
+req0_ctx_set_resendtime(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	req0_ctx *ctx = arg;
-	return (nni_copyin_ms(&ctx->retry, buf, sz, typ));
+	return (nni_copyin_ms(&ctx->retry, buf, sz, t));
 }
 
 static int
-req0_ctx_getopt_resendtime(void *arg, void *buf, size_t *szp, int typ)
+req0_ctx_get_resendtime(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	req0_ctx *ctx = arg;
-	return (nni_copyout_ms(ctx->retry, buf, szp, typ));
+	return (nni_copyout_ms(ctx->retry, buf, szp, t));
 }
 
 static void
@@ -782,38 +782,38 @@ req0_sock_recv(void *arg, nni_aio *aio)
 }
 
 static int
-req0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+req0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	req0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-req0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+req0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	req0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static int
-req0_sock_setopt_resendtime(void *arg, const void *buf, size_t sz, int typ)
+req0_sock_set_resendtime(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	req0_sock *s = arg;
 	int        rv;
-	rv       = req0_ctx_setopt_resendtime(s->ctx, buf, sz, typ);
+	rv       = req0_ctx_set_resendtime(s->ctx, buf, sz, t);
 	s->retry = s->ctx->retry;
 	return (rv);
 }
 
 static int
-req0_sock_getopt_resendtime(void *arg, void *buf, size_t *szp, int typ)
+req0_sock_get_resendtime(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	req0_sock *s = arg;
-	return (req0_ctx_getopt_resendtime(s->ctx, buf, szp, typ));
+	return (req0_ctx_get_resendtime(s->ctx, buf, szp, t));
 }
 
 static int
-req0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
+req0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	req0_sock *s = arg;
 	int        rv;
@@ -822,11 +822,11 @@ req0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
 	if ((rv = nni_pollable_getfd(s->sendable, &fd)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static int
-req0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
+req0_sock_get_recvfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	req0_sock *s = arg;
 	int        rv;
@@ -836,7 +836,7 @@ req0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
 		return (rv);
 	}
 
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static nni_proto_pipe_ops req0_pipe_ops = {
@@ -847,15 +847,15 @@ static nni_proto_pipe_ops req0_pipe_ops = {
 	.pipe_stop  = req0_pipe_stop,
 };
 
-static nni_proto_ctx_option req0_ctx_options[] = {
+static nni_proto_option req0_ctx_options[] = {
 	{
-	    .co_name   = NNG_OPT_REQ_RESENDTIME,
-	    .co_type   = NNI_TYPE_DURATION,
-	    .co_getopt = req0_ctx_getopt_resendtime,
-	    .co_setopt = req0_ctx_setopt_resendtime,
+	    .o_name = NNG_OPT_REQ_RESENDTIME,
+	    .o_type = NNI_TYPE_DURATION,
+	    .o_get  = req0_ctx_get_resendtime,
+	    .o_set  = req0_ctx_set_resendtime,
 	},
 	{
-	    .co_name = NULL,
+	    .o_name = NULL,
 	},
 };
 
@@ -867,34 +867,32 @@ static nni_proto_ctx_ops req0_ctx_ops = {
 	.ctx_options = req0_ctx_options,
 };
 
-static nni_proto_sock_option req0_sock_options[] = {
+static nni_proto_option req0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = req0_sock_getopt_maxttl,
-	    .pso_setopt = req0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = req0_sock_get_maxttl,
+	    .o_set  = req0_sock_set_maxttl,
 	},
 	{
-	    .pso_name   = NNG_OPT_REQ_RESENDTIME,
-	    .pso_type   = NNI_TYPE_DURATION,
-	    .pso_getopt = req0_sock_getopt_resendtime,
-	    .pso_setopt = req0_sock_setopt_resendtime,
+	    .o_name = NNG_OPT_REQ_RESENDTIME,
+	    .o_type = NNI_TYPE_DURATION,
+	    .o_get  = req0_sock_get_resendtime,
+	    .o_set  = req0_sock_set_resendtime,
 	},
 	{
-	    .pso_name   = NNG_OPT_RECVFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = req0_sock_getopt_recvfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_RECVFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = req0_sock_get_recvfd,
 	},
 	{
-	    .pso_name   = NNG_OPT_SENDFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = req0_sock_getopt_sendfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_SENDFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = req0_sock_get_sendfd,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/reqrep0/xrep.c
+++ b/src/protocol/reqrep0/xrep.c
@@ -369,17 +369,17 @@ xrep0_pipe_putq_cb(void *arg)
 }
 
 static int
-xrep0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+xrep0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	xrep0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-xrep0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+xrep0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	xrep0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static void
@@ -408,16 +408,16 @@ static nni_proto_pipe_ops xrep0_pipe_ops = {
 	.pipe_stop  = xrep0_pipe_stop,
 };
 
-static nni_proto_sock_option xrep0_sock_options[] = {
+static nni_proto_option xrep0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = xrep0_sock_getopt_maxttl,
-	    .pso_setopt = xrep0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = xrep0_sock_get_maxttl,
+	    .o_set  = xrep0_sock_set_maxttl,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/reqrep0/xreq.c
+++ b/src/protocol/reqrep0/xreq.c
@@ -268,17 +268,17 @@ xreq0_sock_recv(void *arg, nni_aio *aio)
 }
 
 static int
-xreq0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+xreq0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	xreq0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-xreq0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+xreq0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	xreq0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static nni_proto_pipe_ops xreq0_pipe_ops = {
@@ -289,16 +289,16 @@ static nni_proto_pipe_ops xreq0_pipe_ops = {
 	.pipe_stop  = xreq0_pipe_stop,
 };
 
-static nni_proto_sock_option xreq0_sock_options[] = {
+static nni_proto_option xreq0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = xreq0_sock_getopt_maxttl,
-	    .pso_setopt = xreq0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = xreq0_sock_get_maxttl,
+	    .o_set  = xreq0_sock_set_maxttl,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -587,21 +587,21 @@ drop:
 }
 
 static int
-resp0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+resp0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	resp0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-resp0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+resp0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	resp0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static int
-resp0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
+resp0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	resp0_sock *s = arg;
 	int         rv;
@@ -610,11 +610,11 @@ resp0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
 	if ((rv = nni_pollable_getfd(s->sendable, &fd)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static int
-resp0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
+resp0_sock_get_recvfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	resp0_sock *s = arg;
 	int         rv;
@@ -623,7 +623,7 @@ resp0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
 	if ((rv = nni_pollable_getfd(s->recvable, &fd)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static void
@@ -657,28 +657,28 @@ static nni_proto_ctx_ops resp0_ctx_ops = {
 	.ctx_recv = resp0_ctx_recv,
 };
 
-static nni_proto_sock_option resp0_sock_options[] = {
+static nni_proto_option resp0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = resp0_sock_getopt_maxttl,
-	    .pso_setopt = resp0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = resp0_sock_get_maxttl,
+	    .o_set  = resp0_sock_set_maxttl,
 	},
 	{
-	    .pso_name   = NNG_OPT_RECVFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = resp0_sock_getopt_recvfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_RECVFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = resp0_sock_get_recvfd,
+	    .o_set  = NULL,
 	},
 	{
-	    .pso_name   = NNG_OPT_SENDFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = resp0_sock_getopt_sendfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_SENDFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = resp0_sock_get_sendfd,
+	    .o_set  = NULL,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/survey0/survey.c
+++ b/src/protocol/survey0/survey.c
@@ -449,49 +449,50 @@ surv0_pipe_recv_cb(void *arg)
 }
 
 static int
-surv0_ctx_setopt_surveytime(void *arg, const void *buf, size_t sz, int typ)
+surv0_ctx_set_surveytime(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	surv0_ctx *ctx = arg;
-	return (nni_copyin_ms(&ctx->survtime, buf, sz, typ));
+	return (nni_copyin_ms(&ctx->survtime, buf, sz, t));
 }
 
 static int
-surv0_ctx_getopt_surveytime(void *arg, void *buf, size_t *szp, int typ)
+surv0_ctx_get_surveytime(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	surv0_ctx *ctx = arg;
-	return (nni_copyout_ms(ctx->survtime, buf, szp, typ));
+	return (nni_copyout_ms(ctx->survtime, buf, szp, t));
 }
 
 static int
-surv0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+surv0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	surv0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-surv0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+surv0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	surv0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static int
-surv0_sock_setopt_surveytime(void *arg, const void *buf, size_t sz, int typ)
+surv0_sock_set_surveytime(
+    void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	surv0_sock *s = arg;
-	return (surv0_ctx_setopt_surveytime(s->ctx, buf, sz, typ));
+	return (surv0_ctx_set_surveytime(s->ctx, buf, sz, t));
 }
 
 static int
-surv0_sock_getopt_surveytime(void *arg, void *buf, size_t *szp, int typ)
+surv0_sock_get_surveytime(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	surv0_sock *s = arg;
-	return (surv0_ctx_getopt_surveytime(s->ctx, buf, szp, typ));
+	return (surv0_ctx_get_surveytime(s->ctx, buf, szp, t));
 }
 
 static int
-surv0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
+surv0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	surv0_sock *sock = arg;
 	int         rv;
@@ -510,11 +511,11 @@ surv0_sock_getopt_sendfd(void *arg, void *buf, size_t *szp, int typ)
 	if ((rv = nni_pollable_getfd(sock->sendable, &fd)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static int
-surv0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
+surv0_sock_get_recvfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	surv0_sock *  sock = arg;
 	nni_pollable *recvable;
@@ -525,7 +526,7 @@ surv0_sock_getopt_recvfd(void *arg, void *buf, size_t *szp, int typ)
 	    ((rv = nni_pollable_getfd(recvable, &fd)) != 0)) {
 		return (rv);
 	}
-	return (nni_copyout_int(fd, buf, szp, typ));
+	return (nni_copyout_int(fd, buf, szp, t));
 }
 
 static void
@@ -550,15 +551,15 @@ static nni_proto_pipe_ops surv0_pipe_ops = {
 	.pipe_stop  = surv0_pipe_stop,
 };
 
-static nni_proto_ctx_option surv0_ctx_options[] = {
+static nni_proto_option surv0_ctx_options[] = {
 	{
-	    .co_name   = NNG_OPT_SURVEYOR_SURVEYTIME,
-	    .co_type   = NNI_TYPE_DURATION,
-	    .co_getopt = surv0_ctx_getopt_surveytime,
-	    .co_setopt = surv0_ctx_setopt_surveytime,
+	    .o_name = NNG_OPT_SURVEYOR_SURVEYTIME,
+	    .o_type = NNI_TYPE_DURATION,
+	    .o_get  = surv0_ctx_get_surveytime,
+	    .o_set  = surv0_ctx_set_surveytime,
 	},
 	{
-	    .co_name = NULL,
+	    .o_name = NULL,
 	}
 };
 static nni_proto_ctx_ops surv0_ctx_ops = {
@@ -569,34 +570,32 @@ static nni_proto_ctx_ops surv0_ctx_ops = {
 	.ctx_options = surv0_ctx_options,
 };
 
-static nni_proto_sock_option surv0_sock_options[] = {
+static nni_proto_option surv0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_SURVEYOR_SURVEYTIME,
-	    .pso_type   = NNI_TYPE_DURATION,
-	    .pso_getopt = surv0_sock_getopt_surveytime,
-	    .pso_setopt = surv0_sock_setopt_surveytime,
+	    .o_name = NNG_OPT_SURVEYOR_SURVEYTIME,
+	    .o_type = NNI_TYPE_DURATION,
+	    .o_get  = surv0_sock_get_surveytime,
+	    .o_set  = surv0_sock_set_surveytime,
 	},
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = surv0_sock_getopt_maxttl,
-	    .pso_setopt = surv0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = surv0_sock_get_maxttl,
+	    .o_set  = surv0_sock_set_maxttl,
 	},
 	{
-	    .pso_name   = NNG_OPT_RECVFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = surv0_sock_getopt_recvfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_RECVFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = surv0_sock_get_recvfd,
 	},
 	{
-	    .pso_name   = NNG_OPT_SENDFD,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = surv0_sock_getopt_sendfd,
-	    .pso_setopt = NULL,
+	    .o_name = NNG_OPT_SENDFD,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = surv0_sock_get_sendfd,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/survey0/xrespond.c
+++ b/src/protocol/survey0/xrespond.c
@@ -348,17 +348,17 @@ xresp0_putq_cb(void *arg)
 }
 
 static int
-xresp0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+xresp0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	xresp0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-xresp0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+xresp0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	xresp0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static void
@@ -385,16 +385,16 @@ static nni_proto_pipe_ops xresp0_pipe_ops = {
 	.pipe_stop  = xresp0_pipe_stop,
 };
 
-static nni_proto_sock_option xresp0_sock_options[] = {
+static nni_proto_option xresp0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = xresp0_sock_getopt_maxttl,
-	    .pso_setopt = xresp0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = xresp0_sock_get_maxttl,
+	    .o_set  = xresp0_sock_set_maxttl,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/protocol/survey0/xsurvey.c
+++ b/src/protocol/survey0/xsurvey.c
@@ -280,17 +280,17 @@ xsurv0_recv_cb(void *arg)
 }
 
 static int
-xsurv0_sock_setopt_maxttl(void *arg, const void *buf, size_t sz, int typ)
+xsurv0_sock_set_maxttl(void *arg, const void *buf, size_t sz, nni_opt_type t)
 {
 	xsurv0_sock *s = arg;
-	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, typ));
+	return (nni_copyin_int(&s->ttl, buf, sz, 1, 255, t));
 }
 
 static int
-xsurv0_sock_getopt_maxttl(void *arg, void *buf, size_t *szp, int typ)
+xsurv0_sock_get_maxttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	xsurv0_sock *s = arg;
-	return (nni_copyout_int(s->ttl, buf, szp, typ));
+	return (nni_copyout_int(s->ttl, buf, szp, t));
 }
 
 static void
@@ -356,16 +356,16 @@ static nni_proto_pipe_ops xsurv0_pipe_ops = {
 	.pipe_stop  = xsurv0_pipe_stop,
 };
 
-static nni_proto_sock_option xsurv0_sock_options[] = {
+static nni_proto_option xsurv0_sock_options[] = {
 	{
-	    .pso_name   = NNG_OPT_MAXTTL,
-	    .pso_type   = NNI_TYPE_INT32,
-	    .pso_getopt = xsurv0_sock_getopt_maxttl,
-	    .pso_setopt = xsurv0_sock_setopt_maxttl,
+	    .o_name = NNG_OPT_MAXTTL,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = xsurv0_sock_get_maxttl,
+	    .o_set  = xsurv0_sock_set_maxttl,
 	},
 	// terminate list
 	{
-	    .pso_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/transport/inproc/inproc.c
+++ b/src/transport/inproc/inproc.c
@@ -177,7 +177,7 @@ nni_inproc_pipe_peer(void *arg)
 }
 
 static int
-nni_inproc_pipe_get_addr(void *arg, void *buf, size_t *szp, int typ)
+nni_inproc_pipe_get_addr(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
 	nni_inproc_pipe *p = arg;
 	nni_sockaddr     sa;
@@ -185,7 +185,7 @@ nni_inproc_pipe_get_addr(void *arg, void *buf, size_t *szp, int typ)
 	memset(&sa, 0, sizeof(sa));
 	sa.s_inproc.sa_family = NNG_AF_INPROC;
 	nni_strlcpy(sa.s_inproc.sa_name, p->addr, sizeof(sa.s_inproc.sa_name));
-	return (nni_copyout_sockaddr(&sa, buf, szp, typ));
+	return (nni_copyout_sockaddr(&sa, buf, szp, t));
 }
 
 static int
@@ -435,20 +435,20 @@ nni_inproc_ep_accept(void *arg, nni_aio *aio)
 	nni_mtx_unlock(&nni_inproc.mx);
 }
 
-static nni_tran_pipe_option nni_inproc_pipe_options[] = {
+static nni_tran_option nni_inproc_pipe_options[] = {
 	{
-	    .po_name   = NNG_OPT_LOCADDR,
-	    .po_type   = NNI_TYPE_SOCKADDR,
-	    .po_getopt = nni_inproc_pipe_get_addr,
+	    .o_name = NNG_OPT_LOCADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = nni_inproc_pipe_get_addr,
 	},
 	{
-	    .po_name   = NNG_OPT_REMADDR,
-	    .po_type   = NNI_TYPE_SOCKADDR,
-	    .po_getopt = nni_inproc_pipe_get_addr,
+	    .o_name = NNG_OPT_REMADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = nni_inproc_pipe_get_addr,
 	},
 	// terminate list
 	{
-	    .po_name = NULL,
+	    .o_name = NULL,
 	},
 };
 
@@ -461,10 +461,10 @@ static nni_tran_pipe_ops nni_inproc_pipe_ops = {
 	.p_options = nni_inproc_pipe_options,
 };
 
-static nni_tran_ep_option nni_inproc_ep_options[] = {
+static nni_tran_option nni_inproc_ep_options[] = {
 	// terminate list
 	{
-	    .eo_name = NULL,
+	    .o_name = NULL,
 	},
 };
 

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -20,11 +20,11 @@
 // Windows named pipes.  Other platforms could use other mechanisms,
 // but all implementations on the platform must use the same mechanism.
 
-typedef struct nni_ipc_pipe nni_ipc_pipe;
-typedef struct nni_ipc_ep   nni_ipc_ep;
+typedef struct ipc_pipe ipc_pipe;
+typedef struct ipc_ep   ipc_ep;
 
-// nni_ipc_pipe is one end of an IPC connection.
-struct nni_ipc_pipe {
+// ipc_pipe is one end of an IPC connection.
+struct ipc_pipe {
 	nni_plat_ipc_pipe *ipp;
 	uint16_t           peer;
 	uint16_t           proto;
@@ -48,7 +48,7 @@ struct nni_ipc_pipe {
 	nni_mtx  mtx;
 };
 
-struct nni_ipc_ep {
+struct ipc_ep {
 	nni_sockaddr     sa;
 	nni_plat_ipc_ep *iep;
 	uint16_t         proto;
@@ -58,28 +58,28 @@ struct nni_ipc_ep {
 	nni_mtx          mtx;
 };
 
-static void nni_ipc_pipe_dosend(nni_ipc_pipe *, nni_aio *);
-static void nni_ipc_pipe_dorecv(nni_ipc_pipe *);
-static void nni_ipc_pipe_send_cb(void *);
-static void nni_ipc_pipe_recv_cb(void *);
-static void nni_ipc_pipe_nego_cb(void *);
-static void nni_ipc_ep_cb(void *);
+static void ipc_pipe_dosend(ipc_pipe *, nni_aio *);
+static void ipc_pipe_dorecv(ipc_pipe *);
+static void ipc_pipe_send_cb(void *);
+static void ipc_pipe_recv_cb(void *);
+static void ipc_pipe_nego_cb(void *);
+static void ipc_ep_cb(void *);
 
 static int
-nni_ipc_tran_init(void)
+ipc_tran_init(void)
 {
 	return (0);
 }
 
 static void
-nni_ipc_tran_fini(void)
+ipc_tran_fini(void)
 {
 }
 
 static void
-nni_ipc_pipe_close(void *arg)
+ipc_pipe_close(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
+	ipc_pipe *pipe = arg;
 
 	nni_aio_close(pipe->rxaio);
 	nni_aio_close(pipe->txaio);
@@ -89,9 +89,9 @@ nni_ipc_pipe_close(void *arg)
 }
 
 static void
-nni_ipc_pipe_stop(void *arg)
+ipc_pipe_stop(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
+	ipc_pipe *pipe = arg;
 
 	nni_aio_stop(pipe->rxaio);
 	nni_aio_stop(pipe->txaio);
@@ -99,9 +99,9 @@ nni_ipc_pipe_stop(void *arg)
 }
 
 static void
-nni_ipc_pipe_fini(void *arg)
+ipc_pipe_fini(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
+	ipc_pipe *pipe = arg;
 
 	nni_aio_fini(pipe->rxaio);
 	nni_aio_fini(pipe->txaio);
@@ -117,19 +117,19 @@ nni_ipc_pipe_fini(void *arg)
 }
 
 static int
-nni_ipc_pipe_init(nni_ipc_pipe **pipep, nni_ipc_ep *ep, void *ipp)
+ipc_pipe_init(ipc_pipe **pipep, ipc_ep *ep, void *ipp)
 {
-	nni_ipc_pipe *p;
-	int           rv;
+	ipc_pipe *p;
+	int       rv;
 
 	if ((p = NNI_ALLOC_STRUCT(p)) == NULL) {
 		return (NNG_ENOMEM);
 	}
 	nni_mtx_init(&p->mtx);
-	if (((rv = nni_aio_init(&p->txaio, nni_ipc_pipe_send_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->rxaio, nni_ipc_pipe_recv_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->negaio, nni_ipc_pipe_nego_cb, p)) != 0)) {
-		nni_ipc_pipe_fini(p);
+	if (((rv = nni_aio_init(&p->txaio, ipc_pipe_send_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->rxaio, ipc_pipe_recv_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->negaio, ipc_pipe_nego_cb, p)) != 0)) {
+		ipc_pipe_fini(p);
 		return (rv);
 	}
 	nni_aio_list_init(&p->sendq);
@@ -146,9 +146,9 @@ nni_ipc_pipe_init(nni_ipc_pipe **pipep, nni_ipc_ep *ep, void *ipp)
 }
 
 static void
-nni_ipc_cancel_start(nni_aio *aio, int rv)
+ipc_cancel_start(nni_aio *aio, int rv)
 {
-	nni_ipc_pipe *pipe = nni_aio_get_prov_data(aio);
+	ipc_pipe *pipe = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&pipe->mtx);
 	if (pipe->user_negaio != aio) {
@@ -163,11 +163,11 @@ nni_ipc_cancel_start(nni_aio *aio, int rv)
 }
 
 static void
-nni_ipc_pipe_nego_cb(void *arg)
+ipc_pipe_nego_cb(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
-	nni_aio *     aio  = pipe->negaio;
-	int           rv;
+	ipc_pipe *pipe = arg;
+	nni_aio * aio  = pipe->negaio;
+	int       rv;
 
 	nni_mtx_lock(&pipe->mtx);
 	if ((rv = nni_aio_result(aio)) != 0) {
@@ -220,14 +220,14 @@ done:
 }
 
 static void
-nni_ipc_pipe_send_cb(void *arg)
+ipc_pipe_send_cb(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
-	nni_aio *     aio;
-	nni_aio *     txaio = pipe->txaio;
-	nni_msg *     msg;
-	int           rv;
-	size_t        n;
+	ipc_pipe *pipe = arg;
+	nni_aio * aio;
+	nni_aio * txaio = pipe->txaio;
+	nni_msg * msg;
+	int       rv;
+	size_t    n;
 
 	nni_mtx_lock(&pipe->mtx);
 	aio = nni_list_first(&pipe->sendq);
@@ -255,7 +255,7 @@ nni_ipc_pipe_send_cb(void *arg)
 	nni_aio_list_remove(aio);
 	if (!nni_list_empty(&pipe->sendq)) {
 		// schedule next send
-		nni_ipc_pipe_dosend(pipe, nni_list_first(&pipe->sendq));
+		ipc_pipe_dosend(pipe, nni_list_first(&pipe->sendq));
 	}
 	nni_mtx_unlock(&pipe->mtx);
 
@@ -267,14 +267,14 @@ nni_ipc_pipe_send_cb(void *arg)
 }
 
 static void
-nni_ipc_pipe_recv_cb(void *arg)
+ipc_pipe_recv_cb(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
-	nni_aio *     aio;
-	int           rv;
-	size_t        n;
-	nni_msg *     msg;
-	nni_aio *     rxaio = pipe->rxaio;
+	ipc_pipe *pipe = arg;
+	nni_aio * aio;
+	int       rv;
+	size_t    n;
+	nni_msg * msg;
+	nni_aio * rxaio = pipe->rxaio;
 
 	nni_mtx_lock(&pipe->mtx);
 	aio = nni_list_first(&pipe->recvq);
@@ -346,7 +346,7 @@ nni_ipc_pipe_recv_cb(void *arg)
 	msg         = pipe->rxmsg;
 	pipe->rxmsg = NULL;
 	if (!nni_list_empty(&pipe->recvq)) {
-		nni_ipc_pipe_dorecv(pipe);
+		ipc_pipe_dorecv(pipe);
 	}
 	nni_mtx_unlock(&pipe->mtx);
 
@@ -367,9 +367,9 @@ recv_error:
 }
 
 static void
-nni_ipc_cancel_tx(nni_aio *aio, int rv)
+ipc_cancel_tx(nni_aio *aio, int rv)
 {
-	nni_ipc_pipe *pipe = nni_aio_get_prov_data(aio);
+	ipc_pipe *pipe = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&pipe->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -390,7 +390,7 @@ nni_ipc_cancel_tx(nni_aio *aio, int rv)
 }
 
 static void
-nni_ipc_pipe_dosend(nni_ipc_pipe *pipe, nni_aio *aio)
+ipc_pipe_dosend(ipc_pipe *pipe, nni_aio *aio)
 {
 	nni_aio *txaio;
 	nni_msg *msg;
@@ -425,31 +425,31 @@ nni_ipc_pipe_dosend(nni_ipc_pipe *pipe, nni_aio *aio)
 }
 
 static void
-nni_ipc_pipe_send(void *arg, nni_aio *aio)
+ipc_pipe_send(void *arg, nni_aio *aio)
 {
-	nni_ipc_pipe *pipe = arg;
-	int           rv;
+	ipc_pipe *pipe = arg;
+	int       rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&pipe->mtx);
-	if ((rv = nni_aio_schedule(aio, nni_ipc_cancel_tx, pipe)) != 0) {
+	if ((rv = nni_aio_schedule(aio, ipc_cancel_tx, pipe)) != 0) {
 		nni_mtx_unlock(&pipe->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&pipe->sendq, aio);
 	if (nni_list_first(&pipe->sendq) == aio) {
-		nni_ipc_pipe_dosend(pipe, aio);
+		ipc_pipe_dosend(pipe, aio);
 	}
 	nni_mtx_unlock(&pipe->mtx);
 }
 
 static void
-nni_ipc_cancel_rx(nni_aio *aio, int rv)
+ipc_cancel_rx(nni_aio *aio, int rv)
 {
-	nni_ipc_pipe *pipe = nni_aio_get_prov_data(aio);
+	ipc_pipe *pipe = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&pipe->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -470,7 +470,7 @@ nni_ipc_cancel_rx(nni_aio *aio, int rv)
 }
 
 static void
-nni_ipc_pipe_dorecv(nni_ipc_pipe *pipe)
+ipc_pipe_dorecv(ipc_pipe *pipe)
 {
 	nni_aio *rxaio;
 	nni_iov  iov;
@@ -486,17 +486,17 @@ nni_ipc_pipe_dorecv(nni_ipc_pipe *pipe)
 }
 
 static void
-nni_ipc_pipe_recv(void *arg, nni_aio *aio)
+ipc_pipe_recv(void *arg, nni_aio *aio)
 {
-	nni_ipc_pipe *pipe = arg;
-	int           rv;
+	ipc_pipe *pipe = arg;
+	int       rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&pipe->mtx);
 
-	if ((rv = nni_aio_schedule(aio, nni_ipc_cancel_rx, pipe)) != 0) {
+	if ((rv = nni_aio_schedule(aio, ipc_cancel_rx, pipe)) != 0) {
 		nni_mtx_unlock(&pipe->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -504,24 +504,24 @@ nni_ipc_pipe_recv(void *arg, nni_aio *aio)
 
 	nni_list_append(&pipe->recvq, aio);
 	if (nni_list_first(&pipe->recvq) == aio) {
-		nni_ipc_pipe_dorecv(pipe);
+		ipc_pipe_dorecv(pipe);
 	}
 	nni_mtx_unlock(&pipe->mtx);
 }
 
 static void
-nni_ipc_pipe_start(void *arg, nni_aio *aio)
+ipc_pipe_start(void *arg, nni_aio *aio)
 {
-	nni_ipc_pipe *pipe = arg;
-	nni_aio *     negaio;
-	nni_iov       iov;
-	int           rv;
+	ipc_pipe *pipe = arg;
+	nni_aio * negaio;
+	nni_iov   iov;
+	int       rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&pipe->mtx);
-	if ((rv = nni_aio_schedule(aio, nni_ipc_cancel_start, pipe)) != 0) {
+	if ((rv = nni_aio_schedule(aio, ipc_cancel_start, pipe)) != 0) {
 		nni_mtx_unlock(&pipe->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -547,72 +547,72 @@ nni_ipc_pipe_start(void *arg, nni_aio *aio)
 }
 
 static uint16_t
-nni_ipc_pipe_peer(void *arg)
+ipc_pipe_peer(void *arg)
 {
-	nni_ipc_pipe *pipe = arg;
+	ipc_pipe *pipe = arg;
 
 	return (pipe->peer);
 }
 
 static int
-nni_ipc_pipe_get_addr(void *arg, void *buf, size_t *szp, int typ)
+ipc_pipe_get_addr(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_pipe *p = arg;
-	return (nni_copyout_sockaddr(&p->sa, buf, szp, typ));
+	ipc_pipe *p = arg;
+	return (nni_copyout_sockaddr(&p->sa, buf, szp, t));
 }
 
 static int
-nni_ipc_pipe_get_peer_uid(void *arg, void *buf, size_t *szp, int typ)
+ipc_pipe_get_peer_uid(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_pipe *p = arg;
-	uint64_t      id;
-	int           rv;
+	ipc_pipe *p = arg;
+	uint64_t  id;
+	int       rv;
 	if ((rv = nni_plat_ipc_pipe_get_peer_uid(p->ipp, &id)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_u64(id, buf, szp, typ));
+	return (nni_copyout_u64(id, buf, szp, t));
 }
 
 static int
-nni_ipc_pipe_get_peer_gid(void *arg, void *buf, size_t *szp, int typ)
+ipc_pipe_get_peer_gid(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_pipe *p = arg;
-	uint64_t      id;
-	int           rv;
+	ipc_pipe *p = arg;
+	uint64_t  id;
+	int       rv;
 	if ((rv = nni_plat_ipc_pipe_get_peer_gid(p->ipp, &id)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_u64(id, buf, szp, typ));
+	return (nni_copyout_u64(id, buf, szp, t));
 }
 
 static int
-nni_ipc_pipe_get_peer_pid(void *arg, void *buf, size_t *szp, int typ)
+ipc_pipe_get_peer_pid(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_pipe *p = arg;
-	uint64_t      id;
-	int           rv;
+	ipc_pipe *p = arg;
+	uint64_t  id;
+	int       rv;
 	if ((rv = nni_plat_ipc_pipe_get_peer_pid(p->ipp, &id)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_u64(id, buf, szp, typ));
+	return (nni_copyout_u64(id, buf, szp, t));
 }
 
 static int
-nni_ipc_pipe_get_peer_zoneid(void *arg, void *buf, size_t *szp, int typ)
+ipc_pipe_get_peer_zoneid(void *arg, void *buf, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_pipe *p = arg;
-	uint64_t      id;
-	int           rv;
+	ipc_pipe *p = arg;
+	uint64_t  id;
+	int       rv;
 	if ((rv = nni_plat_ipc_pipe_get_peer_zoneid(p->ipp, &id)) != 0) {
 		return (rv);
 	}
-	return (nni_copyout_u64(id, buf, szp, typ));
+	return (nni_copyout_u64(id, buf, szp, t));
 }
 
 static void
-nni_ipc_ep_fini(void *arg)
+ipc_ep_fini(void *arg)
 {
-	nni_ipc_ep *ep = arg;
+	ipc_ep *ep = arg;
 
 	nni_aio_stop(ep->aio);
 	nni_plat_ipc_ep_fini(ep->iep);
@@ -622,11 +622,11 @@ nni_ipc_ep_fini(void *arg)
 }
 
 static int
-nni_ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
+ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 {
-	nni_ipc_ep *ep;
-	int         rv;
-	size_t      sz;
+	ipc_ep *ep;
+	int     rv;
+	size_t  sz;
 
 	if ((ep = NNI_ALLOC_STRUCT(ep)) == NULL) {
 		return (NNG_ENOMEM);
@@ -637,17 +637,17 @@ nni_ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	ep->sa.s_ipc.sa_family = NNG_AF_IPC;
 
 	if (nni_strlcpy(ep->sa.s_ipc.sa_path, url->u_path, sz) >= sz) {
-		nni_ipc_ep_fini(ep);
+		ipc_ep_fini(ep);
 		return (NNG_EADDRINVAL);
 	}
 
 	if ((rv = nni_plat_ipc_ep_init(&ep->iep, &ep->sa, mode)) != 0) {
-		nni_ipc_ep_fini(ep);
+		ipc_ep_fini(ep);
 		return (rv);
 	}
 
-	if ((rv = nni_aio_init(&ep->aio, nni_ipc_ep_cb, ep)) != 0) {
-		nni_ipc_ep_fini(ep);
+	if ((rv = nni_aio_init(&ep->aio, ipc_ep_cb, ep)) != 0) {
+		ipc_ep_fini(ep);
 		return (rv);
 	}
 	ep->proto = nni_sock_proto_id(sock);
@@ -657,9 +657,9 @@ nni_ipc_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 }
 
 static void
-nni_ipc_ep_close(void *arg)
+ipc_ep_close(void *arg)
 {
-	nni_ipc_ep *ep = arg;
+	ipc_ep *ep = arg;
 
 	nni_aio_close(ep->aio);
 
@@ -669,10 +669,10 @@ nni_ipc_ep_close(void *arg)
 }
 
 static int
-nni_ipc_ep_bind(void *arg)
+ipc_ep_bind(void *arg)
 {
-	nni_ipc_ep *ep = arg;
-	int         rv;
+	ipc_ep *ep = arg;
+	int     rv;
 
 	nni_mtx_lock(&ep->mtx);
 	rv = nni_plat_ipc_ep_listen(ep->iep);
@@ -681,11 +681,11 @@ nni_ipc_ep_bind(void *arg)
 }
 
 static void
-nni_ipc_ep_finish(nni_ipc_ep *ep)
+ipc_ep_finish(ipc_ep *ep)
 {
-	nni_aio *     aio;
-	int           rv;
-	nni_ipc_pipe *pipe = NULL;
+	nni_aio * aio;
+	int       rv;
+	ipc_pipe *pipe = NULL;
 
 	if ((rv = nni_aio_result(ep->aio)) != 0) {
 		goto done;
@@ -694,7 +694,7 @@ nni_ipc_ep_finish(nni_ipc_ep *ep)
 
 	// Attempt to allocate the parent pipe.  If this fails we'll
 	// drop the connection (ENOMEM probably).
-	rv = nni_ipc_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
+	rv = ipc_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
 
 done:
 	aio          = ep->user_aio;
@@ -708,7 +708,7 @@ done:
 	}
 
 	if (pipe != NULL) {
-		nni_ipc_pipe_fini(pipe);
+		ipc_pipe_fini(pipe);
 	}
 	if (aio != NULL) {
 		NNI_ASSERT(rv != 0);
@@ -717,19 +717,19 @@ done:
 }
 
 static void
-nni_ipc_ep_cb(void *arg)
+ipc_ep_cb(void *arg)
 {
-	nni_ipc_ep *ep = arg;
+	ipc_ep *ep = arg;
 
 	nni_mtx_lock(&ep->mtx);
-	nni_ipc_ep_finish(ep);
+	ipc_ep_finish(ep);
 	nni_mtx_unlock(&ep->mtx);
 }
 
 static void
-nni_ipc_cancel_ep(nni_aio *aio, int rv)
+ipc_cancel_ep(nni_aio *aio, int rv)
 {
-	nni_ipc_ep *ep = nni_aio_get_prov_data(aio);
+	ipc_ep *ep = nni_aio_get_prov_data(aio);
 
 	NNI_ASSERT(rv != 0);
 	nni_mtx_lock(&ep->mtx);
@@ -745,10 +745,10 @@ nni_ipc_cancel_ep(nni_aio *aio, int rv)
 }
 
 static void
-nni_ipc_ep_accept(void *arg, nni_aio *aio)
+ipc_ep_accept(void *arg, nni_aio *aio)
 {
-	nni_ipc_ep *ep = arg;
-	int         rv;
+	ipc_ep *ep = arg;
+	int     rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
@@ -756,7 +756,7 @@ nni_ipc_ep_accept(void *arg, nni_aio *aio)
 	nni_mtx_lock(&ep->mtx);
 	NNI_ASSERT(ep->user_aio == NULL);
 
-	if ((rv = nni_aio_schedule(aio, nni_ipc_cancel_ep, ep)) != 0) {
+	if ((rv = nni_aio_schedule(aio, ipc_cancel_ep, ep)) != 0) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -768,10 +768,10 @@ nni_ipc_ep_accept(void *arg, nni_aio *aio)
 }
 
 static void
-nni_ipc_ep_connect(void *arg, nni_aio *aio)
+ipc_ep_connect(void *arg, nni_aio *aio)
 {
-	nni_ipc_ep *ep = arg;
-	int         rv;
+	ipc_ep *ep = arg;
+	int     rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
@@ -779,7 +779,7 @@ nni_ipc_ep_connect(void *arg, nni_aio *aio)
 	nni_mtx_lock(&ep->mtx);
 	NNI_ASSERT(ep->user_aio == NULL);
 
-	if ((rv = nni_aio_schedule(aio, nni_ipc_cancel_ep, ep)) != 0) {
+	if ((rv = nni_aio_schedule(aio, ipc_cancel_ep, ep)) != 0) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -791,14 +791,13 @@ nni_ipc_ep_connect(void *arg, nni_aio *aio)
 }
 
 static int
-nni_ipc_ep_setopt_recvmaxsz(void *arg, const void *data, size_t sz, int typ)
+ipc_ep_set_recvmaxsz(void *arg, const void *data, size_t sz, nni_opt_type t)
 {
-	nni_ipc_ep *ep = arg;
-	size_t      val;
-	int         rv;
+	ipc_ep *ep = arg;
+	size_t  val;
+	int     rv;
 
-	rv = nni_copyin_size(&val, data, sz, 0, NNI_MAXSZ, typ);
-	if ((rv == 0) && (ep != NULL)) {
+	if ((rv = nni_copyin_size(&val, data, sz, 0, NNI_MAXSZ, t)) == 0) {
 		nni_mtx_lock(&ep->mtx);
 		ep->rcvmax = val;
 		nni_mtx_unlock(&ep->mtx);
@@ -807,30 +806,35 @@ nni_ipc_ep_setopt_recvmaxsz(void *arg, const void *data, size_t sz, int typ)
 }
 
 static int
-nni_ipc_ep_getopt_recvmaxsz(void *arg, void *data, size_t *szp, int typ)
+ipc_ep_chk_recvmaxsz(const void *data, size_t sz, nni_opt_type t)
 {
-	nni_ipc_ep *ep = arg;
-	return (nni_copyout_size(ep->rcvmax, data, szp, typ));
+	return (nni_copyin_size(NULL, data, sz, 0, NNI_MAXSZ, t));
 }
 
 static int
-nni_ipc_ep_get_addr(void *arg, void *data, size_t *szp, int typ)
+ipc_ep_get_recvmaxsz(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_ep *ep = arg;
-	return (nni_copyout_sockaddr(&ep->sa, data, szp, typ));
+	ipc_ep *ep = arg;
+	return (nni_copyout_size(ep->rcvmax, data, szp, t));
 }
 
 static int
-nni_ipc_ep_setopt_permissions(void *arg, const void *data, size_t sz, int typ)
+ipc_ep_get_addr(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
-	nni_ipc_ep *ep = arg;
-	int         val;
-	int         rv;
+	ipc_ep *ep = arg;
+	return (nni_copyout_sockaddr(&ep->sa, data, szp, t));
+}
+
+static int
+ipc_ep_set_perms(void *arg, const void *data, size_t sz, nni_opt_type t)
+{
+	ipc_ep *ep = arg;
+	int     val;
+	int     rv;
 
 	// Probably we could further limit this -- most systems don't have
 	// meaningful chmod beyond the lower 9 bits.
-	rv = nni_copyin_int(&val, data, sz, 0, 0x7FFFFFFF, typ);
-	if ((rv == 0) && (ep != NULL)) {
+	if ((rv = nni_copyin_int(&val, data, sz, 0, 0x7FFFFFFF, t)) == 0) {
 		nni_mtx_lock(&ep->mtx);
 		rv = nni_plat_ipc_ep_set_permissions(ep->iep, val);
 		nni_mtx_unlock(&ep->mtx);
@@ -839,123 +843,132 @@ nni_ipc_ep_setopt_permissions(void *arg, const void *data, size_t sz, int typ)
 }
 
 static int
-nni_ipc_ep_setopt_security_desc(
-    void *arg, const void *data, size_t sz, int typ)
+ipc_ep_chk_perms(const void *data, size_t sz, nni_opt_type t)
 {
-	nni_ipc_ep *ep = arg;
-	void *      ptr;
-	int         rv;
-
-	if ((rv = nni_copyin_ptr((void **) &ptr, data, sz, typ)) != 0) {
-		return (rv);
-	}
-
-	if (ep == NULL) {
-		return (0);
-	}
-	return (nni_plat_ipc_ep_set_security_descriptor(ep->iep, ptr));
+	return (nni_copyin_int(NULL, data, sz, 0, 0x7FFFFFFF, t));
 }
 
-static nni_tran_pipe_option nni_ipc_pipe_options[] = {
+static int
+ipc_ep_set_sec_desc(void *arg, const void *data, size_t sz, nni_opt_type t)
+{
+	ipc_ep *ep = arg;
+	void *  ptr;
+	int     rv;
+
+	if ((rv = nni_copyin_ptr(&ptr, data, sz, t)) == 0) {
+		rv = nni_plat_ipc_ep_set_security_descriptor(ep->iep, ptr);
+	}
+	return (rv);
+}
+
+static int
+ipc_ep_chk_sec_desc(const void *data, size_t sz, nni_opt_type t)
+{
+	return (nni_copyin_ptr(NULL, data, sz, t));
+}
+
+static nni_tran_option ipc_pipe_options[] = {
 	{
-	    .po_name   = NNG_OPT_REMADDR,
-	    .po_type   = NNI_TYPE_SOCKADDR,
-	    .po_getopt = nni_ipc_pipe_get_addr,
+	    .o_name = NNG_OPT_REMADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = ipc_pipe_get_addr,
 	},
 	{
-	    .po_name   = NNG_OPT_LOCADDR,
-	    .po_type   = NNI_TYPE_SOCKADDR,
-	    .po_getopt = nni_ipc_pipe_get_addr,
+	    .o_name = NNG_OPT_LOCADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = ipc_pipe_get_addr,
 	},
 	{
-	    .po_name   = NNG_OPT_IPC_PEER_UID,
-	    .po_type   = NNI_TYPE_UINT64,
-	    .po_getopt = nni_ipc_pipe_get_peer_uid,
+	    .o_name = NNG_OPT_IPC_PEER_UID,
+	    .o_type = NNI_TYPE_UINT64,
+	    .o_get  = ipc_pipe_get_peer_uid,
 	},
 	{
-	    .po_name   = NNG_OPT_IPC_PEER_GID,
-	    .po_type   = NNI_TYPE_UINT64,
-	    .po_getopt = nni_ipc_pipe_get_peer_gid,
+	    .o_name = NNG_OPT_IPC_PEER_GID,
+	    .o_type = NNI_TYPE_UINT64,
+	    .o_get  = ipc_pipe_get_peer_gid,
 	},
 	{
-	    .po_name   = NNG_OPT_IPC_PEER_PID,
-	    .po_type   = NNI_TYPE_UINT64,
-	    .po_getopt = nni_ipc_pipe_get_peer_pid,
+	    .o_name = NNG_OPT_IPC_PEER_PID,
+	    .o_type = NNI_TYPE_UINT64,
+	    .o_get  = ipc_pipe_get_peer_pid,
 	},
 	{
-	    .po_name   = NNG_OPT_IPC_PEER_ZONEID,
-	    .po_type   = NNI_TYPE_UINT64,
-	    .po_getopt = nni_ipc_pipe_get_peer_zoneid,
+	    .o_name = NNG_OPT_IPC_PEER_ZONEID,
+	    .o_type = NNI_TYPE_UINT64,
+	    .o_get  = ipc_pipe_get_peer_zoneid,
 	},
 	// terminate list
 	{
-	    .po_name = NULL,
+	    .o_name = NULL,
 	},
 };
 
-static nni_tran_pipe_ops nni_ipc_pipe_ops = {
-	.p_fini    = nni_ipc_pipe_fini,
-	.p_start   = nni_ipc_pipe_start,
-	.p_stop    = nni_ipc_pipe_stop,
-	.p_send    = nni_ipc_pipe_send,
-	.p_recv    = nni_ipc_pipe_recv,
-	.p_close   = nni_ipc_pipe_close,
-	.p_peer    = nni_ipc_pipe_peer,
-	.p_options = nni_ipc_pipe_options,
+static nni_tran_pipe_ops ipc_pipe_ops = {
+	.p_fini    = ipc_pipe_fini,
+	.p_start   = ipc_pipe_start,
+	.p_stop    = ipc_pipe_stop,
+	.p_send    = ipc_pipe_send,
+	.p_recv    = ipc_pipe_recv,
+	.p_close   = ipc_pipe_close,
+	.p_peer    = ipc_pipe_peer,
+	.p_options = ipc_pipe_options,
 };
 
-static nni_tran_ep_option nni_ipc_ep_options[] = {
+static nni_tran_option ipc_ep_options[] = {
 	{
-	    .eo_name   = NNG_OPT_RECVMAXSZ,
-	    .eo_type   = NNI_TYPE_SIZE,
-	    .eo_getopt = nni_ipc_ep_getopt_recvmaxsz,
-	    .eo_setopt = nni_ipc_ep_setopt_recvmaxsz,
+	    .o_name = NNG_OPT_RECVMAXSZ,
+	    .o_type = NNI_TYPE_SIZE,
+	    .o_get  = ipc_ep_get_recvmaxsz,
+	    .o_set  = ipc_ep_set_recvmaxsz,
+	    .o_chk  = ipc_ep_chk_recvmaxsz,
 	},
 	{
-	    .eo_name   = NNG_OPT_LOCADDR,
-	    .eo_type   = NNI_TYPE_SOCKADDR,
-	    .eo_getopt = nni_ipc_ep_get_addr,
-	    .eo_setopt = NULL,
+	    .o_name = NNG_OPT_LOCADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = ipc_ep_get_addr,
 	},
 	{
-	    .eo_name   = NNG_OPT_IPC_SECURITY_DESCRIPTOR,
-	    .eo_type   = NNI_TYPE_POINTER,
-	    .eo_getopt = NULL,
-	    .eo_setopt = nni_ipc_ep_setopt_security_desc,
+	    .o_name = NNG_OPT_IPC_SECURITY_DESCRIPTOR,
+	    .o_type = NNI_TYPE_POINTER,
+	    .o_get  = NULL,
+	    .o_set  = ipc_ep_set_sec_desc,
+	    .o_chk  = ipc_ep_chk_sec_desc,
 	},
 	{
-	    .eo_name   = NNG_OPT_IPC_PERMISSIONS,
-	    .eo_type   = NNI_TYPE_INT32,
-	    .eo_getopt = NULL,
-	    .eo_setopt = nni_ipc_ep_setopt_permissions,
+	    .o_name = NNG_OPT_IPC_PERMISSIONS,
+	    .o_type = NNI_TYPE_INT32,
+	    .o_get  = NULL,
+	    .o_set  = ipc_ep_set_perms,
+	    .o_chk  = ipc_ep_chk_perms,
 	},
 	// terminate list
 	{
-	    .eo_name = NULL,
+	    .o_name = NULL,
 	},
 };
 
-static nni_tran_ep_ops nni_ipc_ep_ops = {
-	.ep_init    = nni_ipc_ep_init,
-	.ep_fini    = nni_ipc_ep_fini,
-	.ep_connect = nni_ipc_ep_connect,
-	.ep_bind    = nni_ipc_ep_bind,
-	.ep_accept  = nni_ipc_ep_accept,
-	.ep_close   = nni_ipc_ep_close,
-	.ep_options = nni_ipc_ep_options,
+static nni_tran_ep_ops ipc_ep_ops = {
+	.ep_init    = ipc_ep_init,
+	.ep_fini    = ipc_ep_fini,
+	.ep_connect = ipc_ep_connect,
+	.ep_bind    = ipc_ep_bind,
+	.ep_accept  = ipc_ep_accept,
+	.ep_close   = ipc_ep_close,
+	.ep_options = ipc_ep_options,
 };
 
-static nni_tran nni_ipc_tran = {
+static nni_tran ipc_tran = {
 	.tran_version = NNI_TRANSPORT_VERSION,
 	.tran_scheme  = "ipc",
-	.tran_ep      = &nni_ipc_ep_ops,
-	.tran_pipe    = &nni_ipc_pipe_ops,
-	.tran_init    = nni_ipc_tran_init,
-	.tran_fini    = nni_ipc_tran_fini,
+	.tran_ep      = &ipc_ep_ops,
+	.tran_pipe    = &ipc_pipe_ops,
+	.tran_init    = ipc_tran_init,
+	.tran_fini    = ipc_tran_fini,
 };
 
 int
 nng_ipc_register(void)
 {
-	return (nni_tran_register(&nni_ipc_tran));
+	return (nni_tran_register(&ipc_tran));
 }

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -22,11 +22,11 @@
 // supplied as well, and uses the supplemental TLS v1.2 code.  It is not
 // an accident that this very closely resembles the TCP transport itself.
 
-typedef struct nni_tls_pipe nni_tls_pipe;
-typedef struct nni_tls_ep   nni_tls_ep;
+typedef struct tls_pipe tls_pipe;
+typedef struct tls_ep   tls_ep;
 
-// nni_tls_pipe is one end of a TLS connection.
-struct nni_tls_pipe {
+// tls_pipe is one end of a TLS connection.
+struct tls_pipe {
 	nni_plat_tcp_pipe *tcp;
 	uint16_t           peer;
 	uint16_t           proto;
@@ -52,7 +52,7 @@ struct nni_tls_pipe {
 	nni_tls *tls;
 };
 
-struct nni_tls_ep {
+struct tls_ep {
 	nni_plat_tcp_ep *tep;
 	uint16_t         proto;
 	size_t           rcvmax;
@@ -68,28 +68,28 @@ struct nni_tls_ep {
 	bool             keepalive;
 };
 
-static void nni_tls_pipe_dorecv(nni_tls_pipe *);
-static void nni_tls_pipe_dosend(nni_tls_pipe *, nni_aio *);
-static void nni_tls_pipe_send_cb(void *);
-static void nni_tls_pipe_recv_cb(void *);
-static void nni_tls_pipe_nego_cb(void *);
-static void nni_tls_ep_cb(void *arg);
+static void tls_pipe_dorecv(tls_pipe *);
+static void tls_pipe_dosend(tls_pipe *, nni_aio *);
+static void tls_pipe_send_cb(void *);
+static void tls_pipe_recv_cb(void *);
+static void tls_pipe_nego_cb(void *);
+static void tls_ep_cb(void *arg);
 
 static int
-nni_tls_tran_init(void)
+tls_tran_init(void)
 {
 	return (0);
 }
 
 static void
-nni_tls_tran_fini(void)
+tls_tran_fini(void)
 {
 }
 
 static void
-nni_tls_pipe_close(void *arg)
+tls_pipe_close(void *arg)
 {
-	nni_tls_pipe *p = arg;
+	tls_pipe *p = arg;
 
 	nni_aio_close(p->rxaio);
 	nni_aio_close(p->txaio);
@@ -99,9 +99,9 @@ nni_tls_pipe_close(void *arg)
 }
 
 static void
-nni_tls_pipe_stop(void *arg)
+tls_pipe_stop(void *arg)
 {
-	nni_tls_pipe *p = arg;
+	tls_pipe *p = arg;
 
 	nni_aio_stop(p->rxaio);
 	nni_aio_stop(p->txaio);
@@ -109,9 +109,9 @@ nni_tls_pipe_stop(void *arg)
 }
 
 static void
-nni_tls_pipe_fini(void *arg)
+tls_pipe_fini(void *arg)
 {
-	nni_tls_pipe *p = arg;
+	tls_pipe *p = arg;
 
 	nni_aio_fini(p->rxaio);
 	nni_aio_fini(p->txaio);
@@ -125,9 +125,9 @@ nni_tls_pipe_fini(void *arg)
 }
 
 static int
-nni_tls_pipe_init(nni_tls_pipe **pipep, nni_tls_ep *ep, void *tpp)
+tls_pipe_init(tls_pipe **pipep, tls_ep *ep, void *tpp)
 {
-	nni_tls_pipe *     p;
+	tls_pipe *         p;
 	nni_plat_tcp_pipe *tcp = tpp;
 	int                rv;
 
@@ -137,10 +137,10 @@ nni_tls_pipe_init(nni_tls_pipe **pipep, nni_tls_ep *ep, void *tpp)
 	nni_mtx_init(&p->mtx);
 
 	if (((rv = nni_tls_init(&p->tls, ep->cfg, tcp)) != 0) ||
-	    ((rv = nni_aio_init(&p->txaio, nni_tls_pipe_send_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->rxaio, nni_tls_pipe_recv_cb, p)) != 0) ||
-	    ((rv = nni_aio_init(&p->negaio, nni_tls_pipe_nego_cb, p)) != 0)) {
-		nni_tls_pipe_fini(p);
+	    ((rv = nni_aio_init(&p->txaio, tls_pipe_send_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->rxaio, tls_pipe_recv_cb, p)) != 0) ||
+	    ((rv = nni_aio_init(&p->negaio, tls_pipe_nego_cb, p)) != 0)) {
+		tls_pipe_fini(p);
 		return (rv);
 	}
 	nni_aio_list_init(&p->recvq);
@@ -157,9 +157,9 @@ nni_tls_pipe_init(nni_tls_pipe **pipep, nni_tls_ep *ep, void *tpp)
 }
 
 static void
-nni_tls_cancel_nego(nni_aio *aio, int rv)
+tls_cancel_nego(nni_aio *aio, int rv)
 {
-	nni_tls_pipe *p = nni_aio_get_prov_data(aio);
+	tls_pipe *p = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&p->mtx);
 	if (p->user_negaio != aio) {
@@ -174,11 +174,11 @@ nni_tls_cancel_nego(nni_aio *aio, int rv)
 }
 
 static void
-nni_tls_pipe_nego_cb(void *arg)
+tls_pipe_nego_cb(void *arg)
 {
-	nni_tls_pipe *p   = arg;
-	nni_aio *     aio = p->negaio;
-	int           rv;
+	tls_pipe *p   = arg;
+	nni_aio * aio = p->negaio;
+	int       rv;
 
 	nni_mtx_lock(&p->mtx);
 	if ((rv = nni_aio_result(aio)) != 0) {
@@ -237,14 +237,14 @@ done:
 }
 
 static void
-nni_tls_pipe_send_cb(void *arg)
+tls_pipe_send_cb(void *arg)
 {
-	nni_tls_pipe *p = arg;
-	int           rv;
-	nni_aio *     aio;
-	size_t        n;
-	nni_msg *     msg;
-	nni_aio *     txaio = p->txaio;
+	tls_pipe *p = arg;
+	int       rv;
+	nni_aio * aio;
+	size_t    n;
+	nni_msg * msg;
+	nni_aio * txaio = p->txaio;
 
 	nni_mtx_lock(&p->mtx);
 	aio = nni_list_first(&p->sendq);
@@ -270,7 +270,7 @@ nni_tls_pipe_send_cb(void *arg)
 	}
 	nni_aio_list_remove(aio);
 	if (!nni_list_empty(&p->sendq)) {
-		nni_tls_pipe_dosend(p, nni_list_first(&p->sendq));
+		tls_pipe_dosend(p, nni_list_first(&p->sendq));
 	}
 	nni_mtx_unlock(&p->mtx);
 
@@ -282,14 +282,14 @@ nni_tls_pipe_send_cb(void *arg)
 }
 
 static void
-nni_tls_pipe_recv_cb(void *arg)
+tls_pipe_recv_cb(void *arg)
 {
-	nni_tls_pipe *p = arg;
-	nni_aio *     aio;
-	int           rv;
-	size_t        n;
-	nni_msg *     msg;
-	nni_aio *     rxaio = p->rxaio;
+	tls_pipe *p = arg;
+	nni_aio * aio;
+	int       rv;
+	size_t    n;
+	nni_msg * msg;
+	nni_aio * rxaio = p->rxaio;
 
 	nni_mtx_lock(&p->mtx);
 	aio = nni_list_first(&p->recvq);
@@ -345,7 +345,7 @@ nni_tls_pipe_recv_cb(void *arg)
 	msg      = p->rxmsg;
 	p->rxmsg = NULL;
 	if (!nni_list_empty(&p->recvq)) {
-		nni_tls_pipe_dorecv(p);
+		tls_pipe_dorecv(p);
 	}
 	nni_mtx_unlock(&p->mtx);
 
@@ -365,9 +365,9 @@ recv_error:
 }
 
 static void
-nni_tls_cancel_tx(nni_aio *aio, int rv)
+tls_cancel_tx(nni_aio *aio, int rv)
 {
-	nni_tls_pipe *p = nni_aio_get_prov_data(aio);
+	tls_pipe *p = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -389,7 +389,7 @@ nni_tls_cancel_tx(nni_aio *aio, int rv)
 }
 
 static void
-nni_tls_pipe_dosend(nni_tls_pipe *p, nni_aio *aio)
+tls_pipe_dosend(tls_pipe *p, nni_aio *aio)
 {
 	nni_aio *txaio;
 	nni_msg *msg;
@@ -423,31 +423,31 @@ nni_tls_pipe_dosend(nni_tls_pipe *p, nni_aio *aio)
 }
 
 static void
-nni_tls_pipe_send(void *arg, nni_aio *aio)
+tls_pipe_send(void *arg, nni_aio *aio)
 {
-	nni_tls_pipe *p = arg;
-	int           rv;
+	tls_pipe *p = arg;
+	int       rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, nni_tls_cancel_tx, p)) != 0) {
+	if ((rv = nni_aio_schedule(aio, tls_cancel_tx, p)) != 0) {
 		nni_mtx_unlock(&p->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&p->sendq, aio);
 	if (nni_list_first(&p->sendq) == aio) {
-		nni_tls_pipe_dosend(p, aio);
+		tls_pipe_dosend(p, aio);
 	}
 	nni_mtx_unlock(&p->mtx);
 }
 
 static void
-nni_tls_cancel_rx(nni_aio *aio, int rv)
+tls_cancel_rx(nni_aio *aio, int rv)
 {
-	nni_tls_pipe *p = nni_aio_get_prov_data(aio);
+	tls_pipe *p = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -468,7 +468,7 @@ nni_tls_cancel_rx(nni_aio *aio, int rv)
 }
 
 static void
-nni_tls_pipe_dorecv(nni_tls_pipe *p)
+tls_pipe_dorecv(tls_pipe *p)
 {
 	nni_aio *rxaio;
 	nni_iov  iov;
@@ -484,16 +484,16 @@ nni_tls_pipe_dorecv(nni_tls_pipe *p)
 }
 
 static void
-nni_tls_pipe_recv(void *arg, nni_aio *aio)
+tls_pipe_recv(void *arg, nni_aio *aio)
 {
-	nni_tls_pipe *p = arg;
-	int           rv;
+	tls_pipe *p = arg;
+	int       rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, nni_tls_cancel_rx, p)) != 0) {
+	if ((rv = nni_aio_schedule(aio, tls_cancel_rx, p)) != 0) {
 		nni_mtx_unlock(&p->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -501,74 +501,74 @@ nni_tls_pipe_recv(void *arg, nni_aio *aio)
 
 	nni_aio_list_append(&p->recvq, aio);
 	if (nni_list_first(&p->recvq) == aio) {
-		nni_tls_pipe_dorecv(p);
+		tls_pipe_dorecv(p);
 	}
 	nni_mtx_unlock(&p->mtx);
 }
 
 static uint16_t
-nni_tls_pipe_peer(void *arg)
+tls_pipe_peer(void *arg)
 {
-	nni_tls_pipe *p = arg;
+	tls_pipe *p = arg;
 
 	return (p->peer);
 }
 
 static int
-nni_tls_pipe_getopt_locaddr(void *arg, void *v, size_t *szp, int typ)
+tls_pipe_get_locaddr(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_pipe *p = arg;
-	int           rv;
-	nni_sockaddr  sa;
+	tls_pipe *   p = arg;
+	int          rv;
+	nni_sockaddr sa;
 
 	memset(&sa, 0, sizeof(sa));
 	if ((rv = nni_tls_sockname(p->tls, &sa)) == 0) {
-		rv = nni_copyout_sockaddr(&sa, v, szp, typ);
+		rv = nni_copyout_sockaddr(&sa, v, szp, t);
 	}
 	return (rv);
 }
 
 static int
-nni_tls_pipe_getopt_remaddr(void *arg, void *v, size_t *szp, int typ)
+tls_pipe_get_remaddr(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_pipe *p = arg;
-	int           rv;
-	nni_sockaddr  sa;
+	tls_pipe *   p = arg;
+	int          rv;
+	nni_sockaddr sa;
 
 	memset(&sa, 0, sizeof(sa));
 	if ((rv = nni_tls_peername(p->tls, &sa)) == 0) {
-		rv = nni_copyout_sockaddr(&sa, v, szp, typ);
+		rv = nni_copyout_sockaddr(&sa, v, szp, t);
 	}
 	return (rv);
 }
 
 static int
-nni_tls_pipe_getopt_keepalive(void *arg, void *v, size_t *szp, int typ)
+tls_pipe_get_keepalive(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_pipe *p = arg;
-	return (nni_copyout_bool(p->keepalive, v, szp, typ));
+	tls_pipe *p = arg;
+	return (nni_copyout_bool(p->keepalive, v, szp, t));
 }
 
 static int
-nni_tls_pipe_getopt_nodelay(void *arg, void *v, size_t *szp, int typ)
+tls_pipe_get_nodelay(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_pipe *p = arg;
-	return (nni_copyout_bool(p->nodelay, v, szp, typ));
+	tls_pipe *p = arg;
+	return (nni_copyout_bool(p->nodelay, v, szp, t));
 }
 
 static void
-nni_tls_pipe_start(void *arg, nni_aio *aio)
+tls_pipe_start(void *arg, nni_aio *aio)
 {
-	nni_tls_pipe *p = arg;
-	nni_aio *     negaio;
-	nni_iov       iov;
-	int           rv;
+	tls_pipe *p = arg;
+	nni_aio * negaio;
+	nni_iov   iov;
+	int       rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, nni_tls_cancel_nego, p)) != 0) {
+	if ((rv = nni_aio_schedule(aio, tls_cancel_nego, p)) != 0) {
 		nni_mtx_unlock(&p->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -594,9 +594,9 @@ nni_tls_pipe_start(void *arg, nni_aio *aio)
 }
 
 static void
-nni_tls_ep_fini(void *arg)
+tls_ep_fini(void *arg)
 {
-	nni_tls_ep *ep = arg;
+	tls_ep *ep = arg;
 
 	nni_aio_stop(ep->aio);
 	if (ep->tep != NULL) {
@@ -611,9 +611,9 @@ nni_tls_ep_fini(void *arg)
 }
 
 static int
-nni_tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
+tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 {
-	nni_tls_ep *      ep;
+	tls_ep *          ep;
 	int               rv;
 	char *            host;
 	char *            serv;
@@ -698,13 +698,13 @@ nni_tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 	if (((rv = nni_plat_tcp_ep_init(&ep->tep, &lsa, &rsa, mode)) != 0) ||
 	    ((rv = nni_tls_config_init(&ep->cfg, tlsmode)) != 0) ||
 	    ((rv = nng_tls_config_auth_mode(ep->cfg, authmode)) != 0) ||
-	    ((rv = nni_aio_init(&ep->aio, nni_tls_ep_cb, ep)) != 0)) {
-		nni_tls_ep_fini(ep);
+	    ((rv = nni_aio_init(&ep->aio, tls_ep_cb, ep)) != 0)) {
+		tls_ep_fini(ep);
 		return (rv);
 	}
 	if ((tlsmode == NNG_TLS_MODE_CLIENT) && (host != NULL)) {
 		if ((rv = nng_tls_config_server_name(ep->cfg, host)) != 0) {
-			nni_tls_ep_fini(ep);
+			tls_ep_fini(ep);
 			return (rv);
 		}
 	}
@@ -716,9 +716,9 @@ nni_tls_ep_init(void **epp, nni_url *url, nni_sock *sock, int mode)
 }
 
 static void
-nni_tls_ep_close(void *arg)
+tls_ep_close(void *arg)
 {
-	nni_tls_ep *ep = arg;
+	tls_ep *ep = arg;
 
 	nni_aio_close(ep->aio);
 
@@ -728,10 +728,10 @@ nni_tls_ep_close(void *arg)
 }
 
 static int
-nni_tls_ep_bind(void *arg)
+tls_ep_bind(void *arg)
 {
-	nni_tls_ep *ep = arg;
-	int         rv;
+	tls_ep *ep = arg;
+	int     rv;
 
 	nni_mtx_lock(&ep->mtx);
 	rv = nni_plat_tcp_ep_listen(ep->tep, &ep->bsa);
@@ -741,11 +741,11 @@ nni_tls_ep_bind(void *arg)
 }
 
 static void
-nni_tls_ep_finish(nni_tls_ep *ep)
+tls_ep_finish(tls_ep *ep)
 {
-	nni_aio *     aio;
-	int           rv;
-	nni_tls_pipe *pipe = NULL;
+	nni_aio * aio;
+	int       rv;
+	tls_pipe *pipe = NULL;
 
 	if ((rv = nni_aio_result(ep->aio)) != 0) {
 		goto done;
@@ -754,7 +754,7 @@ nni_tls_ep_finish(nni_tls_ep *ep)
 
 	// Attempt to allocate the parent pipe.  If this fails we'll
 	// drop the connection (ENOMEM probably).
-	rv = nni_tls_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
+	rv = tls_pipe_init(&pipe, ep, nni_aio_get_output(ep->aio, 0));
 
 done:
 	aio          = ep->user_aio;
@@ -766,7 +766,7 @@ done:
 		return;
 	}
 	if (pipe != NULL) {
-		nni_tls_pipe_fini(pipe);
+		tls_pipe_fini(pipe);
 	}
 	if (aio != NULL) {
 		NNI_ASSERT(rv != 0);
@@ -775,19 +775,19 @@ done:
 }
 
 static void
-nni_tls_ep_cb(void *arg)
+tls_ep_cb(void *arg)
 {
-	nni_tls_ep *ep = arg;
+	tls_ep *ep = arg;
 
 	nni_mtx_lock(&ep->mtx);
-	nni_tls_ep_finish(ep);
+	tls_ep_finish(ep);
 	nni_mtx_unlock(&ep->mtx);
 }
 
 static void
-nni_tls_cancel_ep(nni_aio *aio, int rv)
+tls_cancel_ep(nni_aio *aio, int rv)
 {
-	nni_tls_ep *ep = nni_aio_get_prov_data(aio);
+	tls_ep *ep = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&ep->mtx);
 	if (ep->user_aio != aio) {
@@ -802,17 +802,17 @@ nni_tls_cancel_ep(nni_aio *aio, int rv)
 }
 
 static void
-nni_tls_ep_accept(void *arg, nni_aio *aio)
+tls_ep_accept(void *arg, nni_aio *aio)
 {
-	nni_tls_ep *ep = arg;
-	int         rv;
+	tls_ep *ep = arg;
+	int     rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&ep->mtx);
 	NNI_ASSERT(ep->user_aio == NULL);
-	if ((rv = nni_aio_schedule(aio, nni_tls_cancel_ep, ep)) != 0) {
+	if ((rv = nni_aio_schedule(aio, tls_cancel_ep, ep)) != 0) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, rv);
 		return;
@@ -823,17 +823,17 @@ nni_tls_ep_accept(void *arg, nni_aio *aio)
 }
 
 static void
-nni_tls_ep_connect(void *arg, nni_aio *aio)
+tls_ep_connect(void *arg, nni_aio *aio)
 {
-	nni_tls_ep *ep = arg;
-	int         rv;
+	tls_ep *ep = arg;
+	int     rv;
 
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
 	nni_mtx_lock(&ep->mtx);
 	NNI_ASSERT(ep->user_aio == NULL);
-	if ((rv = nni_aio_schedule(aio, nni_tls_cancel_ep, ep)) != 0) {
+	if ((rv = nni_aio_schedule(aio, tls_cancel_ep, ep)) != 0) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, rv);
 	}
@@ -843,13 +843,18 @@ nni_tls_ep_connect(void *arg, nni_aio *aio)
 }
 
 static int
-nni_tls_ep_setopt_nodelay(void *arg, const void *v, size_t sz, int typ)
+tls_ep_chk_bool(const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	bool        val;
-	int         rv;
-	rv = nni_copyin_bool(&val, v, sz, typ);
-	if ((rv == 0) && (ep != NULL)) {
+	return (nni_copyin_bool(NULL, v, sz, t));
+}
+
+static int
+tls_ep_set_nodelay(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	tls_ep *ep = arg;
+	bool    val;
+	int     rv;
+	if ((rv = nni_copyin_bool(&val, v, sz, t)) == 0) {
 		nni_mtx_lock(&ep->mtx);
 		ep->nodelay = val;
 		nni_mtx_unlock(&ep->mtx);
@@ -858,20 +863,19 @@ nni_tls_ep_setopt_nodelay(void *arg, const void *v, size_t sz, int typ)
 }
 
 static int
-nni_tls_ep_getopt_nodelay(void *arg, void *v, size_t *szp, int typ)
+tls_ep_get_nodelay(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	return (nni_copyout_bool(ep->nodelay, v, szp, typ));
+	tls_ep *ep = arg;
+	return (nni_copyout_bool(ep->nodelay, v, szp, t));
 }
 
 static int
-nni_tls_ep_setopt_keepalive(void *arg, const void *v, size_t sz, int typ)
+tls_ep_set_keepalive(void *arg, const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	bool        val;
-	int         rv;
-	rv = nni_copyin_bool(&val, v, sz, typ);
-	if ((rv == 0) && (ep != NULL)) {
+	tls_ep *ep = arg;
+	bool    val;
+	int     rv;
+	if ((rv = nni_copyin_bool(&val, v, sz, t)) == 0) {
 		nni_mtx_lock(&ep->mtx);
 		ep->keepalive = val;
 		nni_mtx_unlock(&ep->mtx);
@@ -880,37 +884,36 @@ nni_tls_ep_setopt_keepalive(void *arg, const void *v, size_t sz, int typ)
 }
 
 static int
-nni_tls_ep_getopt_keepalive(void *arg, void *v, size_t *szp, int typ)
+tls_ep_get_keepalive(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	return (nni_copyout_bool(ep->keepalive, v, szp, typ));
+	tls_ep *ep = arg;
+	return (nni_copyout_bool(ep->keepalive, v, szp, t));
 }
 
 static int
-nni_tls_ep_getopt_url(void *arg, void *v, size_t *szp, int typ)
+tls_ep_get_url(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	char        ustr[128];
-	char        ipstr[48];  // max for IPv6 addresses including []
-	char        portstr[6]; // max for 16-bit port
+	tls_ep *ep = arg;
+	char    ustr[128];
+	char    ipstr[48];  // max for IPv6 addresses including []
+	char    portstr[6]; // max for 16-bit port
 
 	if (ep->mode == NNI_EP_MODE_DIAL) {
-		return (nni_copyout_str(ep->url->u_rawurl, v, szp, typ));
+		return (nni_copyout_str(ep->url->u_rawurl, v, szp, t));
 	}
 	nni_plat_tcp_ntop(&ep->bsa, ipstr, portstr);
 	snprintf(ustr, sizeof(ustr), "tls+tcp://%s:%s", ipstr, portstr);
-	return (nni_copyout_str(ustr, v, szp, typ));
+	return (nni_copyout_str(ustr, v, szp, t));
 }
 
 static int
-nni_tls_ep_setopt_recvmaxsz(void *arg, const void *v, size_t sz, int typ)
+tls_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	size_t      val;
-	int         rv;
+	tls_ep *ep = arg;
+	size_t  val;
+	int     rv;
 
-	rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, typ);
-	if ((rv == 0) && (ep != NULL)) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, t)) == 0) {
 		nni_mtx_lock(&ep->mtx);
 		ep->rcvmax = val;
 		nni_mtx_unlock(&ep->mtx);
@@ -919,27 +922,41 @@ nni_tls_ep_setopt_recvmaxsz(void *arg, const void *v, size_t sz, int typ)
 }
 
 static int
-nni_tls_ep_getopt_recvmaxsz(void *arg, void *v, size_t *szp, int typ)
+tls_ep_chk_recvmaxsz(const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	return (nni_copyout_size(ep->rcvmax, v, szp, typ));
+	return (nni_copyin_size(NULL, v, sz, 0, NNI_MAXSZ, t));
 }
 
 static int
-tls_setopt_config(void *arg, const void *data, size_t sz, int typ)
+tls_ep_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_ep *    ep = arg;
+	tls_ep *ep = arg;
+	return (nni_copyout_size(ep->rcvmax, v, szp, t));
+}
+
+static int
+tls_ep_chk_config(const void *data, size_t sz, nni_opt_type t)
+{
+	void *v;
+	int   rv;
+	if (((rv = nni_copyin_ptr(&v, data, sz, t)) == 0) && (v == NULL)) {
+		rv = NNG_EINVAL;
+	}
+	return (rv);
+}
+
+static int
+tls_ep_set_config(void *arg, const void *data, size_t sz, nni_opt_type t)
+{
+	tls_ep *        ep = arg;
 	nng_tls_config *cfg, *old;
 	int             rv;
 
-	if ((rv = nni_copyin_ptr((void **) &cfg, data, sz, typ)) != 0) {
+	if ((rv = nni_copyin_ptr((void **) &cfg, data, sz, t)) != 0) {
 		return (rv);
 	}
 	if (cfg == NULL) {
 		return (NNG_EINVAL);
-	}
-	if (ep == NULL) {
-		return (0);
 	}
 	old = ep->cfg;
 	nni_tls_config_hold(cfg);
@@ -951,234 +968,241 @@ tls_setopt_config(void *arg, const void *data, size_t sz, int typ)
 }
 
 static int
-tls_getopt_config(void *arg, void *v, size_t *szp, int typ)
+tls_ep_get_config(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	return (nni_copyout_ptr(ep->cfg, v, szp, typ));
+	tls_ep *ep = arg;
+	return (nni_copyout_ptr(ep->cfg, v, szp, t));
 }
 
 static int
-tls_setopt_ca_file(void *arg, const void *v, size_t sz, int typ)
+tls_ep_chk_string(const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-
-	if ((typ != NNI_TYPE_OPAQUE) && (typ != NNI_TYPE_STRING)) {
+	if ((t != NNI_TYPE_OPAQUE) && (t != NNI_TYPE_STRING)) {
 		return (NNG_EBADTYPE);
 	}
 	if (nni_strnlen(v, sz) >= sz) {
 		return (NNG_EINVAL);
 	}
-	if (ep == NULL) {
-		return (0);
-	}
-	return (nng_tls_config_ca_file(ep->cfg, v));
+	return (0);
 }
 
 static int
-tls_setopt_auth_mode(void *arg, const void *v, size_t sz, int typ)
+tls_ep_set_ca_file(void *arg, const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
-	int         mode;
-	int         rv;
+	tls_ep *ep = arg;
+	int     rv;
+
+	if ((rv = tls_ep_chk_string(v, sz, t)) == 0) {
+		rv = nng_tls_config_ca_file(ep->cfg, v);
+	}
+	return (rv);
+}
+
+static int
+tls_ep_chk_auth_mode(const void *v, size_t sz, nni_opt_type t)
+{
+	return (nni_copyin_int(NULL, v, sz, NNG_TLS_AUTH_MODE_NONE,
+	    NNG_TLS_AUTH_MODE_REQUIRED, t));
+}
+
+static int
+tls_ep_set_auth_mode(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	tls_ep *ep = arg;
+	int     mode;
+	int     rv;
 
 	rv = nni_copyin_int(&mode, v, sz, NNG_TLS_AUTH_MODE_NONE,
-	    NNG_TLS_AUTH_MODE_REQUIRED, typ);
-	if ((rv != 0) || (ep == NULL)) {
-		return (rv);
+	    NNG_TLS_AUTH_MODE_REQUIRED, t);
+	if (rv == 0) {
+		rv = nng_tls_config_auth_mode(ep->cfg, mode);
 	}
-	return (nng_tls_config_auth_mode(ep->cfg, mode));
+	return (rv);
 }
 
 static int
-tls_setopt_server_name(void *arg, const void *v, size_t sz, int typ)
+tls_ep_set_server_name(void *arg, const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
+	tls_ep *ep = arg;
+	int     rv;
 
-	if ((typ != NNI_TYPE_OPAQUE) && (typ != NNI_TYPE_STRING)) {
-		return (NNG_EBADTYPE);
+	if ((rv = tls_ep_chk_string(v, sz, t)) == 0) {
+		rv = nng_tls_config_server_name(ep->cfg, v);
 	}
-	if (nni_strnlen(v, sz) >= sz) {
-		return (NNG_EINVAL);
-	}
-	if (ep == NULL) {
-		return (0);
-	}
-	return (nng_tls_config_server_name(ep->cfg, v));
+	return (rv);
 }
 
 static int
-tls_setopt_cert_key_file(void *arg, const void *v, size_t sz, int typ)
+tls_ep_set_cert_key_file(void *arg, const void *v, size_t sz, nni_opt_type t)
 {
-	nni_tls_ep *ep = arg;
+	tls_ep *ep = arg;
+	int     rv;
 
-	if ((typ != NNI_TYPE_OPAQUE) && (typ != NNI_TYPE_STRING)) {
-		return (NNG_EBADTYPE);
+	if ((rv = tls_ep_chk_string(v, sz, t)) == 0) {
+		rv = nng_tls_config_cert_key_file(ep->cfg, v, NULL);
 	}
-	if (nni_strnlen(v, sz) >= sz) {
-		return (NNG_EINVAL);
-	}
-	if (ep == NULL) {
-		return (0);
-	}
-	return (nng_tls_config_cert_key_file(ep->cfg, v, NULL));
+	return (rv);
 }
 
 static int
-tls_getopt_verified(void *arg, void *v, size_t *szp, int typ)
+tls_pipe_get_verified(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
-	nni_tls_pipe *p = arg;
+	tls_pipe *p = arg;
 
-	return (nni_copyout_bool(nni_tls_verified(p->tls), v, szp, typ));
+	return (nni_copyout_bool(nni_tls_verified(p->tls), v, szp, t));
 }
 
-static nni_tran_pipe_option nni_tls_pipe_options[] = {
+static nni_tran_option tls_pipe_options[] = {
 	{
-	    .po_name   = NNG_OPT_LOCADDR,
-	    .po_type   = NNI_TYPE_SOCKADDR,
-	    .po_getopt = nni_tls_pipe_getopt_locaddr,
+	    .o_name = NNG_OPT_LOCADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = tls_pipe_get_locaddr,
 	},
 	{
-	    .po_name   = NNG_OPT_REMADDR,
-	    .po_type   = NNI_TYPE_SOCKADDR,
-	    .po_getopt = nni_tls_pipe_getopt_remaddr,
+	    .o_name = NNG_OPT_REMADDR,
+	    .o_type = NNI_TYPE_SOCKADDR,
+	    .o_get  = tls_pipe_get_remaddr,
 	},
 	{
-	    .po_name   = NNG_OPT_TLS_VERIFIED,
-	    .po_type   = NNI_TYPE_BOOL,
-	    .po_getopt = tls_getopt_verified,
+	    .o_name = NNG_OPT_TLS_VERIFIED,
+	    .o_type = NNI_TYPE_BOOL,
+	    .o_get  = tls_pipe_get_verified,
 	},
 	{
-	    .po_name   = NNG_OPT_TCP_KEEPALIVE,
-	    .po_type   = NNI_TYPE_BOOL,
-	    .po_getopt = nni_tls_pipe_getopt_keepalive,
+	    .o_name = NNG_OPT_TCP_KEEPALIVE,
+	    .o_type = NNI_TYPE_BOOL,
+	    .o_get  = tls_pipe_get_keepalive,
 	},
 	{
-	    .po_name   = NNG_OPT_TCP_NODELAY,
-	    .po_type   = NNI_TYPE_BOOL,
-	    .po_getopt = nni_tls_pipe_getopt_nodelay,
+	    .o_name = NNG_OPT_TCP_NODELAY,
+	    .o_type = NNI_TYPE_BOOL,
+	    .o_get  = tls_pipe_get_nodelay,
 	},
 	// terminate list
 	{
-	    .po_name = NULL,
+	    .o_name = NULL,
 	},
 };
 
-static nni_tran_pipe_ops nni_tls_pipe_ops = {
-	.p_fini    = nni_tls_pipe_fini,
-	.p_start   = nni_tls_pipe_start,
-	.p_stop    = nni_tls_pipe_stop,
-	.p_send    = nni_tls_pipe_send,
-	.p_recv    = nni_tls_pipe_recv,
-	.p_close   = nni_tls_pipe_close,
-	.p_peer    = nni_tls_pipe_peer,
-	.p_options = nni_tls_pipe_options,
+static nni_tran_pipe_ops tls_pipe_ops = {
+	.p_fini    = tls_pipe_fini,
+	.p_start   = tls_pipe_start,
+	.p_stop    = tls_pipe_stop,
+	.p_send    = tls_pipe_send,
+	.p_recv    = tls_pipe_recv,
+	.p_close   = tls_pipe_close,
+	.p_peer    = tls_pipe_peer,
+	.p_options = tls_pipe_options,
 };
 
-static nni_tran_ep_option nni_tls_ep_options[] = {
+static nni_tran_option tls_ep_options[] = {
 	{
-	    .eo_name   = NNG_OPT_RECVMAXSZ,
-	    .eo_type   = NNI_TYPE_SIZE,
-	    .eo_getopt = nni_tls_ep_getopt_recvmaxsz,
-	    .eo_setopt = nni_tls_ep_setopt_recvmaxsz,
+	    .o_name = NNG_OPT_RECVMAXSZ,
+	    .o_type = NNI_TYPE_SIZE,
+	    .o_get  = tls_ep_get_recvmaxsz,
+	    .o_set  = tls_ep_set_recvmaxsz,
+	    .o_chk  = tls_ep_chk_recvmaxsz,
 	},
 	{
-	    .eo_name   = NNG_OPT_URL,
-	    .eo_type   = NNI_TYPE_STRING,
-	    .eo_getopt = nni_tls_ep_getopt_url,
-	    .eo_setopt = NULL,
+	    .o_name = NNG_OPT_URL,
+	    .o_type = NNI_TYPE_STRING,
+	    .o_get  = tls_ep_get_url,
 	},
 	{
-	    .eo_name   = NNG_OPT_TLS_CONFIG,
-	    .eo_type   = NNI_TYPE_POINTER,
-	    .eo_getopt = tls_getopt_config,
-	    .eo_setopt = tls_setopt_config,
+	    .o_name = NNG_OPT_TLS_CONFIG,
+	    .o_type = NNI_TYPE_POINTER,
+	    .o_get  = tls_ep_get_config,
+	    .o_set  = tls_ep_set_config,
+	    .o_chk  = tls_ep_chk_config,
 	},
 	{
-	    .eo_name   = NNG_OPT_TLS_CERT_KEY_FILE,
-	    .eo_type   = NNI_TYPE_STRING,
-	    .eo_getopt = NULL,
-	    .eo_setopt = tls_setopt_cert_key_file,
+	    .o_name = NNG_OPT_TLS_CERT_KEY_FILE,
+	    .o_type = NNI_TYPE_STRING,
+	    .o_set  = tls_ep_set_cert_key_file,
+	    .o_chk  = tls_ep_chk_string,
 	},
 	{
-	    .eo_name   = NNG_OPT_TLS_CA_FILE,
-	    .eo_type   = NNI_TYPE_STRING,
-	    .eo_getopt = NULL,
-	    .eo_setopt = tls_setopt_ca_file,
+	    .o_name = NNG_OPT_TLS_CA_FILE,
+	    .o_type = NNI_TYPE_STRING,
+	    .o_set  = tls_ep_set_ca_file,
+	    .o_chk  = tls_ep_chk_string,
 	},
 	{
-	    .eo_name   = NNG_OPT_TLS_AUTH_MODE,
-	    .eo_type   = NNI_TYPE_INT32, // enum really
-	    .eo_getopt = NULL,
-	    .eo_setopt = tls_setopt_auth_mode,
+	    .o_name = NNG_OPT_TLS_AUTH_MODE,
+	    .o_type = NNI_TYPE_INT32, // enum really
+	    .o_set  = tls_ep_set_auth_mode,
+	    .o_chk  = tls_ep_chk_auth_mode,
 	},
 	{
-	    .eo_name   = NNG_OPT_TLS_SERVER_NAME,
-	    .eo_type   = NNI_TYPE_STRING,
-	    .eo_getopt = NULL,
-	    .eo_setopt = tls_setopt_server_name,
+	    .o_name = NNG_OPT_TLS_SERVER_NAME,
+	    .o_type = NNI_TYPE_STRING,
+	    .o_set  = tls_ep_set_server_name,
+	    .o_chk  = tls_ep_chk_string,
 	},
 	{
-	    .eo_name   = NNG_OPT_TCP_NODELAY,
-	    .eo_type   = NNI_TYPE_BOOL,
-	    .eo_getopt = nni_tls_ep_getopt_nodelay,
-	    .eo_setopt = nni_tls_ep_setopt_nodelay,
+	    .o_name = NNG_OPT_TCP_NODELAY,
+	    .o_type = NNI_TYPE_BOOL,
+	    .o_get  = tls_ep_get_nodelay,
+	    .o_set  = tls_ep_set_nodelay,
+	    .o_chk  = tls_ep_chk_bool,
 	},
 	{
-	    .eo_name   = NNG_OPT_TCP_KEEPALIVE,
-	    .eo_type   = NNI_TYPE_BOOL,
-	    .eo_getopt = nni_tls_ep_getopt_keepalive,
-	    .eo_setopt = nni_tls_ep_setopt_keepalive,
+	    .o_name = NNG_OPT_TCP_KEEPALIVE,
+	    .o_type = NNI_TYPE_BOOL,
+	    .o_get  = tls_ep_get_keepalive,
+	    .o_set  = tls_ep_set_keepalive,
+	    .o_chk  = tls_ep_chk_bool,
 	},
 	// terminate list
 	{
-	    .eo_name = NULL,
+	    .o_name = NULL,
 	},
 };
 
-static nni_tran_ep_ops nni_tls_ep_ops = {
-	.ep_init    = nni_tls_ep_init,
-	.ep_fini    = nni_tls_ep_fini,
-	.ep_connect = nni_tls_ep_connect,
-	.ep_bind    = nni_tls_ep_bind,
-	.ep_accept  = nni_tls_ep_accept,
-	.ep_close   = nni_tls_ep_close,
-	.ep_options = nni_tls_ep_options,
+static nni_tran_ep_ops tls_ep_ops = {
+	.ep_init    = tls_ep_init,
+	.ep_fini    = tls_ep_fini,
+	.ep_connect = tls_ep_connect,
+	.ep_bind    = tls_ep_bind,
+	.ep_accept  = tls_ep_accept,
+	.ep_close   = tls_ep_close,
+	.ep_options = tls_ep_options,
 };
 
-static nni_tran nni_tls_tran = {
+static nni_tran tls_tran = {
 	.tran_version = NNI_TRANSPORT_VERSION,
 	.tran_scheme  = "tls+tcp",
-	.tran_ep      = &nni_tls_ep_ops,
-	.tran_pipe    = &nni_tls_pipe_ops,
-	.tran_init    = nni_tls_tran_init,
-	.tran_fini    = nni_tls_tran_fini,
+	.tran_ep      = &tls_ep_ops,
+	.tran_pipe    = &tls_pipe_ops,
+	.tran_init    = tls_tran_init,
+	.tran_fini    = tls_tran_fini,
 };
 
-static nni_tran nni_tls4_tran = {
+static nni_tran tls4_tran = {
 	.tran_version = NNI_TRANSPORT_VERSION,
 	.tran_scheme  = "tls+tcp4",
-	.tran_ep      = &nni_tls_ep_ops,
-	.tran_pipe    = &nni_tls_pipe_ops,
-	.tran_init    = nni_tls_tran_init,
-	.tran_fini    = nni_tls_tran_fini,
+	.tran_ep      = &tls_ep_ops,
+	.tran_pipe    = &tls_pipe_ops,
+	.tran_init    = tls_tran_init,
+	.tran_fini    = tls_tran_fini,
 };
 
-static nni_tran nni_tls6_tran = {
+static nni_tran tls6_tran = {
 	.tran_version = NNI_TRANSPORT_VERSION,
 	.tran_scheme  = "tls+tcp6",
-	.tran_ep      = &nni_tls_ep_ops,
-	.tran_pipe    = &nni_tls_pipe_ops,
-	.tran_init    = nni_tls_tran_init,
-	.tran_fini    = nni_tls_tran_fini,
+	.tran_ep      = &tls_ep_ops,
+	.tran_pipe    = &tls_pipe_ops,
+	.tran_init    = tls_tran_init,
+	.tran_fini    = tls_tran_fini,
 };
 
 int
 nng_tls_register(void)
 {
 	int rv;
-	if (((rv = nni_tran_register(&nni_tls_tran)) != 0) ||
-	    ((rv = nni_tran_register(&nni_tls4_tran)) != 0) ||
-	    ((rv = nni_tran_register(&nni_tls6_tran)) != 0)) {
+	if (((rv = nni_tran_register(&tls_tran)) != 0) ||
+	    ((rv = nni_tran_register(&tls4_tran)) != 0) ||
+	    ((rv = nni_tran_register(&tls6_tran)) != 0)) {
 		return (rv);
 	}
 	return (0);


### PR DESCRIPTION
fixes #538 setopt should have an explicit chkopt routine
fixes #537 Internal TCP API needs better name separation
fixes #524 Option types should be "typed"

This is a rework of the option management code, to make it both clearer
and to prepare for further work to break up endpoints.  This reduces
a certain amount of dead or redundant code, and actually saves cycles
when setting options, as some loops were not terminated that should have
been.

