### PR TITLE
Make docs for old versions and tip point to the correct page

### DIFF
--- a/_includes/tip_version.html
+++ b/_includes/tip_version.html
@@ -4,5 +4,5 @@
 </td><td class="content">
 This documentation is for the TIP of nng and may represent unreleased changes or functionality that is not yet stable.
 The latest released version is {{site.latest}}.
-Please see the <a href="/nng/man/v{{ site.latest }}/nng.html">documentation for
+Please see the <a href="/nng/man/v{{ site.latest }}/index.html">documentation for
 {{site.latest}}</a> for the most up-to-date information.</td><tr></table></div>


### PR DESCRIPTION
All the man page docs that are not the latest released version give a notice, saying that the current docs being viewed are not the latest, and offer a link to the latest.  This fixes the broken link; formerly it was pointing to nng.html, now it points to index.html.