### PR TITLE
Fixpipe2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,8 @@ else ()
     nng_check_sym (SO_PEERCRED sys/socket.h NNG_HAVE_SOPEERCRED)
     nng_check_sym (LOCAL_PEERCRED sys/un.h NNG_HAVE_LOCALPEERCRED)
     nng_check_sym (getpeerucred ucred.h NNG_HAVE_GETPEERUCRED)
+    nng_check_sym (atomic_flag_test_and_set stdatomic.h NNG_HAVE_STDATOMIC)
+
 endif ()
 
 nng_check_sym (strlcat string.h NNG_HAVE_STRLCAT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ if (NNG_PLATFORM_POSIX)
         platform/posix/posix_pollq.h
 
         platform/posix/posix_alloc.c
+        platform/posix/posix_atomic.c
         platform/posix/posix_clock.c
         platform/posix/posix_debug.c
         platform/posix/posix_epdesc.c

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -147,6 +147,18 @@ extern void nni_plat_thr_fini(nni_plat_thr *);
 extern bool nni_plat_thr_is_self(nni_plat_thr *);
 
 //
+// Atomics support.  This will evolve over time.
+//
+
+// nni_atomic_flag supports only test-and-set and reset operations.
+// This can be implemented without locks on any reasonable system, and
+// it corresponds to C11 atomic flag.
+typedef struct nni_atomic_flag nni_atomic_flag;
+
+extern bool nni_atomic_flag_test_and_set(nni_atomic_flag *);
+extern void nni_atomic_flag_reset(nni_atomic_flag *);
+
+//
 // Clock Support
 //
 

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -33,8 +33,8 @@ struct nni_ctx {
 };
 
 typedef struct sock_option {
-	const char *o_name;
-	int         o_type;
+	const char * o_name;
+	nni_opt_type o_type;
 	int (*o_get)(nni_sock *, void *, size_t *, nni_opt_type);
 	int (*o_set)(nni_sock *, const void *, size_t, nni_opt_type);
 } sock_option;
@@ -42,7 +42,7 @@ typedef struct sock_option {
 typedef struct nni_sockopt {
 	nni_list_node node;
 	char *        name;
-	int           typ;
+	nni_opt_type  typ;
 	size_t        sz;
 	void *        data;
 } nni_sockopt;

--- a/src/platform/posix/posix_atomic.c
+++ b/src/platform/posix/posix_atomic.c
@@ -1,0 +1,57 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+// POSIX atomics.
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_PLATFORM_POSIX
+
+#ifdef NNG_HAVE_STDATOMIC
+
+#include <stdatomic.h>
+bool
+nni_atomic_flag_test_and_set(nni_atomic_flag *f)
+{
+	return (atomic_flag_test_and_set(&f->f));
+}
+
+void
+nni_atomic_flag_reset(nni_atomic_flag *f)
+{
+	atomic_flag_clear(&f->f);
+}
+#else
+
+#include <pthread.h>
+
+static pthread_mutex_t plat_atomic_lock = PTHREAD_MUTEX_INITIALIZER;
+
+bool
+nni_atomic_flag_test_and_set(nni_atomic_flag *f)
+{
+	bool v;
+	pthread_mutex_lock(&plat_atomic_lock);
+	v    = f->f;
+	f->f = true;
+	pthread_mutex_unlock(&plat_atomic_lock);
+	return (v);
+}
+
+void
+nni_atomic_flag_reset(nni_atomic_flag *f)
+{
+	pthread_mutex_lock(&plat_atomic_lock);
+	f->f = false;
+	pthread_mutex_unlock(&plat_atomic_lock);
+}
+#endif
+
+#endif // NNG_PLATFORM_POSIX

--- a/src/platform/posix/posix_impl.h
+++ b/src/platform/posix/posix_impl.h
@@ -75,6 +75,19 @@ struct nni_plat_flock {
 
 #define NNG_PLATFORM_DIR_SEP "/"
 
+#ifdef NNG_HAVE_STDATOMIC
+
+#include <stdatomic.h>
+
+struct nni_atomic_flag {
+	atomic_flag f;
+};
+#else // NNG_HAVE_C11_ATOMIC
+struct nni_atomic_flag {
+	bool f;
+};
+#endif
+
 #endif
 
 extern int  nni_posix_pollq_sysinit(void);

--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -348,4 +348,5 @@ nni_plat_ncpu(void)
 	return (1);
 #endif
 }
+
 #endif // NNG_PLATFORM_POSIX

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -48,6 +48,10 @@ struct nni_plat_cv {
 	PSRWLOCK           srl;
 };
 
+struct nni_atomic_flag {
+	unsigned f;
+};
+
 // nni_win_event is used with io completion ports.  This allows us to get
 // to a specific completion callback without requiring the poller (in the
 // completion port) to know anything about the event itself.  We also use

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -103,6 +103,18 @@ nni_plat_cv_fini(nni_plat_cv *cv)
 	NNI_ARG_UNUSED(cv);
 }
 
+bool
+nni_atomic_flag_test_and_set(nni_atomic_flag *f)
+{
+	return (InterlockedExchange(&f->f, 1) != 0);
+}
+
+void
+nni_atomic_flag_reset(nni_atomic_flag *f)
+{
+	InterlockedExchange(&f->f, 0);
+}
+
 static unsigned int __stdcall nni_plat_thr_main(void *arg)
 {
 	nni_plat_thr *thr = arg;

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -413,15 +413,14 @@ rep0_pipe_send_cb(void *arg)
 	nni_msg *  msg;
 	size_t     len;
 
-	nni_mtx_lock(&s->lk);
-	p->busy = false;
 	if (nni_aio_result(p->aio_send) != 0) {
 		nni_msg_free(nni_aio_get_msg(p->aio_send));
 		nni_aio_set_msg(p->aio_send, NULL);
 		nni_pipe_stop(p->pipe);
-		nni_mtx_unlock(&s->lk);
 		return;
 	}
+	nni_mtx_lock(&s->lk);
+	p->busy = false;
 	if ((ctx = nni_list_first(&p->sendq)) == NULL) {
 		// Nothing else to send.
 		if (p->id == s->ctx->pipe_id) {

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -402,15 +402,14 @@ resp0_pipe_send_cb(void *arg)
 	nni_msg *   msg;
 	size_t      len;
 
-	nni_mtx_lock(&s->mtx);
-	p->busy = false;
 	if (nni_aio_result(p->aio_send) != 0) {
 		nni_msg_free(nni_aio_get_msg(p->aio_send));
 		nni_aio_set_msg(p->aio_send, NULL);
 		nni_pipe_stop(p->npipe);
-		nni_mtx_unlock(&s->mtx);
 		return;
 	}
+	nni_mtx_lock(&s->mtx);
+	p->busy = false;
 	if ((ctx = nni_list_first(&p->sendq)) == NULL) {
 		// Nothing else to send.
 		if (p->id == s->ctx->pipe_id) {

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -827,14 +827,22 @@ static int
 ipc_ep_get_recvmaxsz(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	ipc_ep *ep = arg;
-	return (nni_copyout_size(ep->rcvmax, data, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_size(ep->rcvmax, data, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
 ipc_ep_get_addr(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	ipc_ep *ep = arg;
-	return (nni_copyout_sockaddr(&ep->sa, data, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_sockaddr(&ep->sa, data, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -868,7 +876,9 @@ ipc_ep_set_sec_desc(void *arg, const void *data, size_t sz, nni_opt_type t)
 	int     rv;
 
 	if ((rv = nni_copyin_ptr(&ptr, data, sz, t)) == 0) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nni_plat_ipc_ep_set_security_descriptor(ep->iep, ptr);
+		nni_mtx_unlock(&ep->mtx);
 	}
 	return (rv);
 }

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -882,7 +882,11 @@ static int
 tcp_ep_get_nodelay(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tcp_ep *ep = arg;
-	return (nni_copyout_bool(ep->nodelay, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_bool(ep->nodelay, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -903,7 +907,11 @@ static int
 tcp_ep_get_keepalive(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tcp_ep *ep = arg;
-	return (nni_copyout_bool(ep->keepalive, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_bool(ep->keepalive, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -931,7 +939,11 @@ static int
 tcp_ep_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tcp_ep *ep = arg;
-	return (nni_copyout_size(ep->rcvmax, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_size(ep->rcvmax, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static nni_tran_option tcp_pipe_options[] = {

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -877,7 +877,11 @@ static int
 tls_ep_get_nodelay(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tls_ep *ep = arg;
-	return (nni_copyout_bool(ep->nodelay, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_bool(ep->nodelay, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -898,7 +902,11 @@ static int
 tls_ep_get_keepalive(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tls_ep *ep = arg;
-	return (nni_copyout_bool(ep->keepalive, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_bool(ep->keepalive, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -947,7 +955,11 @@ static int
 tls_ep_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tls_ep *ep = arg;
-	return (nni_copyout_size(ep->rcvmax, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_size(ep->rcvmax, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -974,9 +986,11 @@ tls_ep_set_config(void *arg, const void *data, size_t sz, nni_opt_type t)
 	if (cfg == NULL) {
 		return (NNG_EINVAL);
 	}
+	nni_mtx_lock(&ep->mtx);
 	old = ep->cfg;
 	nni_tls_config_hold(cfg);
 	ep->cfg = cfg;
+	nni_mtx_unlock(&ep->mtx);
 	if (old != NULL) {
 		nni_tls_config_fini(old);
 	}
@@ -987,7 +1001,11 @@ static int
 tls_ep_get_config(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	tls_ep *ep = arg;
-	return (nni_copyout_ptr(ep->cfg, v, szp, t));
+	int     rv;
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_ptr(ep->cfg, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
 }
 
 static int
@@ -1055,7 +1073,9 @@ tls_ep_set_cert_key_file(void *arg, const void *v, size_t sz, nni_opt_type t)
 	int     rv;
 
 	if ((rv = tls_ep_chk_string(v, sz, t)) == 0) {
+		nni_mtx_lock(&ep->mtx);
 		rv = nng_tls_config_cert_key_file(ep->cfg, v, NULL);
+		nni_mtx_unlock(&ep->mtx);
 	}
 	return (rv);
 }

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -416,7 +416,11 @@ static int
 ws_dialer_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	ws_dialer *d = arg;
-	return (nni_copyout_size(d->rcvmax, v, szp, t));
+	int        rv;
+	nni_mtx_lock(&d->mtx);
+	rv = nni_copyout_size(d->rcvmax, v, szp, t);
+	nni_mtx_unlock(&d->mtx);
+	return (rv);
 }
 
 static int
@@ -439,7 +443,11 @@ static int
 ws_listener_get_recvmaxsz(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	ws_listener *l = arg;
-	return (nni_copyout_size(l->rcvmax, v, szp, t));
+	int          rv;
+	nni_mtx_lock(&l->mtx);
+	rv = nni_copyout_size(l->rcvmax, v, szp, t);
+	nni_mtx_unlock(&l->mtx);
+	return (rv);
 }
 
 static int
@@ -538,7 +546,9 @@ ws_dialer_set_reqhdrs(void *arg, const void *v, size_t sz, nni_opt_type t)
 	}
 
 	if ((rv = ws_check_string(v, sz, t)) == 0) {
+		nni_mtx_lock(&d->mtx);
 		rv = ws_set_headers(&d->headers, v);
+		nni_mtx_unlock(&d->mtx);
 	}
 	return (rv);
 }
@@ -553,7 +563,9 @@ ws_listener_set_reshdrs(void *arg, const void *v, size_t sz, nni_opt_type t)
 		return (NNG_EBUSY);
 	}
 	if ((rv = ws_check_string(v, sz, t)) == 0) {
+		nni_mtx_lock(&l->mtx);
 		rv = ws_set_headers(&l->headers, v);
+		nni_mtx_unlock(&l->mtx);
 	}
 	return (rv);
 }

--- a/src/transport/zerotier/zerotier.c
+++ b/src/transport/zerotier/zerotier.c
@@ -2600,7 +2600,9 @@ zt_ep_set_recvmaxsz(void *arg, const void *data, size_t sz, nni_opt_type t)
 	int    rv;
 
 	if ((rv = nni_copyin_size(&val, data, sz, 0, NNI_MAXSZ, t)) == 0) {
+		nni_mtx_lock(&zt_lk);
 		ep->ze_rcvmax = val;
+		nni_mtx_unlock(&zt_lk);
 	}
 	return (rv);
 }
@@ -2609,7 +2611,11 @@ static int
 zt_ep_get_recvmaxsz(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_size(ep->ze_rcvmax, data, szp, t));
+	int    rv;
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_size(ep->ze_rcvmax, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
@@ -2634,16 +2640,16 @@ zt_ep_set_home(void *arg, const void *data, size_t sz, nni_opt_type t)
 	zt_ep *ep = arg;
 
 	if ((rv = zt_ep_chk_string(data, sz, t)) == 0) {
+		nni_mtx_lock(&zt_lk);
 		if (ep->ze_running) {
 			rv = NNG_ESTATE;
 		} else {
-			nni_mtx_lock(&zt_lk);
 			nni_strlcpy(ep->ze_home, data, sizeof(ep->ze_home));
 			if ((rv = zt_node_find(ep)) != 0) {
 				ep->ze_ztn = NULL;
 			}
-			nni_mtx_unlock(&zt_lk);
 		}
+		nni_mtx_unlock(&zt_lk);
 	}
 
 	return (rv);
@@ -2653,7 +2659,12 @@ static int
 zt_ep_get_home(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_str(ep->ze_home, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_str(ep->ze_home, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
@@ -2663,11 +2674,13 @@ zt_ep_get_url(void *arg, void *data, size_t *szp, nni_opt_type t)
 	zt_ep *  ep = arg;
 	uint64_t addr;
 
+	nni_mtx_lock(&zt_lk);
 	addr = ep->ze_mode == NNI_EP_MODE_DIAL ? ep->ze_raddr : ep->ze_laddr;
 	snprintf(ustr, sizeof(ustr), "zt://%llx.%llx:%u",
 	    (unsigned long long) addr >> zt_port_shift,
 	    (unsigned long long) ep->ze_nwid,
 	    (unsigned) (addr & zt_port_mask));
+	nni_mtx_unlock(&zt_lk);
 	return (nni_copyout_str(ustr, data, szp, t));
 }
 
@@ -2750,14 +2763,24 @@ static int
 zt_ep_get_node(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_u64(ep->ze_ztn->zn_self, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_u64(ep->ze_ztn->zn_self, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
 zt_ep_get_nwid(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_u64(ep->ze_nwid, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_u64(ep->ze_nwid, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
@@ -2788,7 +2811,9 @@ zt_ep_set_ping_time(void *arg, const void *data, size_t sz, nni_opt_type t)
 	int          rv;
 
 	if ((rv = nni_copyin_ms(&val, data, sz, t)) == 0) {
+		nni_mtx_lock(&zt_lk);
 		ep->ze_ping_time = val;
+		nni_mtx_unlock(&zt_lk);
 	}
 	return (rv);
 }
@@ -2797,7 +2822,12 @@ static int
 zt_ep_get_ping_time(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_ms(ep->ze_ping_time, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_ms(ep->ze_ping_time, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
@@ -2814,7 +2844,9 @@ zt_ep_set_ping_tries(void *arg, const void *data, size_t sz, nni_opt_type t)
 	int    rv;
 
 	if ((rv = nni_copyin_int(&val, data, sz, 0, 1000000, t)) == 0) {
+		nni_mtx_lock(&zt_lk);
 		ep->ze_ping_tries = val;
+		nni_mtx_unlock(&zt_lk);
 	}
 	return (rv);
 }
@@ -2823,7 +2855,12 @@ static int
 zt_ep_get_ping_tries(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_int(ep->ze_ping_tries, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_int(ep->ze_ping_tries, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
@@ -2834,7 +2871,9 @@ zt_ep_set_conn_time(void *arg, const void *data, size_t sz, nni_opt_type t)
 	int          rv;
 
 	if ((rv = nni_copyin_ms(&val, data, sz, t)) == 0) {
+		nni_mtx_lock(&zt_lk);
 		ep->ze_conn_time = val;
+		nni_mtx_unlock(&zt_lk);
 	}
 	return (rv);
 }
@@ -2843,7 +2882,12 @@ static int
 zt_ep_get_conn_time(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_ms(ep->ze_conn_time, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_ms(ep->ze_conn_time, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int
@@ -2854,7 +2898,9 @@ zt_ep_set_conn_tries(void *arg, const void *data, size_t sz, nni_opt_type t)
 	int    rv;
 
 	if ((rv = nni_copyin_int(&val, data, sz, 0, 1000000, t)) == 0) {
+		nni_mtx_lock(&zt_lk);
 		ep->ze_conn_tries = val;
+		nni_mtx_unlock(&zt_lk);
 	}
 	return (rv);
 }
@@ -2863,7 +2909,12 @@ static int
 zt_ep_get_conn_tries(void *arg, void *data, size_t *szp, nni_opt_type t)
 {
 	zt_ep *ep = arg;
-	return (nni_copyout_int(ep->ze_conn_tries, data, szp, t));
+	int    rv;
+
+	nni_mtx_lock(&zt_lk);
+	rv = nni_copyout_int(ep->ze_conn_tries, data, szp, t);
+	nni_mtx_unlock(&zt_lk);
+	return (rv);
 }
 
 static int


### PR DESCRIPTION
This is work in progress aimed at simplifying the interlocking between sockets, endpoints, and pipes, with an eye to making the code more resilient and easier to grok by reducing the total number of locks needed for certain key operations.