### PR TITLE
Fix673

### DIFF
--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -112,7 +112,7 @@ nni_dialer_create(nni_dialer **dp, nni_sock *s, const char *urlstr)
 
 	if (((rv = nni_aio_init(&d->d_con_aio, dialer_connect_cb, d)) != 0) ||
 	    ((rv = nni_aio_init(&d->d_tmo_aio, dialer_timer_cb, d)) != 0) ||
-	    ((rv = d->d_ops.d_init(&d->d_data, url, s)) != 0) ||
+	    ((rv = d->d_ops.d_init(&d->d_data, url, d)) != 0) ||
 	    ((rv = nni_idhash_alloc32(dialers, &d->d_id, d)) != 0) ||
 	    ((rv = nni_sock_add_dialer(s, d)) != 0)) {
 		nni_dialer_destroy(d);
@@ -300,6 +300,12 @@ nni_dialer_start(nni_dialer *d, int flags)
 	}
 
 	return (rv);
+}
+
+nni_sock *
+nni_dialer_sock(nni_dialer *d)
+{
+	return (d->d_sock);
 }
 
 int

--- a/src/core/dialer.h
+++ b/src/core/dialer.h
@@ -11,15 +11,16 @@
 #ifndef CORE_DIALER_H
 #define CORE_DIALER_H
 
-extern int      nni_dialer_sys_init(void);
-extern void     nni_dialer_sys_fini(void);
-extern int      nni_dialer_find(nni_dialer **, uint32_t);
-extern int      nni_dialer_hold(nni_dialer *);
-extern void     nni_dialer_rele(nni_dialer *);
-extern uint32_t nni_dialer_id(nni_dialer *);
-extern int      nni_dialer_create(nni_dialer **, nni_sock *, const char *);
-extern void     nni_dialer_close(nni_dialer *);
-extern int      nni_dialer_start(nni_dialer *, int);
+extern int       nni_dialer_sys_init(void);
+extern void      nni_dialer_sys_fini(void);
+extern int       nni_dialer_find(nni_dialer **, uint32_t);
+extern int       nni_dialer_hold(nni_dialer *);
+extern void      nni_dialer_rele(nni_dialer *);
+extern uint32_t  nni_dialer_id(nni_dialer *);
+extern int       nni_dialer_create(nni_dialer **, nni_sock *, const char *);
+extern void      nni_dialer_close(nni_dialer *);
+extern int       nni_dialer_start(nni_dialer *, int);
+extern nni_sock *nni_dialer_sock(nni_dialer *);
 
 extern int nni_dialer_setopt(
     nni_dialer *, const char *, const void *, size_t, nni_opt_type);

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -110,7 +110,7 @@ nni_listener_create(nni_listener **lp, nni_sock *s, const char *urlstr)
 
 	if (((rv = nni_aio_init(&l->l_acc_aio, listener_accept_cb, l)) != 0) ||
 	    ((rv = nni_aio_init(&l->l_tmo_aio, listener_timer_cb, l)) != 0) ||
-	    ((rv = l->l_ops.l_init(&l->l_data, url, s)) != 0) ||
+	    ((rv = l->l_ops.l_init(&l->l_data, url, l)) != 0) ||
 	    ((rv = nni_idhash_alloc32(listeners, &l->l_id, l)) != 0) ||
 	    ((rv = nni_sock_add_listener(s, l)) != 0)) {
 		nni_listener_destroy(l);
@@ -282,6 +282,12 @@ nni_listener_start(nni_listener *l, int flags)
 	listener_accept_start(l);
 
 	return (0);
+}
+
+nni_sock *
+nni_listener_sock(nni_listener *l)
+{
+	return (l->l_sock);
 }
 
 int

--- a/src/core/listener.h
+++ b/src/core/listener.h
@@ -20,6 +20,7 @@ extern uint32_t nni_listener_id(nni_listener *);
 extern int      nni_listener_create(nni_listener **, nni_sock *, const char *);
 extern void     nni_listener_close(nni_listener *);
 extern int      nni_listener_start(nni_listener *, int);
+extern nni_sock *nni_listener_sock(nni_listener *);
 
 extern int nni_listener_setopt(
     nni_listener *, const char *, const void *, size_t, nni_opt_type);

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -216,7 +216,7 @@ nni_pipe_create(nni_pipe **pp, nni_sock *sock, nni_tran *tran, void *tdata)
 	}
 	nni_mtx_unlock(&nni_pipe_lk);
 
-	if ((rv != 0) ||
+	if ((rv != 0) || ((rv = tran->tran_pipe->p_init(tdata, p)) != 0) ||
 	    ((rv = pops->pipe_init(&p->p_proto_data, p, sdata)) != 0)) {
 		nni_pipe_close(p);
 		nni_pipe_rele(p);

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -163,6 +163,15 @@ typedef struct nni_atomic_flag nni_atomic_flag;
 extern bool nni_atomic_flag_test_and_set(nni_atomic_flag *);
 extern void nni_atomic_flag_reset(nni_atomic_flag *);
 
+typedef struct nni_atomic_u64 nni_atomic_u64;
+
+extern void     nni_atomic_init64(nni_atomic_u64 *);
+extern void     nni_atomic_inc64(nni_atomic_u64 *, uint64_t);
+extern void     nni_atomic_dec64(nni_atomic_u64 *, uint64_t);
+extern uint64_t nni_atomic_get64(nni_atomic_u64 *);
+extern void     nni_atomic_set64(nni_atomic_u64 *, uint64_t);
+extern uint64_t nni_atomic_swap64(nni_atomic_u64 *, uint64_t);
+
 //
 // Clock Support
 //

--- a/src/core/transport.h
+++ b/src/core/transport.h
@@ -11,13 +11,6 @@
 #ifndef CORE_TRANSPORT_H
 #define CORE_TRANSPORT_H
 
-// Endpoint modes.  Currently used by transports.  Remove this when we make
-// transport dialers and listeners explicit.
-enum nni_ep_mode {
-	NNI_EP_MODE_DIAL   = 1,
-	NNI_EP_MODE_LISTEN = 2,
-};
-
 // We quite intentionally use a signature where the upper word is nonzero,
 // which ensures that if we get garbage we will reject it.  This is more
 // likely to mismatch than all zero bytes would.  The actual version is
@@ -31,7 +24,8 @@ enum nni_ep_mode {
 #define NNI_TRANSPORT_V2 0x54520002
 #define NNI_TRANSPORT_V3 0x54520003
 #define NNI_TRANSPORT_V4 0x54520004
-#define NNI_TRANSPORT_VERSION NNI_TRANSPORT_V4
+#define NNI_TRANSPORT_V5 0x54520005
+#define NNI_TRANSPORT_VERSION NNI_TRANSPORT_V5
 
 // Option handlers.
 struct nni_tran_option {
@@ -68,7 +62,7 @@ struct nni_tran_option {
 struct nni_tran_dialer_ops {
 	// d_init creates a vanilla dialer. The value created is
 	// used for the first argument for all other dialer functions.
-	int (*d_init)(void **, nni_url *, nni_sock *);
+	int (*d_init)(void **, nni_url *, nni_dialer *);
 
 	// d_fini frees the resources associated with the dialer.
 	// The dialer will already have been closed.
@@ -93,7 +87,7 @@ struct nni_tran_dialer_ops {
 struct nni_tran_listener_ops {
 	// l_init creates a vanilla listener. The value created is
 	// used for the first argument for all other listener functions.
-	int (*l_init)(void **, nni_url *, nni_sock *);
+	int (*l_init)(void **, nni_url *, nni_listener *);
 
 	// l_fini frees the resources associated with the listener.
 	// The listener will already have been closed.
@@ -126,6 +120,11 @@ struct nni_tran_listener_ops {
 // pointers back to socket or even enclosing pipe state, are not
 // provided.)
 struct nni_tran_pipe_ops {
+	// p_init initializes the pipe data structures.  The main
+	// purpose of this is so that the pipe will see the upper
+	// layer nni_pipe and get a chance to register stats and such.
+	int (*p_init)(void *, nni_pipe *);
+
 	// p_fini destroys the pipe.  This should clean up all local
 	// resources, including closing files and freeing memory, used
 	// by the pipe.  After this call returns, the system will not

--- a/src/platform/posix/posix_impl.h
+++ b/src/platform/posix/posix_impl.h
@@ -82,10 +82,20 @@ struct nni_plat_flock {
 struct nni_atomic_flag {
 	atomic_flag f;
 };
+
+struct nni_atomic_u64 {
+	_Atomic unsigned long long v;
+};
+
 #else // NNG_HAVE_C11_ATOMIC
 struct nni_atomic_flag {
 	bool f;
 };
+
+struct nni_atomic_flag {
+	uint64_t v;
+};
+
 #endif
 
 #endif

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -52,6 +52,10 @@ struct nni_atomic_flag {
 	unsigned f;
 };
 
+struct nni_atomic_u64 {
+	LONGLONG v;
+};
+
 // nni_win_io is used with io completion ports.  This allows us to get
 // to a specific completion callback without requiring the poller (in the
 // completion port) to know anything about the event itself.

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -121,6 +121,44 @@ nni_atomic_flag_reset(nni_atomic_flag *f)
 	InterlockedExchange(&f->f, 0);
 }
 
+void
+nni_atomic_inc64(nni_atomic_u64 *v, uint64_t bump)
+{
+	InterlockedAddNoFence64(&v->v, (LONGLONG) bump);
+}
+
+void
+nni_atomic_dec64(nni_atomic_u64 *v, uint64_t bump)
+{
+	// Windows lacks a sub, so we add the negative.
+	InterlockedAddNoFence64(&v->v, (0ll - (LONGLONG) bump));
+}
+
+uint64_t
+nni_atomic_get64(nni_atomic_u64 *v)
+{
+
+	return ((uint64_t)(InterlockedExchangeAdd64(&v->v, 0)));
+}
+
+void
+nni_atomic_set64(nni_atomic_u64 *v, uint64_t u)
+{
+	return (InterlockedExchange64(&v->v, (LONGLONG) u));
+}
+
+uint64_t
+nni_atomic_swap64(nni_atomic_u64 *v, uint64_t u)
+{
+	return ((uint64_t)(InterlockedExchange64(&v->v, (LONGLONG) u)));
+}
+
+void
+nni_atomic_init64(nni_atomic_u64 *v)
+{
+	InterlockedExchange64(&v->v, 0);
+}
+
 static unsigned int __stdcall nni_plat_thr_main(void *arg)
 {
 	nni_plat_thr *thr = arg;


### PR DESCRIPTION
This alters the transports in preparation for statistics, by giving them access to upper layer (opaque) handles for the related structures.  The idea being that transports will be able to register statistics on those structures.

This also creates a 64-bit atomic (unsigned) counter, which can be used for incrementing stats.  While atomic, there are no guarantees about ordering, in order to make statistic changes as a inexpensive as possible, while remaining safe.