### PR TITLE
fix cmake target include directory exporting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -240,6 +240,8 @@ set_target_properties (${PROJECT_NAME} ${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE ${NNG_REQUIRED_LIBRARIES})
 target_link_libraries (${PROJECT_NAME} PRIVATE Threads::Threads)
 
+target_include_directories (${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
+
 install (TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}-target
     FRAMEWORK DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT library


### PR DESCRIPTION
This is a one-liner: the include directory associated with the exported library target was not exported, meaning that when importing the library target it was necessary to manually add the corresponding include directory. With this fix, it is possible to import the nng target properly without having to deal with the include directory manually.

I should also point out that in order to work outside of the main build system, one has to add "find_package(Threads REQUIRED)" in order to define the Threads::Threads target. The minimum cmake version should also be set at 3.1 or higher, otherwise one has to tweak cmake policies a little bit.
