### PR TITLE
Httpreset

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -238,6 +238,7 @@ if (NNG_ENABLE_DOC)
 	nng_http_req_get_method
 	nng_http_req_get_uri
 	nng_http_req_get_version
+	nng_http_req_reset
 	nng_http_req_set_data
 	nng_http_req_set_header
 	nng_http_req_set_method
@@ -254,6 +255,7 @@ if (NNG_ENABLE_DOC)
 	nng_http_res_get_reason
 	nng_http_res_get_status
 	nng_http_res_get_version
+	nng_http_res_reset
 	nng_http_res_set_data
 	nng_http_res_set_header
 	nng_http_res_set_reason

--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -311,6 +311,7 @@ and connections.
 |<<nng_http_req_get_method.3http#,nng_http_req_get_method()>>|return HTTP request method
 |<<nng_http_req_get_uri.3http#,nng_http_req_get_uri()>>|return HTTP request URI
 |<<nng_http_req_get_version.3http#,nng_http_req_get_version()>>|return HTTP request protocol version
+|<<nng_http_req_reset.3http#,nng_http_req_reset()>>|reset HTTP request structure
 |<<nng_http_req_set_data.3http#,nng_http_req_set_data()>>|set HTTP request body
 |<<nng_http_req_set_header.3http#,nng_http_req_set_header()>>|set HTTP request header
 |<<nng_http_req_set_method.3http#,nng_http_req_set_method()>>|set HTTP request method
@@ -327,6 +328,7 @@ and connections.
 |<<nng_http_res_get_reason.3http#,nng_http_res_get_reason()>>|return HTTP response reason
 |<<nng_http_res_get_status.3http#,nng_http_res_get_status()>>|return HTTP response status
 |<<nng_http_res_get_version.3http#,nng_http_res_get_version()>>|return HTTP response protocol version
+|<<nng_http_res_reset.3http#,nng_http_res_reset()>>|reset HTTP response structure
 |<<nng_http_res_set_data.3http#,nng_http_res_set_data()>>|set HTTP response body
 |<<nng_http_res_set_header.3http#,nng_http_res_set_header()>>|set HTTP response header
 |<<nng_http_res_set_reason.3http#,nng_http_res_set_reason()>>|set HTTP response reason

--- a/docs/man/nng_http_req_alloc.3http.adoc
+++ b/docs/man/nng_http_req_alloc.3http.adoc
@@ -30,6 +30,10 @@ and stores a pointer to it in __reqp__.
 The request will be initialized
 to perform an HTTP/1.1 `GET` operation using the URL specified in __url__.
 
+TIP: It is possible to specify `NULL` for the URL.
+In this case the URI for the request must be specified by a subsequent call
+to `<<nng_http_req_set_uri.3http#,nng_http_req_set_uri()>>`.
+
 == RETURN VALUES
 
 This function returns 0 on success, and non-zero otherwise.
@@ -53,6 +57,7 @@ This function returns 0 on success, and non-zero otherwise.
 <<nng_http_req_get_method.3http#,nng_http_req_get_method(3http)>>,
 <<nng_http_req_get_uri.3http#,nng_http_req_get_uri(3http)>>,
 <<nng_http_req_get_version.3http#,nng_http_req_get_version(3http)>>,
+<<nng_http_req_reset.3http#,nng_http_req_reset(3http)>>,
 <<nng_http_req_set_data.3http#,nng_http_req_set_data(3http)>>,
 <<nng_http_req_set_method.3http#,nng_http_req_set_method(3http)>>,
 <<nng_http_req_set_uri.3http#,nng_http_req_set_uri(3http)>>,

--- a/docs/man/nng_http_req_reset.3http.adoc
+++ b/docs/man/nng_http_req_reset.3http.adoc
@@ -1,4 +1,4 @@
-= nng_http_req_free(3http)
+= nng_http_req_reset(3http)
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
@@ -11,7 +11,7 @@
 
 == NAME
 
-nng_http_req_free - free HTTP request structure
+nng_http_req_reset - reset HTTP request structure
 
 == SYNOPSIS
 
@@ -20,16 +20,17 @@ nng_http_req_free - free HTTP request structure
 #include <nng/nng.h>
 #include <nng/supplemental/http/http.h>
 
-void nng_http_req_free(nng_http_req *req);
+void nng_http_req_reset(nng_http_req *req);
 ----
 
 == DESCRIPTION
 
-The `nng_http_req_free()` function deallocates the HTTP request structure
-_req_ entirely.
+The `nng_http_req_reset()` function resets the request __req__ so that it
+is just as if it had been freshly allocated with
+`<<nng_http_req_alloc.3http#,nng_http_req_alloc()>>` with a `NULL` URL.
 
-TIP: Instead of freeing and reallocating request structures, it is possible
-to reuse _req_ with `<<nng_http_req_reset.3http#,nng_http_req_reset()>>`.
+NOTE: Before using this with an HTTP operation, the URI must be set using
+`<<nng_http_req_set_uri.3http#,nng_http_req_set_uri()>>`.
 
 == RETURN VALUES
 
@@ -43,5 +44,5 @@ None.
 
 [.text-left]
 <<nng_http_req_alloc.3http#,nng_http_req_alloc(3http)>>,
-<<nng_http_req_reset.3http#,nng_http_req_reset(3http)>>,
+<<nng_http_req_set_uri.3http#,nng_http_req_set_uri(3http)>>,
 <<nng.7#,nng(7)>>

--- a/docs/man/nng_http_res_alloc.3http.adoc
+++ b/docs/man/nng_http_res_alloc.3http.adoc
@@ -28,8 +28,8 @@ int nng_http_res_alloc(nng_http_res **resp);
 The `nng_http_res_alloc()` function allocates a new HTTP response structure
 and stores a pointer to it in __resp__.
 The response will be initialized
-with status code 200 (`NNG_HTTP_STATUS_OK`), and a reason phrase of "OK",
-and HTTP protocol version "HTTP/1.1".
+with status code 200 (`NNG_HTTP_STATUS_OK`), and a reason phrase of `"OK`",
+and HTTP protocol version `"HTTP/1.1`".
 
 TIP: When an error response is needed, consider using
 `<<nng_http_res_alloc_error.3http#,nng_http_res_alloc_error()>>` instead.
@@ -59,6 +59,7 @@ This function returns 0 on success, and non-zero otherwise.
 <<nng_http_res_get_reason.3http#,nng_http_res_get_reason(3http)>>,
 <<nng_http_res_get_status.3http#,nng_http_res_get_status(3http)>>,
 <<nng_http_res_get_version.3http#,nng_http_res_get_version(3http)>>,
+<<nng_http_res_reset.3http#,nng_http_res_reset(3http)>>,
 <<nng_http_res_set_data.3http#,nng_http_res_set_data(3http)>>,
 <<nng_http_res_set_reason.3http#,nng_http_res_set_reason(3http)>>,
 <<nng_http_res_set_status.3http#,nng_http_res_set_status(3http)>>,

--- a/docs/man/nng_http_res_free.3http.adoc
+++ b/docs/man/nng_http_res_free.3http.adoc
@@ -28,6 +28,9 @@ void nng_http_res_free(nng_http_res *req);
 The `nng_http_res_free()` function deallocates the HTTP response structure
 _res_ entirely.
 
+TIP: Instead of freeing and reallocating response structures, it is possible
+to reuse _res_ with `<<nng_http_res_reset.3http#,nng_http_res_reset()>>`.
+
 == RETURN VALUES
 
 None.
@@ -39,5 +42,6 @@ None.
 == SEE ALSO
 
 [.text-left]
-<<nng_http_res_alloc.3http#,nng_http_req_alloc(3http)>>,
+<<nng_http_res_alloc.3http#,nng_http_res_alloc(3http)>>,
+<<nng_http_res_reset.3http#,nng_http_res_reset(3http)>>,
 <<nng.7#,nng(7)>>

--- a/docs/man/nng_http_res_reset.3http.adoc
+++ b/docs/man/nng_http_res_reset.3http.adoc
@@ -1,4 +1,4 @@
-= nng_http_req_free(3http)
+= nng_http_res_reset(3http)
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
@@ -11,7 +11,7 @@
 
 == NAME
 
-nng_http_req_free - free HTTP request structure
+nng_http_res_reset - reset HTTP response structure
 
 == SYNOPSIS
 
@@ -20,16 +20,14 @@ nng_http_req_free - free HTTP request structure
 #include <nng/nng.h>
 #include <nng/supplemental/http/http.h>
 
-void nng_http_req_free(nng_http_req *req);
+void nng_http_res_reset(nng_http_res *res);
 ----
 
 == DESCRIPTION
 
-The `nng_http_req_free()` function deallocates the HTTP request structure
-_req_ entirely.
-
-TIP: Instead of freeing and reallocating request structures, it is possible
-to reuse _req_ with `<<nng_http_req_reset.3http#,nng_http_req_reset()>>`.
+The `nng_http_res_reset()` function resets the response __res__ so that it
+is just as if it had been freshly allocated with
+`<<nng_http_res_alloc.3http#,nng_http_res_alloc()>>`.
 
 == RETURN VALUES
 
@@ -42,6 +40,5 @@ None.
 == SEE ALSO
 
 [.text-left]
-<<nng_http_req_alloc.3http#,nng_http_req_alloc(3http)>>,
-<<nng_http_req_reset.3http#,nng_http_req_reset(3http)>>,
+<<nng_http_res_alloc.3http#,nng_http_res_alloc(3http)>>,
 <<nng.7#,nng(7)>>

--- a/docs/man/nng_opts_parse.3supp.adoc
+++ b/docs/man/nng_opts_parse.3supp.adoc
@@ -27,7 +27,7 @@ typedef struct nng_optspec {
     bool        o_arg;   // Option takes an argument if true
 } nng_optspec;
 
-int nng_opts_parse(int argc, char *const *argv, const nng_optspec *spec, int *val, const char **arg, int *idx);
+int nng_opts_parse(int argc, char *const *argv, const nng_optspec *spec, int *val, char **arg, int *idx);
 ----
 
 == DESCRIPTION

--- a/src/core/stats.h
+++ b/src/core/stats.h
@@ -85,23 +85,6 @@ void nni_stat_set_unit(nni_stat_item *, int);
 #define nni_stat_dec_atomic(stat, inc)
 #endif
 
-#if 0
-#define nni_stat_append(a, b)
-#define nni_stat_remove(a)
-#define nni_stat_init(a, b, c)
-#define nni_stat_init_scope(a, b, c)
-#define nni_stat_init_string(a, b, c, d)
-#define nni_stat_init_id(a, b, c, d)
-#define nni_stat_init_bool(a, b, c, d)
-#define nni_stat_dec_atomic(a, b)
-#define nni_stat_set_value(a, b)
-#define nni_stat_set_string(a, b)
-#define nni_stat_set_lock(a, b)
-#define nni_stat_set_update(a, b, c)
-#define nni_stat_set_type(a, b)
-#define nni_stat_set_unit(a, b)
-#endif
-
 int  nni_stat_sys_init(void);
 void nni_stat_sys_fini(void);
 

--- a/src/supplemental/http/http.h
+++ b/src/supplemental/http/http.h
@@ -275,6 +275,12 @@ NNG_DECL void nng_http_conn_read_req(
 NNG_DECL void nng_http_conn_read_res(
     nng_http_conn *, nng_http_res *, nng_aio *);
 
+// nng_http_req_reset resets the request to an initially allocated state.
+NNG_DECL void nng_http_req_reset(nng_http_req *);
+
+// nng_http_res_reset resets the response to an initially allocated state.
+NNG_DECL void nng_http_res_reset(nng_http_res *);
+
 // nng_http_handler is a handler used on the server side to handle HTTP
 // requests coming into a specific URL.
 typedef struct nng_http_handler nng_http_handler;

--- a/src/supplemental/http/http_client.c
+++ b/src/supplemental/http/http_client.c
@@ -303,6 +303,7 @@ http_txn_reap(void *arg)
 		// We only close the connection if we created it.
 		if (txn->conn != NULL) {
 			nni_http_conn_fini(txn->conn);
+			txn->conn = NULL;
 		}
 	}
 	nni_aio_fini(txn->aio);

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -867,3 +867,19 @@ nng_http_conn_transact(
 	}
 #endif
 }
+
+void
+nng_http_req_reset(nng_http_req *req)
+{
+#ifdef NNG_SUPP_HTTP
+	nni_http_req_reset(req);
+#endif
+}
+
+void
+nng_http_res_reset(nng_http_res *res)
+{
+#ifdef NNG_SUPP_HTTP
+	nni_http_res_reset(res);
+#endif
+}

--- a/src/supplemental/util/options.c
+++ b/src/supplemental/util/options.c
@@ -17,13 +17,13 @@
 // Call with optidx set to 1 to start parsing.
 int
 nng_opts_parse(int argc, char *const *argv, const nng_optspec *opts, int *val,
-    const char **optarg, int *optidx)
+    char **optarg, int *optidx)
 {
 	const nng_optspec *opt;
 	int                matches;
 	bool               shortopt;
 	size_t             l;
-	const char *       arg = argv[*optidx];
+	char *             arg = argv[*optidx];
 	int                i;
 
 	if ((i = *optidx) >= argc) {

--- a/src/supplemental/util/options.h
+++ b/src/supplemental/util/options.h
@@ -39,7 +39,7 @@ typedef struct nng_optspec nng_optspec;
 // Returns -1 when the end of options is reached, 0 on success, or
 // NNG_EINVAL if the option parse is invalid for any reason.
 NNG_DECL int nng_opts_parse(int argc, char *const *argv,
-    const nng_optspec *opts, int *val, const char **optarg, int *optidx);
+    const nng_optspec *opts, int *val, char **optarg, int *optidx);
 
 #ifdef __cplusplus
 }

--- a/tests/options.c
+++ b/tests/options.c
@@ -27,14 +27,12 @@ static nng_optspec case1[] = {
 };
 
 TestMain("Option Parsing", {
-
 	Convey("Simple works", {
-
-		int         opti = 1;
-		const char *av[6];
-		int         ac = 5;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[6];
+		int   ac = 5;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "-f";
@@ -55,12 +53,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Long works", {
-
-		int         opti = 1;
-		const char *av[6];
-		int         ac = 5;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[6];
+		int   ac = 5;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "--flag";
@@ -81,12 +78,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Attached short works", {
-
-		int         opti = 1;
-		const char *av[3];
-		int         ac = 3;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[3];
+		int   ac = 3;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "-v123";
@@ -101,12 +97,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Attached long (=) works", {
-
-		int         opti = 1;
-		const char *av[3];
-		int         ac = 3;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[3];
+		int   ac = 3;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "--value=123";
@@ -121,12 +116,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Attached long (:) works", {
-
-		int         opti = 1;
-		const char *av[3];
-		int         ac = 3;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[3];
+		int   ac = 3;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "--value:123";
@@ -141,12 +135,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Negative bad short works", {
-
-		int         opti = 1;
-		const char *av[3];
-		int         ac = 3;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[3];
+		int   ac = 3;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "-Z";
@@ -156,12 +149,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Negative bad long works", {
-
-		int         opti = 1;
-		const char *av[3];
-		int         ac = 3;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[3];
+		int   ac = 3;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "--something";
@@ -171,11 +163,11 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("Separator flag works", {
-		int         opti = 1;
-		const char *av[5];
-		int         ac = 5;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[5];
+		int   ac = 5;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "-f";
@@ -190,22 +182,22 @@ TestMain("Option Parsing", {
 	});
 
 	Convey("No options works", {
-		int         opti = 1;
-		const char *av[1];
-		int         ac = 1;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[1];
+		int   ac = 1;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		So(nng_opts_parse(ac, av, case1, &v, &a, &opti) == -1);
 	});
 
 	Convey("No options (but arguments) works", {
-		int         opti = 1;
-		const char *av[2];
-		int         ac = 2;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[2];
+		int   ac = 2;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "123";
@@ -213,12 +205,11 @@ TestMain("Option Parsing", {
 		So(opti == 1);
 	});
 	Convey("Mixed long and short works", {
-
-		int         opti = 1;
-		const char *av[7];
-		int         ac = 7;
-		int         v;
-		const char *a = NULL;
+		int   opti = 1;
+		char *av[7];
+		int   ac = 7;
+		int   v;
+		char *a = NULL;
 
 		av[0] = "program";
 		av[1] = "--value=123";

--- a/tools/nngcat/nngcat.c
+++ b/tools/nngcat/nngcat.c
@@ -200,7 +200,9 @@ static nng_optspec opts[] = {
 	    .o_arg   = true,
 	},
 	{
-	    .o_name = "zt-home", .o_val = OPT_ZTHOME, .o_arg = true,
+	    .o_name = "zt-home",
+	    .o_val  = OPT_ZTHOME,
+	    .o_arg  = true,
 	},
 	{ .o_name = "version", .o_short = 'V', .o_val = OPT_VERSION },
 
@@ -671,10 +673,10 @@ sendrecv(nng_socket sock)
 }
 
 int
-main(int ac, const char **av)
+main(int ac, char **av)
 {
 	int            idx;
-	const char *   arg;
+	char *         arg;
 	int            val;
 	int            rv;
 	char           scratch[512];


### PR DESCRIPTION
This primarily fixes HTTP problems mostly involving the new http_transact api, but which could affect anyone wanting to reuse request or reply structures.  It also affected the server implementation.

A few other issues were squashed along the way as well.

Docs are included.