### PR TITLE
fixes #564 Race regression caused by#522

### DIFF
--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -64,8 +64,6 @@ extern nni_msgq *nni_sock_sendq(nni_sock *);
 // inject incoming messages from pipes to it.
 extern nni_msgq *nni_sock_recvq(nni_sock *);
 
-extern void nni_sock_reconntimes(nni_sock *, nni_duration *, nni_duration *);
-
 // nni_sock_flags returns the socket flags, used to indicate whether read
 // and or write are appropriate for the protocol.
 extern uint32_t nni_sock_flags(nni_sock *);

--- a/tests/sock.c
+++ b/tests/sock.c
@@ -387,7 +387,7 @@ TestMain("Socket Operations", {
 				// Not appropriate for dialer.
 				So(nng_dialer_setopt_bool(
 				       ep, NNG_OPT_RAW, true) == NNG_ENOTSUP);
-				So(nng_dialer_setopt_ms(ep, NNG_OPT_RECONNMINT,
+				So(nng_dialer_setopt_ms(ep, NNG_OPT_SENDTIMEO,
 				       1) == NNG_ENOTSUP);
 				So(nng_dialer_setopt_string(ep,
 				       NNG_OPT_SOCKNAME,


### PR DESCRIPTION
fixes #565 Option getting should validate sizes more aggressively
fixes #563 Reconnect timeouts should be settable on dialers
fixes #562 pipe test is fragile

This fixes a number of things, but the regression is most important.

Note that long term we should look at some kind of different single lock for adding pipes or endpoints to sockets, under a single global lock for the socket.