### PR TITLE
fixes #664 aio cancellation could be better

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -18,7 +18,7 @@
 
 typedef struct nni_aio_ops nni_aio_ops;
 
-typedef void (*nni_aio_cancelfn)(nni_aio *, int);
+typedef void (*nni_aio_cancelfn)(nni_aio *, void *, int);
 
 // nni_aio_init initializes an aio object.  The callback is called with
 // the supplied argument when the operation is complete.  If NULL is

--- a/src/core/msgqueue.c
+++ b/src/core/msgqueue.c
@@ -315,9 +315,9 @@ nni_msgq_run_notify(nni_msgq *mq)
 }
 
 static void
-nni_msgq_cancel(nni_aio *aio, int rv)
+nni_msgq_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_msgq *mq = nni_aio_get_prov_data(aio);
+	nni_msgq *mq = arg;
 
 	nni_mtx_lock(&mq->mq_lock);
 	if (nni_aio_list_active(aio)) {

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -247,9 +247,9 @@ ipc_conn_cb(nni_posix_pfd *pfd, int events, void *arg)
 }
 
 static void
-ipc_conn_cancel(nni_aio *aio, int rv)
+ipc_conn_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ipc_conn *c = nni_aio_get_prov_data(aio);
+	nni_ipc_conn *c = arg;
 
 	nni_mtx_lock(&c->mtx);
 	if (nni_aio_list_active(aio)) {
@@ -352,7 +352,7 @@ ipc_conn_peerid(nni_ipc_conn *c, uint64_t *euid, uint64_t *egid,
 	return (0);
 #elif defined(NNG_HAVE_SOCKPEERCRED)
 	struct sockpeercred uc;
-	socklen_t len = sizeof(uc);
+	socklen_t           len = sizeof(uc);
 	if (getsockopt(fd, SOL_SOCKET, SO_PEERCRED, &uc, &len) != 0) {
 		return (nni_plat_errno(errno));
 	}

--- a/src/platform/posix/posix_ipcdial.c
+++ b/src/platform/posix/posix_ipcdial.c
@@ -78,9 +78,9 @@ nni_ipc_dialer_fini(nni_ipc_dialer *d)
 }
 
 static void
-ipc_dialer_cancel(nni_aio *aio, int rv)
+ipc_dialer_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ipc_dialer *d = nni_aio_get_prov_data(aio);
+	nni_ipc_dialer *d = arg;
 	nni_ipc_conn *  c;
 
 	nni_mtx_lock(&d->mtx);

--- a/src/platform/posix/posix_ipclisten.c
+++ b/src/platform/posix/posix_ipclisten.c
@@ -172,9 +172,9 @@ ipc_listener_cb(nni_posix_pfd *pfd, int events, void *arg)
 }
 
 static void
-ipc_listener_cancel(nni_aio *aio, int rv)
+ipc_listener_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ipc_listener *l = nni_aio_get_prov_data(aio);
+	nni_ipc_listener *l = arg;
 
 	// This is dead easy, because we'll ignore the completion if there
 	// isn't anything to do the accept on!

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -243,9 +243,9 @@ tcp_conn_cb(nni_posix_pfd *pfd, int events, void *arg)
 }
 
 static void
-tcp_conn_cancel(nni_aio *aio, int rv)
+tcp_conn_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_conn *c = nni_aio_get_prov_data(aio);
+	nni_tcp_conn *c = arg;
 
 	nni_mtx_lock(&c->mtx);
 	if (nni_aio_list_active(aio)) {

--- a/src/platform/posix/posix_tcpdial.c
+++ b/src/platform/posix/posix_tcpdial.c
@@ -78,9 +78,9 @@ nni_tcp_dialer_fini(nni_tcp_dialer *d)
 }
 
 static void
-tcp_dialer_cancel(nni_aio *aio, int rv)
+tcp_dialer_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_dialer *d = nni_aio_get_prov_data(aio);
+	nni_tcp_dialer *d = arg;
 	nni_tcp_conn *  c;
 
 	nni_mtx_lock(&d->mtx);

--- a/src/platform/posix/posix_tcplisten.c
+++ b/src/platform/posix/posix_tcplisten.c
@@ -165,9 +165,9 @@ tcp_listener_cb(nni_posix_pfd *pfd, int events, void *arg)
 }
 
 static void
-tcp_listener_cancel(nni_aio *aio, int rv)
+tcp_listener_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_listener *l = nni_aio_get_prov_data(aio);
+	nni_tcp_listener *l = arg;
 
 	// This is dead easy, because we'll ignore the completion if there
 	// isn't anything to do the accept on!

--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -269,9 +269,9 @@ nni_plat_udp_close(nni_plat_udp *udp)
 }
 
 void
-nni_plat_udp_cancel(nni_aio *aio, int rv)
+nni_plat_udp_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_plat_udp *udp = nni_aio_get_prov_data(aio);
+	nni_plat_udp *udp = arg;
 
 	nni_mtx_lock(&udp->udp_mtx);
 	if (nni_aio_list_active(aio)) {

--- a/src/platform/windows/win_iocp.c
+++ b/src/platform/windows/win_iocp.c
@@ -87,9 +87,9 @@ nni_win_iocp_handler(void *arg)
 }
 
 static void
-nni_win_event_cancel(nni_aio *aio, int rv)
+nni_win_event_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_win_event *evt = nni_aio_get_prov_data(aio);
+	nni_win_event *evt = arg;
 
 	nni_mtx_lock(&evt->mtx);
 	if (aio == evt->active) {

--- a/src/platform/windows/win_ipcconn.c
+++ b/src/platform/windows/win_ipcconn.c
@@ -100,9 +100,9 @@ ipc_recv_cb(nni_win_io *io, int rv, size_t num)
 	nni_aio_finish_synch(aio, rv, num);
 }
 static void
-ipc_recv_cancel(nni_aio *aio, int rv)
+ipc_recv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ipc_conn *c = nni_aio_get_prov_data(aio);
+	nni_ipc_conn *c = arg;
 	nni_mtx_lock(&c->mtx);
 	if (aio == nni_list_first(&c->recv_aios)) {
 		c->recv_rv = rv;
@@ -226,9 +226,9 @@ ipc_send_cb(nni_win_io *io, int rv, size_t num)
 }
 
 static void
-ipc_send_cancel(nni_aio *aio, int rv)
+ipc_send_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ipc_conn *c = nni_aio_get_prov_data(aio);
+	nni_ipc_conn *c = arg;
 	nni_mtx_lock(&c->mtx);
 	if (aio == nni_list_first(&c->send_aios)) {
 		c->send_rv = rv;

--- a/src/platform/windows/win_ipcdial.c
+++ b/src/platform/windows/win_ipcdial.c
@@ -134,10 +134,10 @@ ipc_dial_thr(void *arg)
 }
 
 static void
-ipc_dial_cancel(nni_aio *aio, int rv)
+ipc_dial_cancel(nni_aio *aio, void *arg, int rv)
 {
+	nni_ipc_dialer *d = arg;
 	ipc_dial_work * w = &ipc_connecter;
-	nni_ipc_dialer *d = nni_aio_get_prov_data(aio);
 
 	nni_mtx_lock(&w->mtx);
 	if (nni_aio_list_active(aio)) {

--- a/src/platform/windows/win_ipclisten.c
+++ b/src/platform/windows/win_ipclisten.c
@@ -222,9 +222,9 @@ nni_ipc_listener_listen(nni_ipc_listener *l, const nni_sockaddr *sa)
 }
 
 static void
-ipc_accept_cancel(nni_aio *aio, int rv)
+ipc_accept_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ipc_listener *l = nni_aio_get_prov_data(aio);
+	nni_ipc_listener *l = arg;
 
 	nni_mtx_unlock(&l->mtx);
 	if (aio == nni_list_first(&l->aios)) {

--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -45,16 +45,16 @@ struct resolv_item {
 };
 
 static void
-resolv_cancel(nni_aio *aio, int rv)
+resolv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	resolv_item *item;
+	resolv_item *item = arg;
 
 	nni_mtx_lock(&resolv_mtx);
-	if ((item = nni_aio_get_prov_data(aio)) == NULL) {
+	if (item != nni_aio_get_prov_extra(aio, 0)) {
 		nni_mtx_unlock(&resolv_mtx);
 		return;
 	}
-	nni_aio_set_prov_data(aio, NULL);
+	nni_aio_set_prov_extra(aio, 0, NULL);
 	if (nni_aio_list_active(aio)) {
 		// We have not been picked up by a resolver thread yet,
 		// so we can just discard everything.
@@ -236,6 +236,7 @@ resolv_ip(const char *host, const char *serv, int passive, int family,
 	if (resolv_fini) {
 		rv = NNG_ECLOSED;
 	} else {
+		nni_aio_set_prov_extra(aio, 0, item);
 		rv = nni_aio_schedule(aio, resolv_cancel, item);
 	}
 	if (rv != 0) {
@@ -283,7 +284,7 @@ resolv_worker(void *notused)
 			continue;
 		}
 
-		item = nni_aio_get_prov_data(aio);
+		item = nni_aio_get_prov_extra(aio, 0);
 		nni_aio_list_remove(aio);
 
 		// Now attempt to do the work.  This runs synchronously.
@@ -294,7 +295,7 @@ resolv_worker(void *notused)
 		// Check to make sure we were not canceled.
 		if ((aio = item->aio) != NULL) {
 			nng_sockaddr *sa = nni_aio_get_input(aio, 0);
-			nni_aio_set_prov_data(aio, NULL);
+			nni_aio_set_prov_extra(aio, 0, NULL);
 			item->aio = NULL;
 			memcpy(sa, &item->sa, sizeof(*sa));
 			nni_aio_finish(aio, rv, 0);

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -96,9 +96,9 @@ tcp_recv_cb(nni_win_io *io, int rv, size_t num)
 }
 
 static void
-tcp_recv_cancel(nni_aio *aio, int rv)
+tcp_recv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_conn *c = nni_aio_get_prov_data(aio);
+	nni_tcp_conn *c = arg;
 	nni_mtx_lock(&c->mtx);
 	if (aio == nni_list_first(&c->recv_aios)) {
 		c->recv_rv = rv;
@@ -186,9 +186,9 @@ again:
 }
 
 static void
-tcp_send_cancel(nni_aio *aio, int rv)
+tcp_send_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_conn *c = nni_aio_get_prov_data(aio);
+	nni_tcp_conn *c = arg;
 	nni_mtx_lock(&c->mtx);
 	if (aio == nni_list_first(&c->send_aios)) {
 		c->send_rv = rv;

--- a/src/platform/windows/win_tcpdial.c
+++ b/src/platform/windows/win_tcpdial.c
@@ -94,9 +94,9 @@ nni_tcp_dialer_fini(nni_tcp_dialer *d)
 }
 
 static void
-tcp_dial_cancel(nni_aio *aio, int rv)
+tcp_dial_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_dialer *d = nni_aio_get_prov_data(aio);
+	nni_tcp_dialer *d = arg;
 	nni_tcp_conn *  c;
 
 	nni_mtx_lock(&d->mtx);

--- a/src/platform/windows/win_tcplisten.c
+++ b/src/platform/windows/win_tcplisten.c
@@ -236,9 +236,9 @@ nni_tcp_listener_listen(nni_tcp_listener *l, nni_sockaddr *sa)
 }
 
 static void
-tcp_accept_cancel(nni_aio *aio, int rv)
+tcp_accept_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tcp_listener *l = nni_aio_get_prov_data(aio);
+	nni_tcp_listener *l = arg;
 	nni_tcp_conn *    c;
 
 	nni_mtx_lock(&l->mtx);

--- a/src/protocol/reqrep0/rep.c
+++ b/src/protocol/reqrep0/rep.c
@@ -131,9 +131,9 @@ rep0_ctx_init(void **ctxp, void *sarg)
 }
 
 static void
-rep0_ctx_cancel_send(nni_aio *aio, int rv)
+rep0_ctx_cancel_send(nni_aio *aio, void *arg, int rv)
 {
-	rep0_ctx * ctx = nni_aio_get_prov_data(aio);
+	rep0_ctx * ctx = arg;
 	rep0_sock *s   = ctx->sock;
 
 	nni_mtx_lock(&s->lk);
@@ -448,9 +448,9 @@ rep0_pipe_send_cb(void *arg)
 }
 
 static void
-rep0_cancel_recv(nni_aio *aio, int rv)
+rep0_cancel_recv(nni_aio *aio, void *arg, int rv)
 {
-	rep0_ctx * ctx = nni_aio_get_prov_data(aio);
+	rep0_ctx * ctx = arg;
 	rep0_sock *s   = ctx->sock;
 
 	nni_mtx_lock(&s->lk);

--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -590,9 +590,9 @@ req0_ctx_reset(req0_ctx *ctx)
 }
 
 static void
-req0_ctx_cancel_recv(nni_aio *aio, int rv)
+req0_ctx_cancel_recv(nni_aio *aio, void *arg, int rv)
 {
-	req0_ctx * ctx = nni_aio_get_prov_data(aio);
+	req0_ctx * ctx = arg;
 	req0_sock *s   = ctx->sock;
 
 	nni_mtx_lock(&s->mtx);
@@ -666,9 +666,9 @@ req0_ctx_recv(void *arg, nni_aio *aio)
 }
 
 static void
-req0_ctx_cancel_send(nni_aio *aio, int rv)
+req0_ctx_cancel_send(nni_aio *aio, void *arg, int rv)
 {
-	req0_ctx * ctx = nni_aio_get_prov_data(aio);
+	req0_ctx * ctx = arg;
 	req0_sock *s   = ctx->sock;
 
 	nni_mtx_lock(&s->mtx);

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -133,9 +133,9 @@ resp0_ctx_init(void **ctxp, void *sarg)
 }
 
 static void
-resp0_ctx_cancel_send(nni_aio *aio, int rv)
+resp0_ctx_cancel_send(nni_aio *aio, void *arg, int rv)
 {
-	resp0_ctx * ctx = nni_aio_get_prov_data(aio);
+	resp0_ctx * ctx = arg;
 	resp0_sock *s   = ctx->sock;
 
 	nni_mtx_lock(&s->mtx);
@@ -437,9 +437,9 @@ resp0_pipe_send_cb(void *arg)
 }
 
 static void
-resp0_cancel_recv(nni_aio *aio, int rv)
+resp0_cancel_recv(nni_aio *aio, void *arg, int rv)
 {
-	resp0_ctx * ctx = nni_aio_get_prov_data(aio);
+	resp0_ctx * ctx = arg;
 	resp0_sock *s   = ctx->sock;
 
 	nni_mtx_lock(&s->mtx);

--- a/src/supplemental/http/http_client.c
+++ b/src/supplemental/http/http_client.c
@@ -232,9 +232,9 @@ nni_http_client_get_tls(nni_http_client *c, struct nng_tls_config **tlsp)
 }
 
 static void
-http_dial_cancel(nni_aio *aio, int rv)
+http_dial_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_http_client *c = nni_aio_get_prov_data(aio);
+	nni_http_client *c = arg;
 	nni_mtx_lock(&c->mtx);
 	if (nni_aio_list_active(aio)) {
 		nni_aio_list_remove(aio);

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -350,9 +350,9 @@ http_rd_cb(void *arg)
 }
 
 static void
-http_rd_cancel(nni_aio *aio, int rv)
+http_rd_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_http_conn *conn = nni_aio_get_prov_data(aio);
+	nni_http_conn *conn = arg;
 
 	nni_mtx_lock(&conn->mtx);
 	if (aio == conn->rd_uaio) {
@@ -469,9 +469,9 @@ done:
 }
 
 static void
-http_wr_cancel(nni_aio *aio, int rv)
+http_wr_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_http_conn *conn = nni_aio_get_prov_data(aio);
+	nni_http_conn *conn = arg;
 
 	nni_mtx_lock(&conn->mtx);
 	if (aio == conn->wr_uaio) {

--- a/src/supplemental/tls/mbedtls/tls.c
+++ b/src/supplemental/tls/mbedtls/tls.c
@@ -371,9 +371,9 @@ nni_tls_init(nni_tls **tpp, nng_tls_config *cfg, nni_tcp_conn *tcp)
 }
 
 static void
-nni_tls_cancel(nni_aio *aio, int rv)
+nni_tls_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_tls *tp = nni_aio_get_prov_data(aio);
+	nni_tls *tp = arg;
 	nni_mtx_lock(&tp->lk);
 	if (nni_aio_list_active(aio)) {
 		nni_aio_list_remove(aio);

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -517,9 +517,9 @@ ws_start_write(nni_ws *ws)
 }
 
 static void
-ws_cancel_close(nni_aio *aio, int rv)
+ws_cancel_close(nni_aio *aio, void *arg, int rv)
 {
-	nni_ws *ws = nni_aio_get_prov_data(aio);
+	nni_ws *ws = arg;
 	nni_mtx_lock(&ws->mtx);
 	if (ws->wclose) {
 		ws->wclose = false;
@@ -616,15 +616,13 @@ ws_write_cb(void *arg)
 }
 
 static void
-ws_write_cancel(nni_aio *aio, int rv)
+ws_write_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ws *  ws;
+	nni_ws *  ws = arg;
 	ws_msg *  wm;
 	ws_frame *frame;
 
-	// Is this aio active?  We can tell by looking at the
-	// active tx frame.
-	ws = nni_aio_get_prov_data(aio);
+	// Is this aio active?  We can tell by looking at the active tx frame.
 
 	nni_mtx_lock(&ws->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -1038,9 +1036,9 @@ ws_read_cb(void *arg)
 }
 
 static void
-ws_read_cancel(nni_aio *aio, int rv)
+ws_read_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ws *ws = nni_aio_get_prov_data(aio);
+	nni_ws *ws = arg;
 	ws_msg *wm;
 
 	nni_mtx_lock(&ws->mtx);
@@ -1676,9 +1674,9 @@ nni_ws_listener_proto(nni_ws_listener *l, const char *proto)
 }
 
 static void
-ws_accept_cancel(nni_aio *aio, int rv)
+ws_accept_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ws_listener *l = nni_aio_get_prov_data(aio);
+	nni_ws_listener *l = arg;
 
 	nni_mtx_lock(&l->mtx);
 	if (nni_aio_list_active(aio)) {
@@ -2031,9 +2029,9 @@ nni_ws_dialer_proto(nni_ws_dialer *d, const char *proto)
 }
 
 static void
-ws_dial_cancel(nni_aio *aio, int rv)
+ws_dial_cancel(nni_aio *aio, void *arg, int rv)
 {
-	nni_ws *ws = nni_aio_get_prov_data(aio);
+	nni_ws *ws = arg;
 
 	nni_mtx_lock(&ws->mtx);
 	if (aio == ws->useraio) {

--- a/src/transport/ipc/ipc.c
+++ b/src/transport/ipc/ipc.c
@@ -451,9 +451,9 @@ error:
 }
 
 static void
-ipctran_pipe_send_cancel(nni_aio *aio, int rv)
+ipctran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ipctran_pipe *p = nni_aio_get_prov_data(aio);
+	ipctran_pipe *p = arg;
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -544,9 +544,9 @@ ipctran_pipe_send(void *arg, nni_aio *aio)
 }
 
 static void
-ipctran_pipe_recv_cancel(nni_aio *aio, int rv)
+ipctran_pipe_recv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ipctran_pipe *p = nni_aio_get_prov_data(aio);
+	ipctran_pipe *p = arg;
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -686,9 +686,9 @@ ipctran_pipe_get_peer_zoneid(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static void
-ipctran_pipe_conn_cancel(nni_aio *aio, int rv)
+ipctran_pipe_conn_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ipctran_pipe *p = nni_aio_get_prov_data(aio);
+	ipctran_pipe *p = arg;
 
 	nni_mtx_lock(&p->ep->mtx);
 	if (aio == p->useraio) {

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -193,9 +193,9 @@ tcptran_pipe_init(tcptran_pipe **pipep, tcptran_ep *ep)
 }
 
 static void
-tcptran_pipe_conn_cancel(nni_aio *aio, int rv)
+tcptran_pipe_conn_cancel(nni_aio *aio, void *arg, int rv)
 {
-	tcptran_pipe *p = nni_aio_get_prov_data(aio);
+	tcptran_pipe *p = arg;
 
 	nni_mtx_lock(&p->ep->mtx);
 	if (aio == p->useraio) {
@@ -483,9 +483,9 @@ recv_error:
 }
 
 static void
-tcptran_pipe_send_cancel(nni_aio *aio, int rv)
+tcptran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 {
-	tcptran_pipe *p = nni_aio_get_prov_data(aio);
+	tcptran_pipe *p = arg;
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -576,9 +576,9 @@ tcptran_pipe_send(void *arg, nni_aio *aio)
 }
 
 static void
-tcptran_pipe_recv_cancel(nni_aio *aio, int rv)
+tcptran_pipe_recv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	tcptran_pipe *p = nni_aio_get_prov_data(aio);
+	tcptran_pipe *p = arg;
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {

--- a/src/transport/tls/tls.c
+++ b/src/transport/tls/tls.c
@@ -197,9 +197,9 @@ tlstran_pipe_reap(tlstran_pipe *p)
 }
 
 static void
-tlstran_pipe_conn_cancel(nni_aio *aio, int rv)
+tlstran_pipe_conn_cancel(nni_aio *aio, void *arg, int rv)
 {
-	tlstran_pipe *p = nni_aio_get_prov_data(aio);
+	tlstran_pipe *p = arg;
 
 	nni_mtx_lock(&p->ep->mtx);
 	if (aio == p->useraio) {
@@ -493,9 +493,9 @@ recv_error:
 }
 
 static void
-tlstran_pipe_send_cancel(nni_aio *aio, int rv)
+tlstran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 {
-	tlstran_pipe *p = nni_aio_get_prov_data(aio);
+	tlstran_pipe *p = arg;
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {
@@ -578,9 +578,9 @@ tlstran_pipe_send(void *arg, nni_aio *aio)
 }
 
 static void
-tlstran_pipe_recv_cancel(nni_aio *aio, int rv)
+tlstran_pipe_recv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	tlstran_pipe *p = nni_aio_get_prov_data(aio);
+	tlstran_pipe *p = arg;
 
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_list_active(aio)) {

--- a/src/transport/ws/websocket.c
+++ b/src/transport/ws/websocket.c
@@ -120,9 +120,9 @@ ws_pipe_recv_cb(void *arg)
 }
 
 static void
-ws_pipe_recv_cancel(nni_aio *aio, int rv)
+ws_pipe_recv_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ws_pipe *p = nni_aio_get_prov_data(aio);
+	ws_pipe *p = arg;
 	nni_mtx_lock(&p->mtx);
 	if (p->user_rxaio != aio) {
 		nni_mtx_unlock(&p->mtx);
@@ -155,9 +155,9 @@ ws_pipe_recv(void *arg, nni_aio *aio)
 }
 
 static void
-ws_pipe_send_cancel(nni_aio *aio, int rv)
+ws_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ws_pipe *p = nni_aio_get_prov_data(aio);
+	ws_pipe *p = arg;
 	nni_mtx_lock(&p->mtx);
 	if (p->user_txaio != aio) {
 		nni_mtx_unlock(&p->mtx);
@@ -299,9 +299,9 @@ ws_listener_bind(void *arg)
 }
 
 static void
-ws_listener_cancel(nni_aio *aio, int rv)
+ws_listener_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ws_listener *l = nni_aio_get_prov_data(aio);
+	ws_listener *l = arg;
 
 	nni_mtx_lock(&l->mtx);
 	if (nni_aio_list_active(aio)) {
@@ -337,9 +337,9 @@ ws_listener_accept(void *arg, nni_aio *aio)
 }
 
 static void
-ws_dialer_cancel(nni_aio *aio, int rv)
+ws_dialer_cancel(nni_aio *aio, void *arg, int rv)
 {
-	ws_dialer *d = nni_aio_get_prov_data(aio);
+	ws_dialer *d = arg;
 
 	nni_mtx_lock(&d->mtx);
 	if (nni_aio_list_active(aio)) {

--- a/src/transport/zerotier/zerotier.c
+++ b/src/transport/zerotier/zerotier.c
@@ -1840,9 +1840,9 @@ zt_pipe_send(void *arg, nni_aio *aio)
 }
 
 static void
-zt_pipe_cancel_recv(nni_aio *aio, int rv)
+zt_pipe_cancel_recv(nni_aio *aio, void *arg, int rv)
 {
-	zt_pipe *p = nni_aio_get_prov_data(aio);
+	zt_pipe *p = arg;
 	nni_mtx_lock(&zt_lk);
 	if (p->zp_user_rxaio == aio) {
 		p->zp_user_rxaio = NULL;
@@ -2331,9 +2331,9 @@ zt_ep_bind(void *arg)
 }
 
 static void
-zt_ep_cancel(nni_aio *aio, int rv)
+zt_ep_cancel(nni_aio *aio, void *arg, int rv)
 {
-	zt_ep *ep = nni_aio_get_prov_data(aio);
+	zt_ep *ep = arg;
 
 	nni_mtx_lock(&zt_lk);
 	if (nni_aio_list_active(aio)) {
@@ -2417,9 +2417,9 @@ zt_ep_accept(void *arg, nni_aio *aio)
 }
 
 static void
-zt_ep_conn_req_cancel(nni_aio *aio, int rv)
+zt_ep_conn_req_cancel(nni_aio *aio, void *arg, int rv)
 {
-	zt_ep *ep = nni_aio_get_prov_data(aio);
+	zt_ep *ep = arg;
 	// We don't have much to do here.  The AIO will have been
 	// canceled as a result of the "parent" AIO canceling.
 	nni_mtx_lock(&zt_lk);


### PR DESCRIPTION
This changes the signature of the aio cancellation routines
to take the argument for cancellation directly, so we do not
need to lookup the argument using the nni_aio_get_prov_data.

We should probably consider eliminating nni_aio_get_prov_data,
and co, and changing the prov_extra to reflect prov_data.  Later.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
