### PR TITLE
fixes #539 Feature request: customizable http error page

### DIFF
--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -341,7 +341,10 @@ These functions are intended for use with HTTP server applications.
 |<<nng_http_server_get_tls.3http#,nng_http_server_get_tls()>>|get HTTP server TLS configuration
 |<<nng_http_server_hold.3http#,nng_http_server_get_tls()>>|get and hold HTTP server instance
 |<<nng_http_server_release.3http#,nng_http_server_get_tls()>>|release HTTP server instance
+|<<nng_http_server_set_error_file.3http#,nng_http_server_set_error_file()>>|set custom HTTP error file
+|<<nng_http_server_set_error_page.3http#,nng_http_server_set_error_page()>>|set custom HTTP error page
 |<<nng_http_server_set_tls.3http#,nng_http_server_set_tls()>>|set HTTP server TLS configuration
+|<<nng_http_server_res_error.3http#,nng_http_server_res_error()>>|use HTTP server error page
 |<<nng_http_server_start.3http#,nng_http_server_start()>>|start HTTP server
 |<<nng_http_server_stop.3http#,nng_http_server_stop()>>|stop HTTP server
 |===

--- a/docs/man/nng_http_server_res_error.3http.adoc
+++ b/docs/man/nng_http_server_res_error.3http.adoc
@@ -1,0 +1,63 @@
+= nng_http_server_res_error(3http)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_http_server_res_error - use HTTP server error page
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+#include <nng/supplemental/http/http.h>
+
+int nng_http_server_set_error_file(nng_http_server *server,
+        nng_http_res *response);
+----
+
+== DESCRIPTION
+
+The `nng_http_server_res_error()` sets the body of _response_
+to _server_'s error page, which may have been customized using the
+`<<nng_http_server_set_error_file.3http#,nng_http_server_error_file()>>`
+or
+`<<nng_http_server_set_error_page.3http#,nng_http_server_error_page()>>`
+functions.
+
+The status code of the _response_ should have already been set, either
+implicitly by allocating it with
+`<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error()>>`,
+or by calling
+`<<nng_http_res_set_status.3http#,nng_http_res_set_status()>>`.
+
+Any content body previously set for _response_ will be overridden by
+this function.
+
+== RETURN VALUES
+
+This function returns 0 on success, and non-zero otherwise.
+
+== ERRORS
+
+[horizontal]
+`NNG_ENOMEM`:: Insufficient free memory exists.
+`NNG_ENOTSUP`:: HTTP not supported.
+
+== SEE ALSO
+
+[.text-left]
+<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error(3http)>>,
+<<nng_http_server_hold.3http#,nng_http_server_hold(3http)>>,
+<<nng_http_server_set_error_file.3http#,nng_http_server_set_error_file(3http)>>,
+<<nng_http_server_set_error_page.3http#,nng_http_server_set_error_page(3http)>>,
+<<nng_strerror.3#,nng_strerror(3)>>,
+<<nng.7#,nng(7)>>

--- a/docs/man/nng_http_server_set_error_file.3http.adoc
+++ b/docs/man/nng_http_server_set_error_file.3http.adoc
@@ -1,0 +1,73 @@
+= nng_http_server_set_error_file(3http)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_http_server_set_error_file - set custom HTTP error file
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+#include <nng/supplemental/http/http.h>
+
+int nng_http_server_set_error_file(nng_http_server *server,
+        uint16_t code, const char *path);
+----
+
+== DESCRIPTION
+
+The `nng_http_server_set_error_file()` sets an error page to be used
+for HTTP status _code_ on the server instance _server_.
+The body content of the HTTP responses will contain the file contents of
+the file located at _path_, which should be an HTML file.
+
+The custom HTML content will be used when the server is returning an
+internally generated error response, or is returning an error response
+that was allocated with the
+`<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error()>>`
+function.
+This HTML content will also be used if the application calls the
+`<<nng_http_server_res_error.3http#,nng_http_server_res_error()>>`.
+The last custom error page set for _code_ by either this function or
+`<<nng_http_server_set_error_page.3http#,nng_http_server_error_page()>>`
+will be used.
+
+NOTE: Error responses that have their body content changed after allocation,
+or that are written directly by the application, will not use the body
+content supplied here.
+
+NOTE: The file contents of _path_ are read when this function is called.
+Therefore, if the file contents are changed, then this function should
+be called again to update the error page.
+
+== RETURN VALUES
+
+This function returns 0 on success, and non-zero otherwise.
+
+== ERRORS
+
+[horizontal]
+`NNG_ENOENT`:: The file named by _path_ does not exist.
+`NNG_EPERM`:: No permission to read the file named by _path_.
+`NNG_ENOMEM`:: Insufficient free memory exists.
+`NNG_ENOTSUP`:: HTTP not supported.
+
+== SEE ALSO
+
+[.text-left]
+<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error(3http)>>,
+<<nng_http_server_hold.3http#,nng_http_server_hold(3http)>>,
+<<nng_http_server_res_error.3http#,nng_http_server_res_error(3http)>>,
+<<nng_http_server_set_error_page.3http#,nng_http_server_set_error_page(3http)>>,
+<<nng_strerror.3#,nng_strerror(3)>>,
+<<nng.7#,nng(7)>>

--- a/docs/man/nng_http_server_set_error_page.3http.adoc
+++ b/docs/man/nng_http_server_set_error_page.3http.adoc
@@ -1,0 +1,69 @@
+= nng_http_server_set_error_page(3http)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_http_server_set_error_page - set custom HTTP error page
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+#include <nng/supplemental/http/http.h>
+
+int nng_http_server_set_error_page(nng_http_server *server,
+        uint16_t code, const char *html);
+----
+
+== DESCRIPTION
+
+The `nng_http_server_set_error_page()` sets an error page to be used
+for HTTP status _code_ on the server instance _server_.
+The body content of the HTTP responses will contain _html_.
+
+The custom HTML content will be used when the server is returning an
+internally generated error response, or is returning an error response
+that was allocated with the
+`<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error()>>`
+function.
+This HTML content will also be used if the application calls the
+`<<nng_http_server_res_error.3http#,nng_http_server_res_error()>>`.
+The last custom error page set for _code_ by either this function or
+`<<nng_http_server_set_error_file.3http#,nng_http_server_error_file()>>`
+will be used.
+
+NOTE: Error responses that have their body content changed after allocation,
+or that are written directly by the application, will not use the body
+content supplied here.
+
+The supplied HTML content is copied by this function, and may be reused
+after this function returns.
+
+== RETURN VALUES
+
+This function returns 0 on success, and non-zero otherwise.
+
+== ERRORS
+
+[horizontal]
+`NNG_ENOMEM`:: Insufficient free memory exists.
+`NNG_ENOTSUP`:: HTTP not supported.
+
+== SEE ALSO
+
+[.text-left]
+<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error(3http)>>,
+<<nng_http_server_hold.3http#,nng_http_server_hold(3http)>>,
+<<nng_http_server_res_error.3http#,nng_http_server_res_error(3http)>>,
+<<nng_http_server_set_error_file.3http#,nng_http_server_set_error_file(3http)>>,
+<<nng_strerror.3#,nng_strerror(3)>>,
+<<nng.7#,nng(7)>>

--- a/src/supplemental/http/http.h
+++ b/src/supplemental/http/http.h
@@ -407,6 +407,29 @@ NNG_DECL int nng_http_server_set_tls(
 NNG_DECL int nng_http_server_get_tls(
     nng_http_server *, struct nng_tls_config **);
 
+// nng_http_server_set_error_page sets a custom error page (HTML) content
+// to be sent for the given error code.  This is used when the error is
+// generated internally by the framework, or when the application returns
+// the response back to the server via the handler's aio, and the response
+// was allocated with nng_http_res_alloc_error.  If the response was not
+// allocated this way, or the application writes the response itself instead
+// of letting the server do so, then this setting will be ignored.
+NNG_DECL int nng_http_server_set_error_page(
+    nng_http_server *, uint16_t, const char *);
+
+// nng_http_server_set_error_file works like nng_http_server_error_page,
+// except that the content is loaded from the named file path.  The contents
+// are loaded at the time this function is called, so this function should be
+// called anytime the contents of the named file have changed.
+NNG_DECL int nng_http_server_set_error_file(
+    nng_http_server *, uint16_t, const char *);
+
+// nng_http_server_res_error takes replaces the body of the response with
+// a custom error page previously set for the server, using the status
+// of the response.  The response must have the status set first using
+// nng_http_res_set_status or implicitly via nng_http_res_alloc_error.
+NNG_DECL int nng_http_server_res_error(nng_http_server *, nng_http_res *);
+
 // nng_http_hijack is intended to be called by a handler that wishes to
 // take over the processing of the HTTP session -- usually to change protocols
 // (such as in the case of websocket).  The caller is responsible for the

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -30,6 +30,9 @@ typedef struct nng_http_client  nni_http_client;
 
 // These functions are private to the internal framework, and really should
 // not be used elsewhere.
+
+extern const char *nni_http_reason(uint16_t);
+
 extern int   nni_http_req_init(nni_http_req **);
 extern void  nni_http_req_reset(nni_http_req *);
 extern int   nni_http_req_get_buf(nni_http_req *, void **, size_t *);
@@ -111,6 +114,11 @@ extern int         nni_http_res_set_version(nni_http_res *, const char *);
 extern const char *nni_http_res_get_reason(nni_http_res *);
 extern int         nni_http_res_set_reason(nni_http_res *, const char *);
 
+// nni_http_res_is_error is true if the status was allocated as part of
+// nni_http_res_alloc_error().  This is a hint to the server to replace
+// the HTML body with customized content if it exists.
+extern bool nni_http_res_is_error(nni_http_res *);
+
 extern void nni_http_read(nni_http_conn *, nni_aio *);
 extern void nni_http_read_full(nni_http_conn *, nni_aio *);
 extern void nni_http_write(nni_http_conn *, nni_aio *);
@@ -169,6 +177,19 @@ extern int nni_http_server_start(nni_http_server *);
 // Connections that have been "upgraded" are unaffected.  Connections
 // associated with a callback will complete their callback, and then close.
 extern void nni_http_server_stop(nni_http_server *);
+
+// nni_http_server_set_error_page sets an error page for the named status.
+extern int nni_http_server_set_error_page(
+    nni_http_server *, uint16_t, const char *);
+
+// nni_http_server_set_error_page sets an error file for the named status.
+extern int nni_http_server_set_error_file(
+    nni_http_server *, uint16_t, const char *);
+
+// nni_http_server_res_error takes replaces the body of the res with
+// a custom error page previously set for the server, using the status
+// of the res.  The res must have the status set first.
+extern int nni_http_server_res_error(nni_http_server *, nni_http_res *);
 
 // nni_http_hijack is intended to be called by a handler that wishes to
 // take over the processing of the HTTP session -- usually to change protocols

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -676,6 +676,34 @@ nng_http_server_del_handler(nng_http_server *srv, nng_http_handler *h)
 }
 
 int
+nng_http_server_set_error_page(
+    nng_http_server *srv, uint16_t code, const char *body)
+{
+#ifdef NNG_SUPP_HTTP
+	return (nni_http_server_set_error_page(srv, code, body));
+#else
+	NNI_ARG_UNUSED(srv);
+	NNI_ARG_UNUSED(code);
+	NNI_ARG_UNUSED(body);
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
+nng_http_server_set_error_file(
+    nng_http_server *srv, uint16_t code, const char *path)
+{
+#ifdef NNG_SUPP_HTTP
+	return (nni_http_server_set_error_file(srv, code, path));
+#else
+	NNI_ARG_UNUSED(srv);
+	NNI_ARG_UNUSED(code);
+	NNI_ARG_UNUSED(path);
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
 nng_http_server_set_tls(nng_http_server *srv, struct nng_tls_config *cfg)
 {
 #if defined(NNG_SUPP_HTTP) && defined(NNG_SUPP_TLS)
@@ -695,6 +723,19 @@ nng_http_server_get_tls(nng_http_server *srv, struct nng_tls_config **cfgp)
 #else
 	NNI_ARG_UNUSED(srv);
 	NNI_ARG_UNUSED(cfgp);
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
+nng_http_server_res_error(nng_http_server *srv, nng_http_res *res)
+{
+#ifdef NNG_SUPP_HTTP
+	return (nni_http_server_res_error(srv, res));
+#else
+	NNI_ARG_UNUSED(srv);
+	NNI_ARG_UNUSED(res);
+	NNI_ARG_UNUSED(code);
 	return (NNG_ENOTSUP);
 #endif
 }


### PR DESCRIPTION
This adds some new API calls to allow applications to add custom static content for defined error codes.
