### PR TITLE
Only free in nng_send() if we succeed.

### DIFF
--- a/src/nng.c
+++ b/src/nng.c
@@ -158,10 +158,12 @@ nng_send(nng_socket s, void *buf, size_t len, int flags)
 	}
 	memcpy(nng_msg_body(msg), buf, len);
 	if ((rv = nng_sendmsg(s, msg, flags)) != 0) {
+		// If nng_sendmsg() succeeded, then it took ownership.
 		nng_msg_free(msg);
-	}
-	if (flags & NNG_FLAG_ALLOC) {
-		nni_free(buf, len);
+	} else {
+		if (flags & NNG_FLAG_ALLOC) {
+			nni_free(buf, len);
+		}
 	}
 	return (rv);
 }


### PR DESCRIPTION
Both the man page and the comment (in nng.h) of nng_send()
say that the buffer is freed only if the function succeeds.
The previous code always freed (if the flag was set). This
change only frees if we succeed.
