### PR TITLE
fixes #506 AIO "providers" need a way to call nni_aio_schedule.

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -62,8 +62,10 @@ if (NNG_ENABLE_DOC)
 	libnng
 	nng_aio_abort
 	nng_aio_alloc
+	nng_aio_begin
 	nng_aio_cancel
 	nng_aio_count
+	nng_aio_defer
 	nng_aio_finish
 	nng_aio_free
 	nng_aio_get_input

--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -152,9 +152,11 @@ The following functions are used in the asynchronous model:
 |===
 |<<nng_aio_abort.3#,nng_aio_abort()>>|abort asynchronous I/O operation
 |<<nng_aio_alloc.3#,nng_aio_alloc()>>|allocate asynchronous I/O handle
+|<<nng_aio_begin.3#,nng_aio_begin()>>|begin asynchronous I/O operation
 |<<nng_aio_cancel.3#,nng_aio_cancel()>>|cancel asynchronous I/O operation
 |<<nng_aio_count.3#,nng_aio_count()>>|return number of bytes transferred
-|<<nng_aio_finish.3#,nng_aio_finish()>>|finish an asynchronous I/O operation
+|<<nng_aio_defer.3#,nng_aio_defer()>>|defer asynchronous I/O operation
+|<<nng_aio_finish.3#,nng_aio_finish()>>|finish asynchronous I/O operation
 |<<nng_aio_free.3#,nng_aio_free()>>|free asynchronous I/O handle
 |<<nng_aio_get_input.3#,nng_aio_get_input()>>|return input parameter
 |<<nng_aio_get_msg.3#,nng_aio_get_msg()>>|get message from an asynchronous receive

--- a/docs/man/nng_aio_begin.3.adoc
+++ b/docs/man/nng_aio_begin.3.adoc
@@ -1,0 +1,64 @@
+= nng_aio_begin(3)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_aio_begin - begin asynchronous I/O operation
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+
+bool nng_aio_begin(nng_aio *aio);
+----
+
+== DESCRIPTION
+
+The `nng_aio_begin()` function is called by the I/O provider to indicate that
+it is going to process the operation.
+
+The function may return `false`, indicating that the _aio_ has been closed
+by the caller asynchronously.
+In this case the provider should abandon the operation and do nothing else.
+
+This operation should be called at the start of any I/O operation, and must
+be called not more than once for a given I/O operation on a given _aio_.
+
+Once this function is called, if `true` is returned, then the provider MUST
+guarantee that `<<nng_aio_finish.3#nng_aio_finish()>>` is called for the _aio_
+exactly once, when the operation is complete or canceled.
+
+NOTE: This function is only for I/O providers (those actually performing
+the operation such as HTTP handler functions or transport providers); ordinary
+users of the _aio_ should not call this function.
+
+== RETURN VALUES
+
+[horizontal]
+`true`:: The operation has been started.
+`false`:: The operation cannot be started.
+
+== ERRORS
+
+None.
+
+== SEE ALSO
+
+[.text-left]
+<<nng_aio_alloc.3#,nng_aio_alloc(3)>>,
+<<nng_aio_cancel.3#,nng_aio_cancel(3)>>,
+<<nng_aio_defer.3#,nng_aio_defer(3)>>,
+<<nng_aio_finish.3#,nng_aio_finish(3)>>,
+<<nng_aio_result.3#,nng_aio_result(3)>>,
+<<nng_aio.5#,nng_aio(5)>>,
+<<nng.7#,nng(7)>>

--- a/docs/man/nng_aio_defer.3.adoc
+++ b/docs/man/nng_aio_defer.3.adoc
@@ -1,0 +1,78 @@
+= nng_aio_defer(3)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_aio_defer - defer asynchronous I/O operation
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+
+typedef void (*nng_aio_cancelfn)(nng_aio *aio, void *arg, int err);
+
+void nng_aio_defer(nng_aio *aio, nng_aio_cancelfn fn, void *arg);
+----
+
+== DESCRIPTION
+
+The `nng_aio_defer()` function marks operation associated with _aio_ as
+being deferred for asynchronous completion, and also registers a cancellation
+function _fn_ and associated argument _arg_, thereby
+permitting the operation to be canceled.
+
+If the _aio_ is being canceled, the cancellation routine _fn_ will be called
+with the _aio_, the _arg_ specified by `nng_aio_defer()`, and an error
+value in _err_, which is the reason that the operation is being canceled.
+
+The operation may not be cancelable; for example it may have already been
+completed, or be in a state where it is no longer possible to unschedule it.
+In this case, the _cancelfn_ should just return without making any changes.
+
+If the cancellation routine successfully canceled the operation, it should
+ensure that `<<nng_aio_finish.3#,nng_aio_finish()>>` is called, with the
+error code specified by _err_.
+
+IMPORTANT: It is mandatory that I/O providers call
+`<<nng_aio_finish.3#,nng_aio_finish()>>`
+*EXACTLY ONCE* when they are finished with the operation.
+
+NOTE: This function is only for I/O providers (those actually performing
+the operation such as HTTP handler functions or transport providers); ordinary
+users of the _aio_ should not call this function.
+
+NOTE: Care must be taken to ensure that cancellation and completion of
+the routine are multi-thread safe; this will usually involve the use
+of locks or other synchronization primitives.
+
+TIP: For operations that complete synchronously, without any need to be
+deferred, the provider should not bother to call `nng_aio_defer()`,
+although it is harmless if it does.
+
+== RETURN VALUES
+
+None.
+
+== ERRORS
+
+None.
+
+== SEE ALSO
+
+[.text-left]
+<<nng_aio_alloc.3#,nng_aio_alloc(3)>>,
+<<nng_aio_cancel.3#,nng_aio_cancel(3)>>,
+<<nng_aio_finish.3#,nng_aio_finish(3)>>,
+<<nng_aio_result.3#,nng_aio_result(3)>>,
+<<nng_aio.5#,nng_aio(5)>>,
+<<nng.7#,nng(7)>>

--- a/docs/man/nng_aio_finish.3.adoc
+++ b/docs/man/nng_aio_finish.3.adoc
@@ -52,7 +52,9 @@ None.
 
 [.text-left]
 <<nng_aio_alloc.3#,nng_aio_alloc(3)>>,
+<<nng_aio_begin.3#,nng_aio_begin(3)>>,
 <<nng_aio_cancel.3#,nng_aio_cancel(3)>>,
+<<nng_aio_defer.3#,nng_aio_defer(3)>>,
 <<nng_aio_result.3#,nng_aio_result(3)>>,
 <<nng_aio.5#,nng_aio(5)>>,
 <<nng.7#,nng(7)>>

--- a/docs/man/nng_http_handler_alloc.3http.adoc
+++ b/docs/man/nng_http_handler_alloc.3http.adoc
@@ -63,7 +63,8 @@ The generic (first) form of this creates a handler that uses a user-supplied
 function to process HTTP requests.
 This function uses the asynchronous I/O framework.
 The function takes a pointer to an `<<nng_aio.5#,nng_aio>>` structure.
-That structure will be passed with the following input values (retrieved with
+
+The _aio_ will be passed with the following input values (retrieved with
 `<<nng_aio_get_input.3#,nng_aio_get_input()>>`):
 
    0: `nng_http_req *` __request__:: The client's HTTP request.
@@ -85,6 +86,13 @@ _aio_ should be completed successfully.
 If any non-zero status is returned back to the caller instead,
 then a generic 500 response will be created and
 sent, if possible, and the connection will be closed.
+
+The _aio_ may be scheduled for deferred completion using the
+`<<nng_aio_defer.3#,nng_aio_defer()>>` function.
+
+NOTE: The callback function should *NOT* call
+`<<nng_aio_begin.3#,nng_aio_begin()>>`,
+as that will already have been done by the server framework.
 
 === Directory Handler
 
@@ -137,6 +145,7 @@ This function returns 0 on success, and non-zero otherwise.
 == SEE ALSO
 
 [.text-left]
+<<nng_aio_defer.3#,nng_aio_defer(3)>>,
 <<nng_aio_finish.3#,nng_aio_finish(3)>>,
 <<nng_aio_get_input.3#,nng_aio_get_input(3)>>,
 <<nng_aio_set_output.3#,nng_aio_set_output(3)>>,

--- a/src/nng.c
+++ b/src/nng.c
@@ -1601,6 +1601,21 @@ nng_aio_finish(nng_aio *aio, int rv)
 	nni_aio_finish(aio, rv, nni_aio_count(aio));
 }
 
+void
+nng_aio_defer(nng_aio *aio, nng_aio_cancelfn fn, void *arg)
+{
+	nni_aio_schedule(aio, fn, arg);
+}
+
+bool
+nng_aio_begin(nng_aio *aio)
+{
+	if (nni_aio_begin(aio) != 0) {
+		return (false);
+	}
+	return (true);
+}
+
 #if 0
 int
 nng_snapshot_create(nng_socket sock, nng_snapshot **snapp)


### PR DESCRIPTION
This also creates the nng_aio_begin and nng_aio_defer APIs, and documents and tests them.