### PR TITLE
fixes #767 Want tunable stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,11 +108,25 @@ option (NNG_ENABLE_COVERAGE "Enable coverage reporting." OFF)
 # Enable access to private APIs for our own use.
 add_definitions (-DNNG_PRIVATE)
 
+# We can use rlimit to configure the stack size for systems
+# that have too small defaults.  This is not used for Windows,
+# which can grow thread stacks sensibly.  (Note that NNG can get
+# by with a smallish stack, but application callbacks might require
+# larger values if using aio completion callbacks.)
+if (NOT WIN32)
+    option (NNG_SETSTACKSIZE "Use rlimit for thread stack size" OFF)
+    if (NNG_SETSTACKSIZE)
+        add_definitions(-DNNG_SETSTACKSIZE)
+    endif()
+    mark_as_advanced(NNG_SETSTACKSIZE)
+endif()
+
+
 option (NNG_ENABLE_TLS "Enable TLS protocol (requires mbedTLS" OFF)
 if (NNG_ENABLE_TLS)
     add_definitions(-DNNG_SUPP_TLS)
     set(NNG_SUPP_TLS ON)
-   endif()
+endif()
 
 option (NNG_ENABLE_HTTP "Enable HTTP API" ON)
 if (NNG_ENABLE_HTTP)

--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -24,12 +24,18 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifdef NNG_SETSTACKSIZE
+#include <limits.h>
+#include <sys/resource.h>
+#endif
+
 static pthread_mutex_t nni_plat_init_lock = PTHREAD_MUTEX_INITIALIZER;
 static int             nni_plat_inited    = 0;
 static int             nni_plat_forked    = 0;
 
 pthread_condattr_t  nni_cvattr;
 pthread_mutexattr_t nni_mxattr;
+pthread_attr_t      nni_thrattr;
 
 void
 nni_plat_mtx_init(nni_plat_mtx *mtx)
@@ -222,7 +228,7 @@ nni_plat_thr_init(nni_plat_thr *thr, void (*fn)(void *), void *arg)
 	thr->arg  = arg;
 
 	// POSIX wants functions to return a void *, but we don't care.
-	rv = pthread_create(&thr->tid, NULL, nni_plat_thr_main, thr);
+	rv = pthread_create(&thr->tid, &nni_thrattr, nni_plat_thr_main, thr);
 	if (rv != 0) {
 		// nni_printf("pthread_create: %s",
 		// strerror(rv));
@@ -270,22 +276,39 @@ nni_plat_init(int (*helper)(void))
 		pthread_mutex_unlock(&nni_plat_init_lock);
 		return (0);
 	}
-	if (pthread_condattr_init(&nni_cvattr) != 0) {
+
+	if ((pthread_mutexattr_init(&nni_mxattr) != 0) ||
+	    (pthread_condattr_init(&nni_cvattr) != 0) ||
+	    (pthread_attr_init(&nni_thrattr) != 0)) {
+		// Technically this is leaking, but it should never
+		// occur, so really not worried about it.
 		pthread_mutex_unlock(&nni_plat_init_lock);
 		return (NNG_ENOMEM);
 	}
+
 #if !defined(NNG_USE_GETTIMEOFDAY) && NNG_USE_CLOCKID != CLOCK_REALTIME
 	if (pthread_condattr_setclock(&nni_cvattr, NNG_USE_CLOCKID) != 0) {
 		pthread_mutex_unlock(&nni_plat_init_lock);
+		pthread_mutexattr_destroy(&nni_mxattr);
+		pthread_condattr_destroy(&nni_cvattr);
+		pthread_attr_destroy(&nni_thrattr);
 		return (NNG_ENOMEM);
 	}
 #endif
 
-	if (pthread_mutexattr_init(&nni_mxattr) != 0) {
+#if defined(NNG_SETSTACKSIZE)
+	struct rlimit rl;
+	if ((getrlimit(RLIMIT_STACK, &rl) == 0) &&
+	    (rl.rlim_cur != RLIM_INFINITY) &&
+	    (rl.rlim_cur >= PTHREAD_STACK_MIN) &&
+	    (pthread_attr_setstacksize(&nni_thrattr, rl.rlim_cur) != 0)) {
 		pthread_mutex_unlock(&nni_plat_init_lock);
+		pthread_mutexattr_destroy(&nni_mxattr);
 		pthread_condattr_destroy(&nni_cvattr);
+		pthread_attr_destroy(&nni_thrattr);
 		return (NNG_ENOMEM);
 	}
+#endif
 
 	// if this one fails we don't care.
 	(void) pthread_mutexattr_settype(
@@ -295,6 +318,7 @@ nni_plat_init(int (*helper)(void))
 		pthread_mutex_unlock(&nni_plat_init_lock);
 		pthread_mutexattr_destroy(&nni_mxattr);
 		pthread_condattr_destroy(&nni_cvattr);
+		pthread_attr_destroy(&nni_thrattr);
 		return (rv);
 	}
 
@@ -303,6 +327,7 @@ nni_plat_init(int (*helper)(void))
 		nni_posix_pollq_sysfini();
 		pthread_mutexattr_destroy(&nni_mxattr);
 		pthread_condattr_destroy(&nni_cvattr);
+		pthread_attr_destroy(&nni_thrattr);
 		return (rv);
 	}
 
@@ -312,6 +337,7 @@ nni_plat_init(int (*helper)(void))
 		nni_posix_pollq_sysfini();
 		pthread_mutexattr_destroy(&nni_mxattr);
 		pthread_condattr_destroy(&nni_cvattr);
+		pthread_attr_destroy(&nni_thrattr);
 		return (NNG_ENOMEM);
 	}
 	if ((rv = helper()) == 0) {


### PR DESCRIPTION
This enables a CMake option which will use the rlimit value for the stack size -- but only on Windows.  This is off by default, but apps needing this can configure it to get larger stacks.