### PR TITLE
fixes #745 HTTP server redirect handler

### DIFF
--- a/docs/man/nng_http_handler_alloc.3http.adoc
+++ b/docs/man/nng_http_handler_alloc.3http.adoc
@@ -31,6 +31,9 @@ int nng_http_handler_alloc_directory(nng_http_handler **hp, const char *path,
 int nng_http_handler_alloc_file(nng_http_handler **hp, const char *path,
     const char *filename);
 
+int nng_http_handler_alloc_redirect(nng_http_handler **hp, const char *path,
+    uint16_t status, const char *location);
+
 int nng_http_handler_alloc_static(nng_http_handler **hp, const char *path,
     const void *data, size_t size, const char *content_type);
 ----
@@ -48,7 +51,7 @@ Only the path component of the Request URI is
 considered when determining whether the handler should be called.
 
 Additionally each handler has a method it is registered to handle
-(the default is "GET", see
+(the default is `GET`, see
 `<<nng_http_handler_set_method.3http#,nng_http_handler_set_method()>>`), and
 optionally a 'Host' header it can be matched against (see
 `<<nng_http_handler_set_host.3http#,nng_http_handler_set_host()>>`).
@@ -123,9 +126,30 @@ of the requested file name.
 If a content type cannot be determined from
 the extension, then `application/octet-stream` is used.
 
+=== Redirect Handler
+
+The fourth member is used to arrange for a server redirect from one
+URL to another.
+The reply will be with status code __status__, which should be a 3XX
+code such as 301, and a `Location:` header will contain the URL
+referenced by __location__, with any residual suffix from the request
+URI appended.
+
+TIP: Use `<<nng_http_handler_set_tree#,nng_http_handler_set_tree()>>`
+to redirect an entire tree.
+For example, it is possible to redirect an entire HTTP site to another
+HTTPS site by specifying `/` as the path and then using the base
+of the new site, such as `https://newsite.example.com` as the
+new location.
+
+TIP: Be sure to use the appropriate value for __status__.
+Permanent redirection should use 301 and temporary redirections should use 307.
+In REST APIs, using a redirection to supply the new location of an object
+created with `POST` should use 303.
+
 === Static Handler
 
-The fourth member of this family, `nng_http_handler_alloc_static()`, creates
+The fifth member of this family, `nng_http_handler_alloc_static()`, creates
 a handler to serve up fixed content located in program data.
 The client is
 sent the _data_, with `Content-Length` of _size_ bytes, and `Content-Type` of
@@ -133,7 +157,7 @@ __content_type__.
 
 == RETURN VALUES
 
-This function returns 0 on success, and non-zero otherwise.
+These functions return 0 on success, and non-zero otherwise.
 
 == ERRORS
 

--- a/src/supplemental/http/http.h
+++ b/src/supplemental/http/http.h
@@ -328,6 +328,12 @@ NNG_DECL int nng_http_handler_alloc_file(
 NNG_DECL int nng_http_handler_alloc_static(
     nng_http_handler **, const char *, const void *, size_t, const char *);
 
+// nng_http_handler_alloc_redirect creates an HTTP redirect handler.
+// The status is given, along with the new URL.  If the status is 0,
+// then 301 will be used instead.
+NNG_DECL int nng_http_handler_alloc_redirect(
+    nng_http_handler **, const char *, uint16_t, const char *);
+
 // nng_http_handler_alloc_file creates a "directory" based handler, that
 // serves up static content from the given directory tree.  Directories
 // that contain an index.html or index.htm file use that file for the

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -121,6 +121,13 @@ extern int         nni_http_res_set_reason(nni_http_res *, const char *);
 // the HTML body with customized content if it exists.
 extern bool nni_http_res_is_error(nni_http_res *);
 
+// nni_http_alloc_html_error allocates a string corresponding to an
+// HTML error.  This can be set as the body of the res.  The status
+// will be looked up using HTTP status code lookups, but the details
+// will be added if present as further body text.  The result can
+// be freed with nni_strfree() later.
+extern int nni_http_alloc_html_error(char **, uint16_t, const char *);
+
 extern void nni_http_read(nni_http_conn *, nni_aio *);
 extern void nni_http_read_full(nni_http_conn *, nni_aio *);
 extern void nni_http_write(nni_http_conn *, nni_aio *);
@@ -214,7 +221,7 @@ extern int nni_http_hijack(nni_http_conn *);
 //
 // The callback function will receive the following arguments (via
 // nng_aio_get_input(): nni_http_request *, nni_http_handler *, and
-// nni_http_context_t *.  The first is a request object, for convenience.
+// nni_http_conn_t *.  The first is a request object, for convenience.
 // The second is the handler, from which the callback can obtain any other
 // data it has set.  The final is the http context, from which its possible
 // to hijack the session.
@@ -243,6 +250,10 @@ extern int nni_http_handler_init_directory(
 // supplied, with the Content-Type supplied in the final argument.
 extern int nni_http_handler_init_static(
     nni_http_handler **, const char *, const void *, size_t, const char *);
+
+// nni_http_handler_init_redirect creates a handler that redirects the request.
+extern int nni_http_handler_init_redirect(
+    nni_http_handler **, const char *, uint16_t, const char *);
 
 // nni_http_handler_fini destroys a handler.  This should only be done before
 // the handler is added, or after it is deleted.  The server automatically

--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -128,15 +128,19 @@ nni_http_res_reset(nni_http_res *res)
 void
 nni_http_req_free(nni_http_req *req)
 {
-	nni_http_req_reset(req);
-	NNI_FREE_STRUCT(req);
+	if (req != NULL) {
+		nni_http_req_reset(req);
+		NNI_FREE_STRUCT(req);
+	}
 }
 
 void
 nni_http_res_free(nni_http_res *res)
 {
-	nni_http_res_reset(res);
-	NNI_FREE_STRUCT(res);
+	if (res != NULL) {
+		nni_http_res_reset(res);
+		NNI_FREE_STRUCT(res);
+	}
 }
 
 static int
@@ -1012,36 +1016,49 @@ nni_http_res_set_reason(nni_http_res *res, const char *reason)
 }
 
 int
+nni_http_alloc_html_error(char **html, uint16_t code, const char *details)
+{
+	const char *rsn = nni_http_reason(code);
+
+	return (nni_asprintf(html,
+	    "<!DOCTYPE html>\n"
+	    "<html><head><title>%d %s</title>\n"
+	    "<style>"
+	    "body { font-family: Arial, sans serif; text-align: center }\n"
+	    "h1 { font-size: 36px; }"
+	    "span { background-color: gray; color: white; padding: 7px; "
+	    "border-radius: 5px }"
+	    "h2 { font-size: 24px; }"
+	    "p { font-size: 20px; }"
+	    "</style></head>"
+	    "<body><p>&nbsp;</p>"
+	    "<h1><span>%d</span></h1>"
+	    "<h2>%s</h2>"
+	    "<p>%s</p>"
+	    "</body></html>",
+	    code, rsn, code, rsn, details != NULL ? details : ""));
+}
+
+int
 nni_http_res_alloc_error(nni_http_res **resp, uint16_t err)
 {
-	char          html[512];
+	char *        html = NULL;
+	nni_http_res *res  = NULL;
 	int           rv;
-	nni_http_res *res;
 
-	if ((rv = nni_http_res_alloc(&res)) != 0) {
-		return (rv);
-	}
-
-	// very simple builtin error page
-	(void) snprintf(html, sizeof(html),
-	    "<head><title>%d %s</title></head>"
-	    "<body><p/><h1 align=\"center\">"
-	    "<span style=\"font-size: 36px; border-radius: 5px; "
-	    "background-color: black; color: white; padding: 7px; "
-	    "font-family: Arial, sans serif;\">%d</span></h1>"
-	    "<p align=\"center\">"
-	    "<span style=\"font-size: 24px; font-family: Arial, sans serif;\">"
-	    "%s</span></p></body>",
-	    err, nni_http_reason(err), err, nni_http_reason(err));
-
-	res->code = err;
-	if (((rv = nni_http_res_set_header(
+	if (((rv = nni_http_res_alloc(&res)) != 0) ||
+	    ((rv = nni_http_alloc_html_error(&html, err, NULL)) != 0) ||
+	    ((rv = nni_http_res_set_header(
 	          res, "Content-Type", "text/html; charset=UTF-8")) != 0) ||
 	    ((rv = nni_http_res_copy_data(res, html, strlen(html))) != 0)) {
+		nni_strfree(html);
 		nni_http_res_free(res);
 	} else {
+		nni_strfree(html);
+		res->code  = err;
 		res->iserr = true;
 		*resp      = res;
 	}
+
 	return (rv);
 }

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -559,6 +559,21 @@ nng_http_handler_alloc_directory(
 }
 
 int
+nng_http_handler_alloc_redirect(
+    nng_http_handler **hp, const char *uri, uint16_t status, const char *where)
+{
+#ifdef NNG_SUPP_HTTP
+	return (nni_http_handler_init_redirect(hp, uri, status, where));
+#else
+	NNI_ARG_UNUSED(hp);
+	NNI_ARG_UNUSED(uri);
+	NNI_ARG_UNUSED(status);
+	NNI_ARG_UNUSED(where);
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
 nng_http_handler_alloc_static(nng_http_handler **hp, const char *uri,
     const void *data, size_t size, const char *ctype)
 {


### PR DESCRIPTION
This also cleans up error pages a bit, and makes freeing REQ and RES objects safe even if they are NULL.