### PR TITLE
TCP separation & enhancements.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,9 @@ if (NNG_PLATFORM_WINDOWS)
         platform/windows/win_resolv.c
         platform/windows/win_sockaddr.c
         platform/windows/win_tcp.c
+        platform/windows/win_tcpconn.c
+        platform/windows/win_tcpdial.c
+        platform/windows/win_tcplisten.c
         platform/windows/win_thread.c
         platform/windows/win_udp.c
         )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,9 @@ if (NNG_PLATFORM_POSIX)
         platform/posix/posix_resolv_gai.c
         platform/posix/posix_sockaddr.c
         platform/posix/posix_tcp.c
+        platform/posix/posix_tcpconn.c
+        platform/posix/posix_tcpdial.c
+        platform/posix/posix_tcplisten.c
         platform/posix/posix_thread.c
         platform/posix/posix_udp.c
     )

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -197,6 +197,30 @@ extern int nni_plat_ncpu(void);
 //
 // TCP Support.
 //
+typedef struct nni_tcp_conn     nni_tcp_conn;
+typedef struct nni_tcp_dialer   nni_tcp_dialer;
+typedef struct nni_tcp_listener nni_tcp_listener;
+
+extern void nni_tcp_conn_fini(nni_tcp_conn *);
+extern void nni_tcp_conn_close(nni_tcp_conn *);
+extern void nni_tcp_conn_send(nni_tcp_conn *, nni_aio *);
+extern void nni_tcp_conn_recv(nni_tcp_conn *, nni_aio *);
+extern int  nni_tcp_conn_peername(nni_tcp_conn *, nni_sockaddr *);
+extern int  nni_tcp_conn_sockname(nni_tcp_conn *, nni_sockaddr *);
+extern int  nni_tcp_conn_set_nodelay(nni_tcp_conn *, bool);
+extern int  nni_tcp_conn_set_keepalive(nni_tcp_conn *, bool);
+
+extern int  nni_tcp_dialer_init(nni_tcp_dialer **);
+extern void nni_tcp_dialer_fini(nni_tcp_dialer *);
+extern void nni_tcp_dialer_close(nni_tcp_dialer *);
+extern void nni_tcp_dialer_dial(
+    nni_tcp_dialer *, const nni_sockaddr *, nni_aio *);
+
+extern int  nni_tcp_listener_init(nni_tcp_listener **);
+extern void nni_tcp_listener_fini(nni_tcp_listener *);
+extern void nni_tcp_listener_close(nni_tcp_listener *);
+extern int  nni_tcp_listener_listen(nni_tcp_listener *, nni_sockaddr *);
+extern void nni_tcp_listener_accept(nni_tcp_listener *, nni_aio *);
 
 typedef struct nni_plat_tcp_ep   nni_plat_tcp_ep;
 typedef struct nni_plat_tcp_pipe nni_plat_tcp_pipe;

--- a/src/platform/posix/posix_aio.h
+++ b/src/platform/posix/posix_aio.h
@@ -20,8 +20,8 @@
 #include "core/nng_impl.h"
 #include "posix_pollq.h"
 
+#include <sys/stat.h>  // needed for musl build
 #include <sys/types.h> // needed for mode_t
-#include <sys/stat.h> // needed for musl build
 
 typedef struct nni_posix_pipedesc nni_posix_pipedesc;
 typedef struct nni_posix_epdesc   nni_posix_epdesc;
@@ -48,5 +48,7 @@ extern int  nni_posix_epdesc_listen(nni_posix_epdesc *);
 extern void nni_posix_epdesc_accept(nni_posix_epdesc *, nni_aio *);
 extern int  nni_posix_epdesc_sockname(nni_posix_epdesc *, nni_sockaddr *);
 extern int  nni_posix_epdesc_set_permissions(nni_posix_epdesc *, mode_t);
+
+extern int nni_posix_tcp_conn_init(nni_tcp_conn **, nni_posix_pfd *);
 
 #endif // PLATFORM_POSIX_AIO_H

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -1,0 +1,430 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_POSIX
+#include "platform/posix/posix_aio.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+#ifdef NNG_HAVE_ALLOCA
+#include <alloca.h>
+#endif
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+typedef struct nni_tcp_conn nni_tcp_conn;
+struct nni_tcp_conn {
+	nni_posix_pfd *pfd;
+	nni_list       readq;
+	nni_list       writeq;
+	bool           closed;
+	nni_mtx        mtx;
+};
+
+static void
+tcp_conn_doclose(nni_tcp_conn *c)
+{
+	nni_aio *aio;
+
+	c->closed = true;
+	while (((aio = nni_list_first(&c->readq)) != NULL) ||
+	    ((aio = nni_list_first(&c->writeq)) != NULL)) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+	}
+	nni_posix_pfd_close(c->pfd);
+}
+
+static void
+tcp_conn_dowrite(nni_tcp_conn *c)
+{
+	nni_aio *aio;
+	int      fd;
+
+	if (c->closed || ((fd = nni_posix_pfd_fd(c->pfd)) < 0)) {
+		return;
+	}
+
+	while ((aio = nni_list_first(&c->writeq)) != NULL) {
+		unsigned      i;
+		int           n;
+		int           niov;
+		unsigned      naiov;
+		nni_iov *     aiov;
+		struct msghdr hdr;
+#ifdef NNG_HAVE_ALLOCA
+		struct iovec *iovec;
+#else
+		struct iovec iovec[16];
+#endif
+
+		memset(&hdr, 0, sizeof(hdr));
+		nni_aio_get_iov(aio, &naiov, &aiov);
+
+#ifdef NNG_HAVE_ALLOCA
+		if (naiov > 64) {
+			nni_aio_list_remove(aio);
+			nni_aio_finish_error(aio, NNG_EINVAL);
+			continue;
+		}
+		iovec = alloca(naiov * sizeof(*iovec));
+#else
+		if (naiov > NNI_NUM_ELEMENTS(iovec)) {
+			nni_aio_list_remove(aio);
+			nni_aio_finish_error(aio, NNG_EINVAL);
+			continue;
+		}
+#endif
+
+		for (niov = 0, i = 0; i < naiov; i++) {
+			if (aiov[i].iov_len > 0) {
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				iovec[niov].iov_base = aiov[i].iov_buf;
+				niov++;
+			}
+		}
+
+		hdr.msg_iovlen = niov;
+		hdr.msg_iov    = iovec;
+
+		if ((n = sendmsg(fd, &hdr, MSG_NOSIGNAL)) < 0) {
+			switch (errno) {
+			case EINTR:
+				continue;
+			case EAGAIN:
+#ifdef EWOULDBLOCK
+#if EWOULDBLOCK != EAGAIN
+			case EWOULDBLOCK:
+#endif
+#endif
+				return;
+			default:
+				nni_aio_list_remove(aio);
+				nni_aio_finish_error(
+				    aio, nni_plat_errno(errno));
+				tcp_conn_doclose(c);
+				return;
+			}
+		}
+
+		nni_aio_bump_count(aio, n);
+		// We completed the entire operation on this aio.
+		// (Sendmsg never returns a partial result.)
+		nni_aio_list_remove(aio);
+		nni_aio_finish(aio, 0, nni_aio_count(aio));
+
+		// Go back to start of loop to see if there is another
+		// aio ready for us to process.
+	}
+}
+
+static void
+tcp_conn_doread(nni_tcp_conn *c)
+{
+	nni_aio *aio;
+	int      fd;
+
+	if (c->closed || ((fd = nni_posix_pfd_fd(c->pfd)) < 0)) {
+		return;
+	}
+
+	while ((aio = nni_list_first(&c->readq)) != NULL) {
+		unsigned i;
+		int      n;
+		int      niov;
+		unsigned naiov;
+		nni_iov *aiov;
+#ifdef NNG_HAVE_ALLOCA
+		struct iovec *iovec;
+#else
+		struct iovec iovec[16];
+#endif
+
+		nni_aio_get_iov(aio, &naiov, &aiov);
+#ifdef NNG_HAVE_ALLOCA
+		if (naiov > 64) {
+			nni_aio_list_remove(aio);
+			nni_aio_finish_error(aio, NNG_EINVAL);
+			continue;
+		}
+		iovec = alloca(naiov * sizeof(*iovec));
+#else
+		if (naiov > NNI_NUM_ELEMENTS(iovec)) {
+			nni_aio_list_remove(aio);
+			nni_aio_finish_error(aio, NNG_EINVAL);
+			continue;
+		}
+#endif
+		for (niov = 0, i = 0; i < naiov; i++) {
+			if (aiov[i].iov_len != 0) {
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				iovec[niov].iov_base = aiov[i].iov_buf;
+				niov++;
+			}
+		}
+
+		if ((n = readv(fd, iovec, niov)) < 0) {
+			switch (errno) {
+			case EINTR:
+				continue;
+			case EAGAIN:
+				return;
+			default:
+				nni_aio_list_remove(aio);
+				nni_aio_finish_error(
+				    aio, nni_plat_errno(errno));
+				return;
+			}
+		}
+
+		if (n == 0) {
+			// No bytes indicates a closed descriptor.
+			// This implicitly completes this (all!) aio.
+			tcp_conn_doclose(c);
+			return;
+		}
+
+		nni_aio_bump_count(aio, n);
+
+		// We completed the entire operation on this aio.
+		nni_aio_list_remove(aio);
+		nni_aio_finish(aio, 0, nni_aio_count(aio));
+
+		// Go back to start of loop to see if there is another
+		// aio ready for us to process.
+	}
+}
+
+void
+nni_tcp_conn_close(nni_tcp_conn *c)
+{
+	nni_mtx_lock(&c->mtx);
+	tcp_conn_doclose(c);
+	nni_mtx_unlock(&c->mtx);
+}
+
+static void
+tcp_conn_cb(nni_posix_pfd *pfd, int events, void *arg)
+{
+	nni_tcp_conn *c = arg;
+
+	nni_mtx_lock(&c->mtx);
+	if (events & POLLIN) {
+		tcp_conn_doread(c);
+	}
+	if (events & POLLOUT) {
+		tcp_conn_dowrite(c);
+	}
+	if (events & (POLLHUP | POLLERR | POLLNVAL)) {
+		tcp_conn_doclose(c);
+	} else {
+		events = 0;
+		if (!nni_list_empty(&c->writeq)) {
+			events |= POLLOUT;
+		}
+		if (!nni_list_empty(&c->readq)) {
+			events |= POLLIN;
+		}
+		if ((!c->closed) && (events != 0)) {
+			nni_posix_pfd_arm(pfd, events);
+		}
+	}
+	nni_mtx_unlock(&c->mtx);
+}
+
+static void
+tcp_conn_cancel(nni_aio *aio, int rv)
+{
+	nni_tcp_conn *c = nni_aio_get_prov_data(aio);
+
+	nni_mtx_lock(&c->mtx);
+	if (nni_aio_list_active(aio)) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, rv);
+	}
+	nni_mtx_unlock(&c->mtx);
+}
+
+void
+nni_tcp_conn_send(nni_tcp_conn *c, nni_aio *aio)
+{
+
+	int rv;
+
+	if (nni_aio_begin(aio) != 0) {
+		return;
+	}
+	nni_mtx_lock(&c->mtx);
+
+	if (c->closed) {
+		nni_mtx_unlock(&c->mtx);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+		return;
+	}
+
+	if ((rv = nni_aio_schedule(aio, tcp_conn_cancel, c)) != 0) {
+		nni_mtx_unlock(&c->mtx);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+	nni_aio_list_append(&c->writeq, aio);
+
+	if (nni_list_first(&c->writeq) == aio) {
+		tcp_conn_dowrite(c);
+		// If we are still the first thing on the list, that
+		// means we didn't finish the job, so arm the poller to
+		// complete us.
+		if (nni_list_first(&c->writeq) == aio) {
+			nni_posix_pfd_arm(c->pfd, POLLOUT);
+		}
+	}
+	nni_mtx_unlock(&c->mtx);
+}
+
+void
+nni_tcp_conn_recv(nni_tcp_conn *c, nni_aio *aio)
+{
+	int rv;
+
+	if (nni_aio_begin(aio) != 0) {
+		return;
+	}
+	nni_mtx_lock(&c->mtx);
+
+	if (c->closed) {
+		nni_mtx_unlock(&c->mtx);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+		return;
+	}
+
+	if ((rv = nni_aio_schedule(aio, tcp_conn_cancel, c)) != 0) {
+		nni_mtx_unlock(&c->mtx);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+	nni_aio_list_append(&c->readq, aio);
+
+	// If we are only job on the list, go ahead and try to do an
+	// immediate transfer. This allows for faster completions in
+	// many cases.  We also need not arm a list if it was already
+	// armed.
+	if (nni_list_first(&c->readq) == aio) {
+		tcp_conn_doread(c);
+		// If we are still the first thing on the list, that
+		// means we didn't finish the job, so arm the poller to
+		// complete us.
+		if (nni_list_first(&c->readq) == aio) {
+			nni_posix_pfd_arm(c->pfd, POLLIN);
+		}
+	}
+	nni_mtx_unlock(&c->mtx);
+}
+
+int
+nni_tcp_conn_peername(nni_tcp_conn *c, nni_sockaddr *sa)
+{
+	struct sockaddr_storage ss;
+	socklen_t               sslen = sizeof(ss);
+	int                     fd    = nni_posix_pfd_fd(c->pfd);
+
+	if (getpeername(fd, (void *) &ss, &sslen) != 0) {
+		return (nni_plat_errno(errno));
+	}
+	return (nni_posix_sockaddr2nn(sa, &ss));
+}
+
+int
+nni_tcp_conn_sockname(nni_tcp_conn *c, nni_sockaddr *sa)
+{
+	struct sockaddr_storage ss;
+	socklen_t               sslen = sizeof(ss);
+	int                     fd    = nni_posix_pfd_fd(c->pfd);
+
+	if (getsockname(fd, (void *) &ss, &sslen) != 0) {
+		return (nni_plat_errno(errno));
+	}
+	return (nni_posix_sockaddr2nn(sa, &ss));
+}
+
+int
+nni_tcp_conn_set_keepalive(nni_tcp_conn *c, bool keep)
+{
+	int val = keep ? 1 : 0;
+	int fd  = nni_posix_pfd_fd(c->pfd);
+
+	if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof(val)) != 0) {
+		return (nni_plat_errno(errno));
+	}
+	return (0);
+}
+
+int
+nni_tcp_conn_set_nodelay(nni_tcp_conn *c, bool nodelay)
+{
+
+	int val = nodelay ? 1 : 0;
+	int fd  = nni_posix_pfd_fd(c->pfd);
+
+	if (setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val)) != 0) {
+		return (nni_plat_errno(errno));
+	}
+	return (0);
+}
+
+int
+nni_posix_tcp_conn_init(nni_tcp_conn **cp, nni_posix_pfd *pfd)
+{
+	nni_tcp_conn *c;
+
+	if ((c = NNI_ALLOC_STRUCT(c)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+
+	c->closed = false;
+	c->pfd    = pfd;
+
+	nni_mtx_init(&c->mtx);
+	nni_aio_list_init(&c->readq);
+	nni_aio_list_init(&c->writeq);
+
+	nni_posix_pfd_set_cb(pfd, tcp_conn_cb, c);
+
+	*cp = c;
+	return (0);
+}
+
+void
+nni_tcp_conn_fini(nni_tcp_conn *c)
+{
+	nni_tcp_conn_close(c);
+	nni_posix_pfd_fini(c->pfd);
+	c->pfd = NULL;
+	nni_mtx_fini(&c->mtx);
+
+	NNI_FREE_STRUCT(c);
+}
+
+#endif // NNG_PLATFORM_POSIX

--- a/src/platform/posix/posix_tcpdial.c
+++ b/src/platform/posix/posix_tcpdial.c
@@ -1,0 +1,231 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_POSIX
+#include "platform/posix/posix_aio.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
+#endif
+
+typedef struct nni_tcp_dialer nni_tcp_dialer;
+
+struct nni_tcp_dialer {
+	nni_list connq; // pending connections
+	bool     closed;
+	nni_mtx  mtx;
+};
+
+// Dialer stuff.
+int
+nni_tcp_dialer_init(nni_tcp_dialer **dp)
+{
+	nni_tcp_dialer *d;
+
+	if ((d = NNI_ALLOC_STRUCT(d)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	nni_mtx_init(&d->mtx);
+	d->closed = false;
+	nni_aio_list_init(&d->connq);
+	*dp = d;
+	return (0);
+}
+
+void
+nni_tcp_dialer_close(nni_tcp_dialer *d)
+{
+	nni_aio *aio;
+	nni_mtx_lock(&d->mtx);
+	if (d->closed) {
+		nni_mtx_unlock(&d->mtx);
+		return;
+	}
+	d->closed = true;
+	while ((aio = nni_list_first(&d->connq)) != NULL) {
+		nni_posix_pfd *pfd;
+		nni_list_remove(&d->connq, aio);
+		nni_mtx_unlock(&d->mtx);
+		pfd = nni_aio_get_prov_extra(aio, 0);
+		nni_posix_pfd_fini(pfd);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+		nni_mtx_lock(&d->mtx);
+	}
+	nni_mtx_unlock(&d->mtx);
+}
+
+void
+nni_tcp_dialer_fini(nni_tcp_dialer *d)
+{
+	nni_tcp_dialer_close(d);
+	nni_mtx_fini(&d->mtx);
+	NNI_FREE_STRUCT(d);
+}
+
+static void
+tcp_dialer_cancel(nni_aio *aio, int rv)
+{
+	nni_tcp_dialer *d = nni_aio_get_prov_data(aio);
+	nni_posix_pfd * pfd;
+
+	nni_mtx_lock(&d->mtx);
+	if (!nni_aio_list_active(aio)) {
+		nni_mtx_unlock(&d->mtx);
+		return;
+	}
+	nni_aio_list_remove(aio);
+	pfd = nni_aio_get_prov_extra(aio, 0);
+	nni_mtx_unlock(&d->mtx);
+
+	// If the callback is already running, or queued, this could be
+	// blocked on that.
+	nni_posix_pfd_fini(pfd);
+	nni_aio_finish_error(aio, rv);
+}
+
+static void
+tcp_dialer_cb(nni_posix_pfd *pfd, int ev, void *arg)
+{
+	nni_aio *       aio = arg;
+	nni_tcp_dialer *d   = nni_aio_get_prov_data(aio);
+	nni_tcp_conn *  c;
+	int             fd;
+	int             rv;
+
+	nni_mtx_lock(&d->mtx);
+	if (!nni_aio_list_active(aio)) {
+		// already canceled, so this is a callback running concurrent
+		// to the pfd_fini.  Just ignore it.
+		nni_mtx_unlock(&d->mtx);
+		return;
+	}
+
+	if (ev & POLLNVAL) {
+		rv = EBADF;
+
+	} else {
+		socklen_t sz = sizeof(int);
+		fd           = nni_posix_pfd_fd(pfd);
+		if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &rv, &sz) < 0) {
+			rv = errno;
+		}
+		if (rv == EINPROGRESS) {
+			// Connection still in progress, come back
+			// later.
+			nni_mtx_unlock(&d->mtx);
+			return;
+		} else if (rv != 0) {
+			rv = nni_plat_errno(rv);
+		}
+	}
+
+	nni_aio_list_remove(aio);
+	nni_mtx_unlock(&d->mtx);
+
+	if ((rv != 0) || ((rv = nni_posix_tcp_conn_init(&c, pfd)) != 0)) {
+		nni_posix_pfd_fini(pfd);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+
+	nni_aio_set_output(aio, 0, c);
+	nni_aio_finish(aio, 0, 0);
+}
+
+// We don't give local address binding support.  Outbound dialers always
+// get an ephemeral port.
+void
+nni_tcp_dialer_dial(nni_tcp_dialer *d, const nni_sockaddr *sa, nni_aio *aio)
+{
+	nni_tcp_conn *          c;
+	nni_posix_pfd *         pfd = NULL;
+	struct sockaddr_storage ss;
+	size_t                  sslen;
+	int                     fd;
+	int                     rv;
+
+	if (nni_aio_begin(aio) != 0) {
+		return;
+	}
+
+	if (((sslen = nni_posix_nn2sockaddr(&ss, sa)) == 0) ||
+	    ((ss.ss_family != AF_INET) && (ss.ss_family != AF_INET6))) {
+		nni_aio_finish_error(aio, NNG_EADDRINVAL);
+		return;
+	}
+
+	if ((fd = socket(ss.ss_family, SOCK_STREAM | SOCK_CLOEXEC, 0)) < 0) {
+		nni_aio_finish_error(aio, nni_plat_errno(errno));
+		return;
+	}
+
+	// This arranges for the fd to be in nonblocking mode, and adds the
+	// pollfd to the list.
+	if ((rv = nni_posix_pfd_init(&pfd, fd)) != 0) {
+		(void) close(fd);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+
+	nni_aio_set_prov_extra(aio, 0, pfd);
+	nni_posix_pfd_set_cb(pfd, tcp_dialer_cb, aio);
+
+	nni_mtx_lock(&d->mtx);
+	if (d->closed) {
+		rv = NNG_ECLOSED;
+		goto error;
+	}
+	if ((rv = nni_aio_schedule(aio, tcp_dialer_cancel, d)) != 0) {
+		goto error;
+	}
+	if ((rv = connect(fd, (void *) &ss, sslen)) != 0) {
+		if (errno != EINPROGRESS) {
+			rv = nni_plat_errno(errno);
+			goto error;
+		}
+		// Asynchronous connect.
+		if ((rv = nni_posix_pfd_arm(pfd, POLLOUT)) != 0) {
+			goto error;
+		}
+		nni_list_append(&d->connq, aio);
+		nni_mtx_unlock(&d->mtx);
+		return;
+	}
+	// Immediate connect, cool!  This probably only happens
+	// on loopback, and probably not on every platform.
+	if ((rv = nni_posix_tcp_conn_init(&c, pfd)) != 0) {
+		goto error;
+	}
+	nni_mtx_unlock(&d->mtx);
+	nni_aio_set_output(aio, 0, c);
+	nni_aio_finish(aio, 0, 0);
+	return;
+
+error:
+	nni_mtx_unlock(&d->mtx);
+	nni_posix_pfd_fini(pfd);
+	nni_aio_finish_error(aio, rv);
+}
+
+#endif // NNG_PLATFORM_POSIX

--- a/src/platform/posix/posix_tcplisten.c
+++ b/src/platform/posix/posix_tcplisten.c
@@ -1,0 +1,322 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_POSIX
+#include "platform/posix/posix_aio.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#ifndef SOCK_CLOEXEC
+#define SOCK_CLOEXEC 0
+#endif
+
+struct nni_tcp_listener {
+	nni_posix_pfd *pfd;
+	nni_list       acceptq;
+	bool           started;
+	bool           closed;
+	nni_mtx        mtx;
+};
+
+int
+nni_tcp_listener_init(nni_tcp_listener **lp)
+{
+	nni_tcp_listener *l;
+	if ((l = NNI_ALLOC_STRUCT(l)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+
+	nni_mtx_init(&l->mtx);
+
+	l->pfd     = NULL;
+	l->closed  = false;
+	l->started = false;
+
+	nni_aio_list_init(&l->acceptq);
+	*lp = l;
+	return (0);
+}
+
+static void
+tcp_listener_doclose(nni_tcp_listener *l)
+{
+	nni_aio *aio;
+
+	l->closed = true;
+	while ((aio = nni_list_first(&l->acceptq)) != NULL) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+	}
+
+	if (l->pfd != NULL) {
+		nni_posix_pfd_close(l->pfd);
+	}
+}
+
+void
+nni_tcp_listener_close(nni_tcp_listener *l)
+{
+	nni_mtx_lock(&l->mtx);
+	tcp_listener_doclose(l);
+	nni_mtx_unlock(&l->mtx);
+}
+
+static void
+tcp_listener_doaccept(nni_tcp_listener *l)
+{
+	nni_aio *aio;
+
+	while ((aio = nni_list_first(&l->acceptq)) != NULL) {
+		int            newfd;
+		int            fd;
+		int            rv;
+		nni_posix_pfd *pfd;
+		nni_tcp_conn * c;
+
+		fd = nni_posix_pfd_fd(l->pfd);
+
+#ifdef NNG_USE_ACCEPT4
+		newfd = accept4(fd, NULL, NULL, SOCK_CLOEXEC);
+		if ((newfd < 0) && ((errno == ENOSYS) || (errno == ENOTSUP))) {
+			newfd = accept(fd, NULL, NULL);
+		}
+#else
+		newfd = accept(fd, NULL, NULL);
+#endif
+		if (newfd < 0) {
+			switch (errno) {
+			case EAGAIN:
+#ifdef EWOULDBLOCK
+#if EWOULDBLOCK != EAGAIN
+			case EWOULDBLOCK:
+#endif
+#endif
+				rv = nni_posix_pfd_arm(l->pfd, POLLIN);
+				if (rv != 0) {
+					nni_aio_list_remove(aio);
+					nni_aio_finish_error(aio, rv);
+					continue;
+				}
+				// Come back later...
+				return;
+			case ECONNABORTED:
+			case ECONNRESET:
+				// Eat them, they aren't interesting.
+				continue;
+			default:
+				// Error this one, but keep moving to the next.
+				rv = nni_plat_errno(errno);
+				nni_aio_list_remove(aio);
+				nni_aio_finish_error(aio, rv);
+				continue;
+			}
+		}
+
+		if ((rv = nni_posix_pfd_init(&pfd, newfd)) != 0) {
+			close(newfd);
+			nni_aio_list_remove(aio);
+			nni_aio_finish_error(aio, rv);
+			continue;
+		}
+
+		if ((rv = nni_posix_tcp_conn_init(&c, pfd)) != 0) {
+			nni_posix_pfd_fini(pfd);
+			nni_aio_list_remove(aio);
+			nni_aio_finish_error(aio, rv);
+			continue;
+		}
+
+		nni_aio_set_output(aio, 0, c);
+		nni_aio_finish(aio, 0, 0);
+	}
+}
+
+static void
+tcp_listener_cb(nni_posix_pfd *pfd, int events, void *arg)
+{
+	nni_tcp_listener *l = arg;
+
+	nni_mtx_lock(&l->mtx);
+	if (events & POLLNVAL) {
+		tcp_listener_doclose(l);
+		nni_mtx_unlock(&l->mtx);
+		return;
+	}
+	NNI_ASSERT(pfd == l->pfd);
+
+	// Anything else will turn up in accept.
+	tcp_listener_doaccept(l);
+	nni_mtx_unlock(&l->mtx);
+}
+
+static void
+tcp_listener_cancel(nni_aio *aio, int rv)
+{
+	nni_tcp_listener *l = nni_aio_get_prov_data(aio);
+
+	// This is dead easy, because we'll ignore the completion if there
+	// isn't anything to do the accept on!
+	NNI_ASSERT(rv != 0);
+	nni_mtx_lock(&l->mtx);
+	if (nni_aio_list_active(aio)) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, rv);
+	}
+	nni_mtx_unlock(&l->mtx);
+}
+
+int
+nni_tcp_listener_listen(nni_tcp_listener *l, nni_sockaddr *sa)
+{
+	socklen_t               len;
+	struct sockaddr_storage ss;
+	int                     rv;
+	int                     fd;
+	nni_posix_pfd *         pfd;
+
+	if (((len = nni_posix_nn2sockaddr(&ss, sa)) == 0) ||
+	    ((ss.ss_family != AF_INET) && (ss.ss_family != AF_INET6))) {
+		return (NNG_EADDRINVAL);
+	}
+
+	nni_mtx_lock(&l->mtx);
+	if (l->started) {
+		nni_mtx_unlock(&l->mtx);
+		return (NNG_ESTATE);
+	}
+	if (l->closed) {
+		nni_mtx_unlock(&l->mtx);
+		return (NNG_ECLOSED);
+	}
+
+	if ((fd = socket(ss.ss_family, SOCK_STREAM | SOCK_CLOEXEC, 0)) < 0) {
+		nni_mtx_unlock(&l->mtx);
+		return (nni_plat_errno(errno));
+	}
+
+	if ((rv = nni_posix_pfd_init(&pfd, fd)) != 0) {
+		nni_mtx_unlock(&l->mtx);
+		nni_posix_pfd_fini(pfd);
+		return (rv);
+	}
+
+// On the Windows Subsystem for Linux, SO_REUSEADDR behaves like Windows
+// SO_REUSEADDR, which is almost completely different (and wrong!) from
+// traditional SO_REUSEADDR.
+#if defined(SO_REUSEADDR) && !defined(NNG_PLATFORM_WSL)
+	{
+		int on = 1;
+		// If for some reason this doesn't work, it's probably ok.
+		// Second bind will fail.
+		(void) setsockopt(
+		    fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+	}
+#endif
+
+	if (bind(fd, (struct sockaddr *) &ss, len) < 0) {
+		rv = nni_plat_errno(errno);
+		nni_mtx_unlock(&l->mtx);
+		nni_posix_pfd_fini(pfd);
+		return (rv);
+	}
+
+	// Listen -- 128 depth is probably sufficient.  If it isn't, other
+	// bad things are going to happen.
+	if (listen(fd, 128) != 0) {
+		rv = nni_plat_errno(errno);
+		nni_mtx_unlock(&l->mtx);
+		nni_posix_pfd_fini(pfd);
+		return (rv);
+	}
+
+	// Lets get the bound sockname, and pass that back to the caller.
+	// This permits ephemeral port binding to work.
+	// If this fails for some reason, we just don't update the
+	// sockaddr structure.  This is kind of suboptimal, but failures
+	// here should never occur.
+	len = sizeof(ss);
+	(void) getsockname(fd, (void *) &ss, &len);
+	(void) nni_posix_sockaddr2nn(sa, &ss);
+
+	nni_posix_pfd_set_cb(pfd, tcp_listener_cb, l);
+
+	l->pfd     = pfd;
+	l->started = true;
+	nni_mtx_unlock(&l->mtx);
+
+	return (0);
+}
+
+void
+nni_tcp_listener_fini(nni_tcp_listener *l)
+{
+	nni_posix_pfd *pfd;
+
+	nni_mtx_lock(&l->mtx);
+	tcp_listener_doclose(l);
+	pfd = l->pfd;
+	nni_mtx_unlock(&l->mtx);
+
+	if (pfd != NULL) {
+		nni_posix_pfd_fini(pfd);
+	}
+	nni_mtx_fini(&l->mtx);
+	NNI_FREE_STRUCT(l);
+}
+
+void
+nni_tcp_listener_accept(nni_tcp_listener *l, nni_aio *aio)
+{
+	int rv;
+
+	// Accept is simpler than the connect case.  With accept we just
+	// need to wait for the socket to be readable to indicate an incoming
+	// connection is ready for us.  There isn't anything else for us to
+	// do really, as that will have been done in listen.
+	if (nni_aio_begin(aio) != 0) {
+		return;
+	}
+	nni_mtx_lock(&l->mtx);
+
+	if (!l->started) {
+		nni_mtx_unlock(&l->mtx);
+		nni_aio_finish_error(aio, NNG_ESTATE);
+		return;
+	}
+	if (l->closed) {
+		nni_mtx_unlock(&l->mtx);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+		return;
+	}
+	if ((rv = nni_aio_schedule(aio, tcp_listener_cancel, l)) != 0) {
+		nni_mtx_unlock(&l->mtx);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+	nni_aio_list_append(&l->acceptq, aio);
+	if (nni_list_first(&l->acceptq) == aio) {
+		tcp_listener_doaccept(l);
+	}
+	nni_mtx_unlock(&l->mtx);
+}
+
+#endif // NNG_PLATFORM_POSIX

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -90,6 +90,10 @@ extern void nni_win_event_complete(nni_win_event *, int);
 
 extern int nni_win_iocp_register(HANDLE);
 
+extern int  nni_win_tcp_conn_init(nni_tcp_conn **, SOCKET);
+extern void nni_win_tcp_conn_set_addrs(
+    nni_tcp_conn *, const SOCKADDR_STORAGE *, const SOCKADDR_STORAGE *);
+
 extern int  nni_win_iocp_sysinit(void);
 extern void nni_win_iocp_sysfini(void);
 

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -85,7 +85,6 @@ extern int nni_win_error(int);
 extern int  nni_win_event_init(nni_win_event *, nni_win_event_ops *, void *);
 extern void nni_win_event_fini(nni_win_event *);
 extern void nni_win_event_submit(nni_win_event *, nni_aio *);
-extern void nni_win_event_resubmit(nni_win_event *, nni_aio *);
 extern void nni_win_event_close(nni_win_event *);
 extern void nni_win_event_complete(nni_win_event *, int);
 

--- a/src/platform/windows/win_iocp.c
+++ b/src/platform/windows/win_iocp.c
@@ -146,11 +146,6 @@ nni_win_event_start(nni_win_event *evt)
 		nni_win_event_finish(evt);
 	}
 }
-void
-nni_win_event_resubmit(nni_win_event *evt, nni_aio *aio)
-{
-	nni_aio_list_prepend(&evt->aios, aio);
-}
 
 void
 nni_win_event_submit(nni_win_event *evt, nni_aio *aio)

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -1,0 +1,231 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_WINDOWS
+
+#include <malloc.h>
+#include <stdio.h>
+
+struct nni_tcp_conn {
+	SOCKET           s;
+	nni_win_event    rcv_ev;
+	nni_win_event    snd_ev;
+	SOCKADDR_STORAGE sockname;
+	SOCKADDR_STORAGE peername;
+};
+
+static int  tcp_conn_start(nni_win_event *, nni_aio *);
+static void tcp_conn_finish(nni_win_event *, nni_aio *);
+static void tcp_conn_cancel(nni_win_event *);
+
+static nni_win_event_ops tcp_conn_ops = {
+	.wev_start  = tcp_conn_start,
+	.wev_finish = tcp_conn_finish,
+	.wev_cancel = tcp_conn_cancel,
+};
+
+static int
+tcp_conn_start(nni_win_event *evt, nni_aio *aio)
+{
+	int           rv;
+	SOCKET        s;
+	DWORD         niov;
+	DWORD         flags;
+	nni_tcp_conn *c = evt->ptr;
+	unsigned      i;
+	unsigned      naiov;
+	nni_iov *     aiov;
+	WSABUF *      iov;
+
+	nni_aio_get_iov(aio, &naiov, &aiov);
+	iov = _malloca(naiov * sizeof(*iov));
+
+	// Put the AIOs in Windows form.
+	for (niov = 0, i = 0; i < naiov; i++) {
+		if (aiov[i].iov_len != 0) {
+			iov[niov].buf = aiov[i].iov_buf;
+			iov[niov].len = (ULONG) aiov[i].iov_len;
+			niov++;
+		}
+	}
+
+	if ((s = c->s) == INVALID_SOCKET) {
+		_freea(iov);
+		evt->status = NNG_ECLOSED;
+		evt->count  = 0;
+		return (1);
+	}
+
+	// Note that the IOVs for the event were prepared on entry already.
+	// The actual aio's iov array we don't touch.
+
+	evt->count = 0;
+	flags      = 0;
+	if (evt == &c->snd_ev) {
+		rv = WSASend(s, iov, niov, NULL, flags, &evt->olpd, NULL);
+	} else {
+		rv = WSARecv(s, iov, niov, NULL, &flags, &evt->olpd, NULL);
+	}
+	_freea(iov);
+
+	if ((rv == SOCKET_ERROR) &&
+	    ((rv = GetLastError()) != ERROR_IO_PENDING)) {
+		// Synchronous failure.
+		evt->status = nni_win_error(rv);
+		evt->count  = 0;
+		return (1);
+	}
+
+	// Wait for the I/O completion event.  Note that when an I/O
+	// completes immediately, the I/O completion packet is still
+	// delivered.
+	return (0);
+}
+
+static void
+tcp_conn_cancel(nni_win_event *evt)
+{
+	nni_tcp_conn *c = evt->ptr;
+
+	(void) CancelIoEx((HANDLE) c->s, &evt->olpd);
+}
+
+static void
+tcp_conn_finish(nni_win_event *evt, nni_aio *aio)
+{
+	if ((evt->status == 0) && (evt->count == 0)) {
+		// Windows sometimes returns a zero read.  Convert these
+		// into an NNG_ECLOSED.  (We are never supposed to come
+		// back with zero length read.)
+		evt->status = NNG_ECLOSED;
+	}
+	nni_aio_finish(aio, evt->status, evt->count);
+}
+
+int
+nni_win_tcp_conn_init(nni_tcp_conn **connp, SOCKET s)
+{
+	nni_tcp_conn *c;
+	int           rv;
+	BOOL          yes;
+	DWORD         no;
+
+	if ((c = NNI_ALLOC_STRUCT(c)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	if (((rv = nni_win_event_init(&c->rcv_ev, &tcp_conn_ops, c)) != 0) ||
+	    ((rv = nni_win_event_init(&c->snd_ev, &tcp_conn_ops, c)) != 0)) {
+		nni_tcp_conn_fini(c);
+		return (rv);
+	}
+
+	// Don't inherit the handle (CLOEXEC really).
+	SetHandleInformation((HANDLE) s, HANDLE_FLAG_INHERIT, 0);
+
+	no = 0;
+	(void) setsockopt(
+	    s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &no, sizeof(no));
+	yes = 1;
+	(void) setsockopt(
+	    s, IPPROTO_TCP, TCP_NODELAY, (char *) &yes, sizeof(yes));
+
+	c->s   = s;
+	*connp = c;
+	return (0);
+}
+
+void
+nni_win_tcp_conn_set_addrs(
+    nni_tcp_conn *c, const SOCKADDR_STORAGE *loc, const SOCKADDR_STORAGE *rem)
+{
+	memcpy(&c->sockname, loc, sizeof(*loc));
+	memcpy(&c->peername, rem, sizeof(*rem));
+}
+
+void
+nni_tcp_conn_send(nni_tcp_conn *c, nni_aio *aio)
+{
+	nni_win_event_submit(&c->snd_ev, aio);
+}
+
+void
+nni_tcp_conn_recv(nni_tcp_conn *c, nni_aio *aio)
+{
+	nni_win_event_submit(&c->rcv_ev, aio);
+}
+
+void
+nni_tcp_conn_close(nni_tcp_conn *c)
+{
+	SOCKET s;
+
+	nni_win_event_close(&c->rcv_ev);
+
+	if ((s = c->s) != INVALID_SOCKET) {
+		c->s = INVALID_SOCKET;
+		closesocket(s);
+	}
+}
+
+int
+nni_tcp_conn_peername(nni_tcp_conn *c, nni_sockaddr *sa)
+{
+	if (nni_win_sockaddr2nn(sa, &c->peername) < 0) {
+		return (NNG_EADDRINVAL);
+	}
+	return (0);
+}
+
+int
+nni_tcp_conn_sockname(nni_tcp_conn *c, nni_sockaddr *sa)
+{
+	if (nni_win_sockaddr2nn(sa, &c->sockname) < 0) {
+		return (NNG_EADDRINVAL);
+	}
+	return (0);
+}
+
+int
+nni_tcp_conn_set_nodelay(nni_tcp_conn *c, bool val)
+{
+	BOOL b;
+	b = val ? TRUE : FALSE;
+	if (setsockopt(
+	        c->s, IPPROTO_TCP, TCP_NODELAY, (void *) &b, sizeof(b)) != 0) {
+		return (nni_win_error(WSAGetLastError()));
+	}
+	return (0);
+}
+
+int
+nni_tcp_conn_set_keepalive(nni_tcp_conn *c, bool val)
+{
+	BOOL b;
+	b = val ? TRUE : FALSE;
+	if (setsockopt(
+	        c->s, SOL_SOCKET, SO_KEEPALIVE, (void *) &b, sizeof(b)) != 0) {
+		return (nni_win_error(WSAGetLastError()));
+	}
+	return (0);
+}
+
+void
+nni_tcp_conn_fini(nni_tcp_conn *c)
+{
+	nni_tcp_conn_close(c);
+
+	nni_win_event_fini(&c->snd_ev);
+	nni_win_event_fini(&c->rcv_ev);
+	NNI_FREE_STRUCT(c);
+}
+
+#endif // NNG_PLATFORM_WINDOWS

--- a/src/platform/windows/win_tcpdial.c
+++ b/src/platform/windows/win_tcpdial.c
@@ -1,0 +1,228 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_WINDOWS
+
+#include <malloc.h>
+#include <stdio.h>
+
+// XXX: This dialer code unfortunately only supports a single outstanding
+// connection request at a time.  Fixing it will require creating
+// subordinate contexts.
+
+static int  tcp_dialer_start(nni_win_event *, nni_aio *);
+static void tcp_dialer_finish(nni_win_event *, nni_aio *);
+static void tcp_dialer_cancel(nni_win_event *);
+
+struct nni_tcp_dialer {
+	SOCKET           s;
+	nni_win_event    con_ev;
+	SOCKADDR_STORAGE ss;
+	int              sslen;
+	LPFN_CONNECTEX   connectex; // looked up name via ioctl
+};
+
+static nni_win_event_ops tcp_dialer_ops = {
+	.wev_start  = tcp_dialer_start,
+	.wev_finish = tcp_dialer_finish,
+	.wev_cancel = tcp_dialer_cancel,
+};
+
+int
+nni_tcp_dialer_init(nni_tcp_dialer **dp)
+{
+	nni_tcp_dialer *d;
+	int             rv;
+	SOCKET          s;
+	DWORD           nbytes;
+	GUID            guid = WSAID_CONNECTEX;
+
+	if ((d = NNI_ALLOC_STRUCT(d)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	ZeroMemory(d, sizeof(*d));
+
+	d->s = INVALID_SOCKET;
+
+	// Create a scratch socket for use with ioctl.
+	s = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+	if (s == INVALID_SOCKET) {
+		rv = nni_win_error(GetLastError());
+		goto fail;
+	}
+
+	// Look up the function pointer.
+	if (WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid,
+	        sizeof(guid), &d->connectex, sizeof(d->connectex), &nbytes,
+	        NULL, NULL) == SOCKET_ERROR) {
+		rv = nni_win_error(GetLastError());
+		goto fail;
+	}
+
+	closesocket(s);
+	s = INVALID_SOCKET;
+
+	// Now initialize the win events for later use.
+	rv = nni_win_event_init(&d->con_ev, &tcp_dialer_ops, d);
+	if (rv != 0) {
+		goto fail;
+	}
+
+	*dp = d;
+	return (0);
+
+fail:
+	if (s != INVALID_SOCKET) {
+		closesocket(s);
+	}
+	nni_tcp_dialer_fini(d);
+	return (rv);
+}
+
+void
+nni_tcp_dialer_close(nni_tcp_dialer *d)
+{
+	nni_win_event_close(&d->con_ev);
+	if (d->s != INVALID_SOCKET) {
+		closesocket(d->s);
+		d->s = INVALID_SOCKET;
+	}
+}
+
+void
+nni_tcp_dialer_fini(nni_tcp_dialer *d)
+{
+	nni_tcp_dialer_close(d);
+	NNI_FREE_STRUCT(d);
+}
+
+static void
+tcp_dialer_cancel(nni_win_event *evt)
+{
+	nni_tcp_dialer *d = evt->ptr;
+	SOCKET          s = d->s;
+
+	if (s != INVALID_SOCKET) {
+		CancelIoEx((HANDLE) s, &evt->olpd);
+	}
+}
+
+static void
+tcp_dialer_finish(nni_win_event *evt, nni_aio *aio)
+{
+	nni_tcp_dialer * d = evt->ptr;
+	nni_tcp_conn *   c;
+	SOCKET           s;
+	int              rv;
+	DWORD            yes = 1;
+	int              len;
+	SOCKADDR_STORAGE ss;
+
+	s    = d->s;
+	d->s = INVALID_SOCKET;
+
+	// The socket was already registered with the IOCP.
+
+	if (((rv = evt->status) != 0) ||
+	    ((rv = nni_win_tcp_conn_init(&c, s)) != 0)) {
+		// The new pipe is already fine for us.  Discard
+		// the old one, since failed to be able to use it.
+		closesocket(s);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+
+	(void) setsockopt(s, SOL_SOCKET, SO_UPDATE_CONNECT_CONTEXT,
+	    (char *) &yes, sizeof(yes));
+
+	len = sizeof(ss);
+	(void) getsockname(s, (SOCKADDR *) &ss, &len);
+
+	// Windows seems to be unable to get peernames for sockets on
+	// connect - perhaps because we supplied it already with connectex.
+	// For now, just steal the address from the endpoint.
+	nni_win_tcp_conn_set_addrs(c, &ss, &d->ss);
+
+	nni_aio_set_output(aio, 0, c);
+	nni_aio_finish(aio, 0, 0);
+}
+
+static int
+tcp_dialer_start(nni_win_event *evt, nni_aio *aio)
+{
+	nni_tcp_dialer * d = evt->ptr;
+	SOCKET           s;
+	SOCKADDR_STORAGE bss;
+	int              len;
+	int              rv;
+	DWORD            no;
+
+	NNI_ARG_UNUSED(aio);
+
+	s = socket(d->ss.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	if (s == INVALID_SOCKET) {
+		evt->status = nni_win_error(GetLastError());
+		evt->count  = 0;
+		return (1);
+	}
+
+	// Don't inherit the handle (CLOEXEC really).
+	SetHandleInformation((HANDLE) s, HANDLE_FLAG_INHERIT, 0);
+
+	no = 0;
+	(void) setsockopt(
+	    s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &no, sizeof(no));
+
+	// Windows ConnectEx requires the socket to be bound first.
+	// We just bind to an ephemeral address in the same family.
+	ZeroMemory(&bss, sizeof(bss));
+	bss.ss_family = d->ss.ss_family;
+	len           = d->sslen;
+	if (bind(s, (struct sockaddr *) &bss, len) < 0) {
+		evt->status = nni_win_error(GetLastError());
+		evt->count  = 0;
+		closesocket(s);
+
+		return (1);
+	}
+	// Register with the I/O completion port so we can get the
+	// events for the next call.
+	if ((rv = nni_win_iocp_register((HANDLE) s)) != 0) {
+		closesocket(s);
+		evt->status = rv;
+		evt->count  = 0;
+		return (1);
+	}
+
+	d->s = s;
+	if (!d->connectex(s, (struct sockaddr *) &d->ss, d->sslen, NULL, 0,
+	        NULL, &evt->olpd)) {
+		if ((rv = GetLastError()) != ERROR_IO_PENDING) {
+			closesocket(s);
+			d->s        = INVALID_SOCKET;
+			evt->status = nni_win_error(rv);
+			evt->count  = 0;
+			return (1);
+		}
+	}
+	return (0);
+}
+
+extern void
+nni_tcp_dialer_dial(nni_tcp_dialer *d, const nni_sockaddr *sa, nni_aio *aio)
+{
+	d->sslen = nni_win_nn2sockaddr(&d->ss, sa);
+
+	nni_win_event_submit(&d->con_ev, aio);
+}
+
+#endif // NNG_PLATFORM_WINDOWS

--- a/src/platform/windows/win_tcplisten.c
+++ b/src/platform/windows/win_tcplisten.c
@@ -1,0 +1,289 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_WINDOWS
+
+#include <malloc.h>
+#include <stdbool.h>
+#include <stdio.h>
+
+struct nni_tcp_listener {
+	SOCKET                    s;
+	SOCKET                    acc_s;
+	nni_win_event             acc_ev;
+	bool                      started;
+	char                      buf[512]; // to hold acceptex results
+	LPFN_ACCEPTEX             acceptex;
+	LPFN_GETACCEPTEXSOCKADDRS getacceptexsockaddrs;
+};
+
+static int  tcp_listener_start(nni_win_event *, nni_aio *);
+static void tcp_listener_finish(nni_win_event *, nni_aio *);
+static void tcp_listener_cancel(nni_win_event *);
+
+static nni_win_event_ops tcp_listener_ops = {
+	.wev_start  = tcp_listener_start,
+	.wev_finish = tcp_listener_finish,
+	.wev_cancel = tcp_listener_cancel,
+};
+
+int
+nni_tcp_listener_init(nni_tcp_listener **lp)
+{
+	nni_tcp_listener *l;
+	int               rv;
+	SOCKET            s;
+	DWORD             nbytes;
+	GUID              guid1 = WSAID_ACCEPTEX;
+	GUID              guid2 = WSAID_GETACCEPTEXSOCKADDRS;
+
+	if ((l = NNI_ALLOC_STRUCT(l)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	ZeroMemory(l, sizeof(*l));
+
+	l->s = INVALID_SOCKET;
+
+	// Create a scratch socket for use with ioctl.
+	s = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+	if (s == INVALID_SOCKET) {
+		rv = nni_win_error(GetLastError());
+		goto fail;
+	}
+
+	// Look up the function pointer.
+	if (WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid1,
+	        sizeof(guid1), &l->acceptex, sizeof(l->acceptex), &nbytes,
+	        NULL, NULL) == SOCKET_ERROR) {
+		rv = nni_win_error(GetLastError());
+		goto fail;
+	}
+	if (WSAIoctl(s, SIO_GET_EXTENSION_FUNCTION_POINTER, &guid2,
+	        sizeof(guid2), &l->getacceptexsockaddrs,
+	        sizeof(l->getacceptexsockaddrs), &nbytes, NULL,
+	        NULL) == SOCKET_ERROR) {
+		rv = nni_win_error(GetLastError());
+		goto fail;
+	}
+
+	closesocket(s);
+	s = INVALID_SOCKET;
+
+	// Now initialize the win events for later use.
+	rv = nni_win_event_init(&l->acc_ev, &tcp_listener_ops, l);
+	if (rv != 0) {
+		goto fail;
+	}
+
+	*lp = l;
+	return (0);
+
+fail:
+	if (s != INVALID_SOCKET) {
+		closesocket(s);
+	}
+	nni_tcp_listener_fini(l);
+	return (rv);
+}
+
+void
+nni_tcp_listener_close(nni_tcp_listener *l)
+{
+	nni_win_event_close(&l->acc_ev);
+	if (l->s != INVALID_SOCKET) {
+		closesocket(l->s);
+		l->s = INVALID_SOCKET;
+	}
+	if (l->acc_s != INVALID_SOCKET) {
+		closesocket(l->acc_s);
+	}
+}
+
+void
+nni_tcp_listener_fini(nni_tcp_listener *l)
+{
+	nni_tcp_listener_close(l);
+	NNI_FREE_STRUCT(l);
+}
+
+int
+nni_tcp_listener_listen(nni_tcp_listener *l, nni_sockaddr *sa)
+{
+	int              rv;
+	SOCKET           s;
+	SOCKADDR_STORAGE ss;
+	BOOL             yes;
+	DWORD            no;
+	int              len;
+
+	if ((sa->s_family != NNG_AF_INET) && (sa->s_family != NNG_AF_INET6)) {
+		return (NNG_EADDRINVAL);
+	}
+	len = nni_win_nn2sockaddr(&ss, sa);
+
+	s = socket(ss.ss_family, SOCK_STREAM, IPPROTO_TCP);
+	if (s == INVALID_SOCKET) {
+		return (nni_win_error(GetLastError()));
+	}
+
+	// Don't inherit the handle (CLOEXEC really).
+	SetHandleInformation((HANDLE) s, HANDLE_FLAG_INHERIT, 0);
+
+	no = 0;
+	(void) setsockopt(
+	    s, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &no, sizeof(no));
+	yes = 1;
+	(void) setsockopt(
+	    s, IPPROTO_TCP, TCP_NODELAY, (char *) &yes, sizeof(yes));
+
+	if ((rv = nni_win_iocp_register((HANDLE) s)) != 0) {
+		closesocket(s);
+		return (rv);
+	}
+
+	// Make sure that we use the address exclusively.  Windows lets
+	// others hijack us by default.
+	yes = 1;
+	rv  = setsockopt(
+            s, SOL_SOCKET, SO_EXCLUSIVEADDRUSE, (char *) &yes, sizeof(yes));
+	if (rv != 0) {
+		rv = nni_win_error(GetLastError());
+		closesocket(s);
+		return (rv);
+	}
+
+	if (l->started) {
+		closesocket(s);
+		return (NNG_EBUSY);
+	}
+	if (bind(s, (struct sockaddr *) &ss, len) != 0) {
+		rv = nni_win_error(GetLastError());
+		closesocket(s);
+		return (rv);
+	}
+
+	// Update the bound address. This should never fail.
+	if ((rv = getsockname(s, (SOCKADDR *) &ss, &len)) == 0) {
+		nni_win_sockaddr2nn(sa, &ss);
+	}
+
+	if (listen(s, SOMAXCONN) != 0) {
+		rv = nni_win_error(GetLastError());
+		closesocket(s);
+		return (rv);
+	}
+
+	l->s       = s;
+	l->started = true;
+
+	return (0);
+}
+
+static void
+tcp_listener_cancel(nni_win_event *evt)
+{
+	nni_tcp_listener *l = evt->ptr;
+	SOCKET            s = l->s;
+
+	if (s != INVALID_SOCKET) {
+		CancelIoEx((HANDLE) s, &evt->olpd);
+	}
+}
+
+static void
+tcp_listener_finish(nni_win_event *evt, nni_aio *aio)
+{
+	nni_tcp_listener *l = evt->ptr;
+	nni_tcp_conn *    c;
+	SOCKET            s;
+	int               rv;
+	int               len1;
+	int               len2;
+	SOCKADDR *        sa1;
+	SOCKADDR *        sa2;
+	SOCKADDR_STORAGE  ss1;
+	SOCKADDR_STORAGE  ss2;
+
+	s        = l->acc_s;
+	l->acc_s = INVALID_SOCKET;
+
+	if (s == INVALID_SOCKET) {
+		return;
+	}
+
+	if (((rv = evt->status) != 0) ||
+	    ((rv = nni_win_iocp_register((HANDLE) s)) != 0) ||
+	    ((rv = nni_win_tcp_conn_init(&c, s)) != 0)) {
+		closesocket(s);
+		nni_aio_finish_error(aio, rv);
+		return;
+	}
+
+	// Collect the local and peer addresses, because normal getsockname
+	// and getpeername don't work with AcceptEx.
+	len1 = (int) sizeof(sa1);
+	len2 = (int) sizeof(sa2);
+	l->getacceptexsockaddrs(l->buf, 0, 256, 256, &sa1, &len1, &sa2, &len2);
+	NNI_ASSERT(len1 > 0);
+	NNI_ASSERT(len1 < (int) sizeof(SOCKADDR_STORAGE));
+	NNI_ASSERT(len2 > 0);
+	NNI_ASSERT(len2 < (int) sizeof(SOCKADDR_STORAGE));
+	memcpy(&ss1, sa1, len1);
+	memcpy(&ss2, sa2, len2);
+
+	nni_win_tcp_conn_set_addrs(c, &ss1, &ss2);
+
+	nni_aio_set_output(aio, 0, c);
+	nni_aio_finish(aio, 0, 0);
+}
+
+static int
+tcp_listener_start(nni_win_event *evt, nni_aio *aio)
+{
+	nni_tcp_listener *l = evt->ptr;
+	SOCKET            s = l->s;
+	SOCKET            acc_s;
+	DWORD             cnt;
+	int               rv;
+
+	NNI_ARG_UNUSED(aio);
+
+	// Windows requires us to explicity create the socket before
+	// calling accept on it.
+	acc_s = socket(AF_INET6, SOCK_STREAM, IPPROTO_TCP);
+	if (acc_s == INVALID_SOCKET) {
+		evt->status = nni_win_error(GetLastError());
+		evt->count  = 0;
+		return (1);
+	}
+	l->acc_s = acc_s;
+
+	if ((!l->acceptex(s, acc_s, l->buf, 0, 256, 256, &cnt, &evt->olpd)) &&
+	    ((rv = GetLastError()) != ERROR_IO_PENDING)) {
+		// Fast failure (synchronous.)
+		evt->status = nni_win_error(rv);
+		evt->count  = 0;
+		return (1);
+	}
+
+	// This is either success, or asynchronous completion.  In either
+	// event the I/O completion packet is delivered.
+	return (0);
+}
+
+void
+nni_tcp_listener_accept(nni_tcp_listener *l, nni_aio *aio)
+{
+	nni_win_event_submit(&l->acc_ev, aio);
+}
+
+#endif // NNG_PLATFORM_WINDOWS

--- a/tests/compat_tcp.c
+++ b/tests/compat_tcp.c
@@ -119,9 +119,11 @@ int main (int argc, const char *argv[])
     rc = nn_connect (sc, "tcp://:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
+#if 0 // NNG does not validate names apriori
     rc = nn_connect (sc, "tcp://-hostname:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
+#endif
     rc = nn_connect (sc, "tcp://abc.123.---.#:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
@@ -132,12 +134,14 @@ int main (int argc, const char *argv[])
     errno_assert (nn_errno () == EINVAL);
 #endif
 
+#if 0 // Again NNG is not validating names apriori.
     rc = nn_connect (sc, "tcp://abc...123:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
     rc = nn_connect (sc, "tcp://.123:5555");
     nn_assert (rc < 0);
     errno_assert (nn_errno () == EINVAL);
+#endif
 
     /*  Connect correctly. Do so before binding the peer socket. */
     test_connect (sc, socket_address);


### PR DESCRIPTION
This separates the dialer and listener for TCP for both POSIX and Windows, and moves lookups for DNS into the connection logic as part of the async bit, leading to further self-healing, etc.

This isn't ready for integration yet.