### PR TITLE
fixes #715 nng_opts_parse() uses const incorrectly

### DIFF
--- a/docs/man/nng_opts_parse.3supp.adoc
+++ b/docs/man/nng_opts_parse.3supp.adoc
@@ -27,7 +27,7 @@ typedef struct nng_optspec {
     bool        o_arg;   // Option takes an argument if true
 } nng_optspec;
 
-int nng_opts_parse(int argc, const char **argv, const nng_optspec *spec, int *val, const char **arg, int *idx);
+int nng_opts_parse(int argc, char *const *argv, const nng_optspec *spec, int *val, const char **arg, int *idx);
 ----
 
 == DESCRIPTION

--- a/src/supplemental/util/options.c
+++ b/src/supplemental/util/options.c
@@ -16,7 +16,7 @@
 
 // Call with optidx set to 1 to start parsing.
 int
-nng_opts_parse(int argc, const char **argv, const nng_optspec *opts, int *val,
+nng_opts_parse(int argc, char *const *argv, const nng_optspec *opts, int *val,
     const char **optarg, int *optidx)
 {
 	const nng_optspec *opt;

--- a/src/supplemental/util/options.h
+++ b/src/supplemental/util/options.h
@@ -38,7 +38,7 @@ typedef struct nng_optspec nng_optspec;
 // set to match the option string, and optidx will be increment appropriately.
 // Returns -1 when the end of options is reached, 0 on success, or
 // NNG_EINVAL if the option parse is invalid for any reason.
-NNG_DECL int nng_opts_parse(int argc, const char **argv,
+NNG_DECL int nng_opts_parse(int argc, char *const *argv,
     const nng_optspec *opts, int *val, const char **optarg, int *optidx);
 
 #ifdef __cplusplus


### PR DESCRIPTION
fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
