### PR TITLE
fixes #738 http server needs a way to collect request entity data

### DIFF
--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -356,6 +356,7 @@ These functions are intended for use with HTTP server applications.
 
 |===
 |<<nng_http_handler_alloc.3http#,nng_http_handler_alloc()>>|allocate HTTP server handler
+|<<nng_http_handler_collect_body.3http#,nng_http_handler_collect_body()>>|set HTTP handler to collect request body
 |<<nng_http_handler_free.3http#,nng_http_handler_free()>>|free HTTP server handler
 |<<nng_http_handler_get_data.3http#,nng_http_handler_get_data()>>|return extra data for HTTP handler
 |<<nng_http_handler_set_data.3http#,nng_http_handler_set_data()>>|set extra data for HTTP handler

--- a/docs/man/nng_http_handler_alloc.3http.adoc
+++ b/docs/man/nng_http_handler_alloc.3http.adoc
@@ -149,6 +149,7 @@ This function returns 0 on success, and non-zero otherwise.
 <<nng_aio_finish.3#,nng_aio_finish(3)>>,
 <<nng_aio_get_input.3#,nng_aio_get_input(3)>>,
 <<nng_aio_set_output.3#,nng_aio_set_output(3)>>,
+<<nng_http_handler_collect_body.3http#,nng_http_handler_collect_body(3http)>>,
 <<nng_http_handler_free.3http#,nng_http_handler_free(3http)>>,
 <<nng_http_handler_set_host.3http#,nng_http_handler_set_host(3http)>>,
 <<nng_http_handler_set_method.3http#,nng_http_handler_set_method(3http)>>,

--- a/docs/man/nng_http_handler_collect_body.3http.adoc
+++ b/docs/man/nng_http_handler_collect_body.3http.adoc
@@ -1,0 +1,78 @@
+= nng_http_handler_collect_body(3http)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_http_handler_collect_body - set HTTP handler to collect request body
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+#include <nng/supplemental/http/http.h>
+
+int nng_http_handler_collect_body(nng_http_handler *handler, bool want, size_t maxsz);
+----
+
+== DESCRIPTION
+
+The `nng_http_handler_collect_data()` function causes the _handler_ to
+collect any request body that was submitted with the request, and attach
+it to the `nng_http_req` before the handler is called.
+
+Subsequently the data can be retrieved by the handler from the request with the
+`<<nng_http_req_get_data.3http#,nng_http_req_get_data()>>` function.
+
+The collection is enabled if _want_ is true.
+Furthermore, the data that the client may sent is limited by the
+value of _maxsz_.
+If the client attempts to send more data than _maxsz_, then the
+request will be terminated with a 400 "`Bad Request`" status.
+
+TIP: Limiting the size of incoming request data can provide protection
+against denial of service attacks, as a buffer of the client-supplied
+size must be allocated to receive the data.
+
+In order to provide an unlimited size, use `(size_t)-1` for _maxsz_.
+The value `0` for _maxsz_ can be used to prevent any data from being passed
+by the client.
+
+The built-in handlers for files, directories, and static data limit the
+_maxsz_ to zero by default.
+Otherwise the default setting is to enable this capability with a default
+value of _maxsz_ of 1 megabyte.
+
+NOTE: The handler looks for data indicated by the `Content-Length:` HTTP
+header.
+If this header is absent, the request is assumed not to contain any data.
+
+NOTE: This specifically does not support the `Chunked` transfer-encoding.
+This is considered a bug, and is a deficiency for full HTTP/1.1 compliance.
+However, few clients send data in this format, so in practice this should
+not create few limitations.
+
+== RETURN VALUES
+
+This function returns 0 on success, and non-zero otherwise.
+
+== ERRORS
+
+[horizontal]
+`NNG_ENOTSUP`:: No support for HTTP in the library.
+
+== SEE ALSO
+
+[.text-left]
+<<nng_http_handler_alloc.3http#,nng_http_handler_alloc(3http)>>,
+<<nng_http_server_add_handler.3http#,nng_http_server_add_handler(3http)>>,
+<<nng_http_req_get_data.3http#,nng_http_req_get_data(3http)>>,
+<<nng.7#,nng(7)>>

--- a/src/supplemental/http/http.h
+++ b/src/supplemental/http/http.h
@@ -350,6 +350,16 @@ NNG_DECL int nng_http_handler_set_method(nng_http_handler *, const char *);
 // that case is not considered.)
 NNG_DECL int nng_http_handler_set_host(nng_http_handler *, const char *);
 
+// nng_http_handler_collect_body is used to indicate the server should
+// check for, and process, data sent by the client, which will be attached
+// to the request.  If this is false, then the handler will need to check
+// for and process any content data.  By default the server will accept
+// up to 1MB.  If the client attempts to send more data than requested,
+// then a 400 Bad Request will be sent back to the client.  To set an
+// unlimited value, use (size_t)-1.  To preclude the client from sending
+// *any* data, use 0.  (The static and file handlers use 0 by default.)
+NNG_DECL int nng_http_handler_collect_body(nng_http_handler *, bool, size_t);
+
 // nng_http_handler_set_tree indicates that the handler is being registered
 // for a heirarchical tree, rather than just a single path, so it will be
 // called for all child paths supplied.  By default the handler is only

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -101,6 +101,7 @@ extern int nni_http_req_copy_data(nni_http_req *, const void *, size_t);
 extern int nni_http_res_copy_data(nni_http_res *, const void *, size_t);
 extern int nni_http_req_set_data(nni_http_req *, const void *, size_t);
 extern int nni_http_res_set_data(nni_http_res *, const void *, size_t);
+extern int nni_http_req_alloc_data(nni_http_req *, size_t);
 extern int nni_http_res_alloc_data(nni_http_res *, size_t);
 extern const char *nni_http_req_get_method(nni_http_req *);
 extern const char *nni_http_req_get_version(nni_http_req *);
@@ -247,6 +248,11 @@ extern int nni_http_handler_init_static(
 // the handler is added, or after it is deleted.  The server automatically
 // calls this for any handlers still registered with it if it is destroyed.
 extern void nni_http_handler_fini(nni_http_handler *);
+
+// nni_http_handler_collect_body informs the server that it should collect
+// the entitty data associated with the client request, and sets the maximum
+// size to accept.
+extern void nni_http_handler_collect_body(nni_http_handler *, bool, size_t);
 
 // nni_http_handler_set_tree marks the handler as servicing the entire
 // tree (e.g. a directory), rather than just a leaf node.  The handler

--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -382,6 +382,17 @@ nni_http_req_copy_data(nni_http_req *req, const void *data, size_t size)
 }
 
 int
+nni_http_req_alloc_data(nni_http_req *req, size_t size)
+{
+	int rv;
+
+	if ((rv = http_entity_alloc_data(&req->data, size)) != 0) {
+		return (rv);
+	}
+	return (0);
+}
+
+int
 nni_http_res_copy_data(nni_http_res *res, const void *data, size_t size)
 {
 	int rv;

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -587,6 +587,17 @@ nng_http_handler_set_method(nng_http_handler *h, const char *meth)
 }
 
 int
+nng_http_handler_collect_body(nng_http_handler *h, bool want, size_t len)
+{
+#ifdef NNG_SUPP_HTTP
+	nni_http_handler_collect_body(h, want, len);
+	return (0);
+#else
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
 nng_http_handler_set_host(nng_http_handler *h, const char *host)
 {
 #ifdef NNG_SUPP_HTTP


### PR DESCRIPTION
This adds a new API, nng_http_handler_collect_body(), and test cases and documentation for same.

This is necessary to simplify post handling for REST API services, for example.