### PR TITLE
nni_url_parse does not handle ipc and inproc specially

### DIFF
--- a/src/core/url.c
+++ b/src/core/url.c
@@ -307,6 +307,7 @@ nni_url_parse(nni_url **urlp, const char *raw)
 			goto error;
 		}
 		*urlp = url;
+		return (0);
 	}
 
 	// Look for host part (including colon).  Will be terminated by


### PR DESCRIPTION
A missing return in nni_url_parse causes the special handling of ipc and inproc to be overwritten and the URL to be parsed completely. 

This results in the memory allocated by the strdup to leak.

It also means ipc and inproc URLs are canonicalized, not a bad thing per se, but this contradicts the documentation and breaks compatibility with nanomsg legacy code.