### PR TITLE
fixes #611 Memory Leaks under Windows

### DIFF
--- a/src/platform/posix/posix_alloc.c
+++ b/src/platform/posix/posix_alloc.c
@@ -17,13 +17,13 @@
 void *
 nni_alloc(size_t sz)
 {
-	return (malloc(sz));
+	return (sz > 0 ? malloc(sz) : NULL);
 }
 
 void *
 nni_zalloc(size_t sz)
 {
-	return (calloc(1, sz));
+	return (sz > 0 ? calloc(1, sz) : NULL);
 }
 
 void

--- a/src/platform/posix/posix_file.c
+++ b/src/platform/posix/posix_file.c
@@ -115,14 +115,18 @@ nni_plat_file_get(const char *name, void **datap, size_t *lenp)
 	}
 
 	len = st.st_size;
-	if ((data = nni_alloc(len)) == NULL) {
-		rv = NNG_ENOMEM;
-		goto done;
-	}
-	if (fread(data, 1, len, f) != len) {
-		rv = nni_plat_errno(errno);
-		nni_free(data, len);
-		goto done;
+	if (len > 0) {
+		if ((data = nni_alloc(len)) == NULL) {
+			rv = NNG_ENOMEM;
+			goto done;
+		}
+		if (fread(data, 1, len, f) != len) {
+			rv = nni_plat_errno(errno);
+			nni_free(data, len);
+			goto done;
+		}
+	} else {
+		data = NULL;
 	}
 	*datap = data;
 	*lenp  = len;

--- a/src/platform/windows/win_file.c
+++ b/src/platform/windows/win_file.c
@@ -136,14 +136,19 @@ nni_plat_file_get(const char *name, void **datap, size_t *lenp)
 		rv = nni_win_error(GetLastError());
 		goto done;
 	}
-	if ((data = nni_alloc((size_t) sz)) == NULL) {
-		rv = NNG_ENOMEM;
-		goto done;
-	}
-	if (!ReadFile(h, data, sz, &nread, NULL)) {
-		rv = nni_win_error(GetLastError());
-		nni_free(data, sz);
-		goto done;
+	if (sz > 0) {
+		if ((data = nni_alloc((size_t) sz)) == NULL) {
+			rv = NNG_ENOMEM;
+			goto done;
+		}
+		if (!ReadFile(h, data, sz, &nread, NULL)) {
+			rv = nni_win_error(GetLastError());
+			nni_free(data, sz);
+			goto done;
+		}
+	} else {
+		data  = NULL;
+		nread = 0;
 	}
 
 	// We can get a short read, indicating end of file.  We return

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -19,13 +19,13 @@
 void *
 nni_alloc(size_t sz)
 {
-	return (malloc(sz));
+	return (sz > 0 ? malloc(sz) : NULL);
 }
 
 void *
 nni_zalloc(size_t sz)
 {
-	return (calloc(1, sz));
+	return (sz > 0 ? calloc(1, sz) : NULL);
 }
 
 void

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -228,9 +228,13 @@ sub0_subscribe(void *arg, const void *buf, size_t sz, nni_opt_type t)
 		nni_mtx_unlock(&s->lk);
 		return (NNG_ENOMEM);
 	}
-	if ((newtopic->buf = nni_alloc(sz)) == NULL) {
-		nni_mtx_unlock(&s->lk);
-		return (NNG_ENOMEM);
+	if (sz > 0) {
+		if ((newtopic->buf = nni_alloc(sz)) == NULL) {
+			nni_mtx_unlock(&s->lk);
+			return (NNG_ENOMEM);
+		}
+	} else {
+		newtopic->buf = NULL;
 	}
 	NNI_LIST_NODE_INIT(&newtopic->node);
 	newtopic->len = sz;


### PR DESCRIPTION
Windows actually allocates an object of size zero when calling
malloc on size zero.  This is unusual behavior, and we just
add logic to work more like malloc on POSIX systems.
