### PR TITLE
Added QNX support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,13 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Windows")
     add_definitions (-D_WIN32_WINNT=0x0600)
     list (APPEND CMAKE_REQUIRED_DEFINITIONS -D_WIN32_WINNT=0x0600)
 
+elseif (CMAKE_SYSTEM_NAME MATCHES "QNX")
+    add_definitions (-DNNG_PLATFORM_POSIX)
+    add_definitions (-D__EXT_BSD)    
+    add_definitions (-D_QNX_SOURCE)
+    add_definitions (-DNNG_PLATFORM_QNX)
+    set(NNG_PLATFORM_POSIX ON)   
+
 else ()
     message (AUTHOR_WARNING "WARNING: This platform may not be supported: ${CMAKE_SYSTEM_NAME}")
     message (AUTHOR_WARNING "${ISSUE_REPORT_MSG}")

--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -50,6 +50,7 @@ struct resolv_item {
 	int          passive;
 	const char * name;
 	int          proto;
+	int          socktype;
 	uint16_t     port;
 	nni_aio *    aio;
 	nng_sockaddr sa;
@@ -138,6 +139,7 @@ resolv_task(resolv_item *item)
 	}
 	hints.ai_protocol = item->proto;
 	hints.ai_family   = item->family;
+	hints.ai_socktype = item->socktype;
 
 	// We can pass any non-zero service number, but we have to pass
 	// *something*, in case we are using a NULL hostname.
@@ -191,7 +193,7 @@ done:
 
 static void
 resolv_ip(const char *host, const char *serv, int passive, int family,
-    int proto, nni_aio *aio)
+    int proto, int socktype, nni_aio *aio)
 {
 	resolv_item *item;
 	sa_family_t  fam;
@@ -249,12 +251,13 @@ resolv_ip(const char *host, const char *serv, int passive, int family,
 
 	// NB: host and serv must remain valid until this is completed.
 	memset(&item->sa, 0, sizeof(item->sa));
-	item->name    = host;
-	item->proto   = proto;
-	item->aio     = aio;
-	item->family  = fam;
-	item->passive = passive;
-	item->port    = htons((uint16_t) port);
+	item->name     = host;
+	item->proto    = proto;
+	item->aio      = aio;
+	item->family   = fam;
+	item->passive  = passive;
+	item->socktype = socktype;
+	item->port     = htons((uint16_t) port);
 
 	nni_mtx_lock(&resolv_mtx);
 	if (resolv_fini) {
@@ -277,14 +280,14 @@ void
 nni_tcp_resolv(
     const char *host, const char *serv, int family, int passive, nni_aio *aio)
 {
-	resolv_ip(host, serv, passive, family, IPPROTO_TCP, aio);
+	resolv_ip(host, serv, passive, family, IPPROTO_TCP, SOCK_STREAM, aio);
 }
 
 void
 nni_udp_resolv(
     const char *host, const char *serv, int family, int passive, nni_aio *aio)
 {
-	resolv_ip(host, serv, passive, family, IPPROTO_UDP, aio);
+	resolv_ip(host, serv, passive, family, IPPROTO_UDP, SOCK_DGRAM, aio);
 }
 
 void


### PR DESCRIPTION
Adding support for QNX.

- Updated cmake to support QNX
- Resolved issue on QNX where calls to getaddrinfo() would fail due to hints,ai_socktype not being explicitly set. I also explicitly set hints.ai_socktype on the windows platform. This was not necessary, however I think there is value in keeping the code consistent on both platforms.
