### PR TITLE
fixes #682 Support for Chunked Transfer Coding

### DIFF
--- a/docs/man/nng_http_conn_transact.3http.adoc
+++ b/docs/man/nng_http_conn_transact.3http.adoc
@@ -48,11 +48,6 @@ exists.
 That function behaves similarily, but creates a connection on demand
 for the transaction, and disposes of it when finished.
 
-NOTE: This function does not support reading data sent using chunked
-transfer encoding, and if the server attempts to do so, the underlying
-connection will be closed and an `NNG_ENOTSUP` error will be returned.
-This limitation is considered a bug, and a fix is planned for the future.
-
 WARNING: If the remote server tries to send an extremely large buffer,
 then a corresponding allocation will be made, which can lead to denial
 of service attacks.
@@ -79,7 +74,7 @@ None.
 `NNG_ECLOSED`:: The connection was closed.
 `NNG_ECONNRESET`:: The peer closed the connection.
 `NNG_ENOMEM`:: Insufficient free memory to perform the operation.
-`NNG_ENOTSUP`:: HTTP operations are not supported, or peer sent chunked encoding.
+`NNG_ENOTSUP`:: HTTP operations are not supported.
 `NNG_EPROTO`:: An HTTP protocol error occurred.
 `NNG_ETIMEDOUT`:: Timeout waiting for data from the connection.
 

--- a/docs/man/nng_http_handler_collect_body.3http.adoc
+++ b/docs/man/nng_http_handler_collect_body.3http.adoc
@@ -58,7 +58,7 @@ If this header is absent, the request is assumed not to contain any data.
 NOTE: This specifically does not support the `Chunked` transfer-encoding.
 This is considered a bug, and is a deficiency for full HTTP/1.1 compliance.
 However, few clients send data in this format, so in practice this should
-not create few limitations.
+create few limitations.
 
 == RETURN VALUES
 

--- a/src/supplemental/http/CMakeLists.txt
+++ b/src/supplemental/http/CMakeLists.txt
@@ -16,6 +16,7 @@ if (NNG_SUPP_HTTP)
                 supplemental/http/http.h
                 supplemental/http/http_api.h
                 supplemental/http/http_client.c
+                supplemental/http/http_chunk.c
                 supplemental/http/http_conn.c
                 supplemental/http/http_msg.c
                 supplemental/http/http_public.c

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -27,6 +27,8 @@ typedef struct nng_http_conn    nni_http_conn;
 typedef struct nng_http_handler nni_http_handler;
 typedef struct nng_http_server  nni_http_server;
 typedef struct nng_http_client  nni_http_client;
+typedef struct nng_http_chunk   nni_http_chunk;
+typedef struct nng_http_chunks  nni_http_chunks;
 
 // These functions are private to the internal framework, and really should
 // not be used elsewhere.
@@ -45,6 +47,33 @@ extern int   nni_http_res_get_buf(nni_http_res *, void **, size_t *);
 extern int   nni_http_res_parse(nni_http_res *, void *, size_t, size_t *);
 extern void  nni_http_res_get_data(nni_http_res *, void **, size_t *);
 extern char *nni_http_res_headers(nni_http_res *);
+
+// Chunked transfer encoding.  For the moment this is not part of our public
+// API.  We can change that later.
+
+// nni_http_chunk_list_init creates a list of chunks, which shall not exceed
+// the specified overall size.  (Size 0 means no limit.)
+extern int nni_http_chunks_init(nni_http_chunks **, size_t);
+
+extern void nni_http_chunks_free(nni_http_chunks *);
+
+// nni_http_chunk_iter iterates over all chunks in the list.
+// Pass NULL for the last chunk to start at the head.  Returns NULL when done.
+extern nni_http_chunk *nni_http_chunks_iter(
+    nni_http_chunks *, nni_http_chunk *);
+
+// nni_http_chunk_list_size returns the combined size of all chunks in list.
+extern size_t nni_http_chunks_size(nni_http_chunks *);
+
+// nni_http_chunk_size returns the size of given chunk.
+extern size_t nni_http_chunk_size(nni_http_chunk *);
+// nni_http_chunk_data returns a pointer to the data.
+extern void *nni_http_chunk_data(nni_http_chunk *);
+
+extern int nni_http_chunks_parse(nni_http_chunks *, void *, size_t, size_t *);
+
+extern void nni_http_read_chunks(
+    nni_http_conn *, nni_http_chunks *, nni_aio *);
 
 // Private to the server. (Used to support session hijacking.)
 extern void  nni_http_conn_set_ctx(nni_http_conn *, void *);

--- a/src/supplemental/http/http_chunk.c
+++ b/src/supplemental/http/http_chunk.c
@@ -1,0 +1,341 @@
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "core/nng_impl.h"
+
+#include "http_api.h"
+
+// Chunked transfer encoding support.
+
+// Note that HTTP/1.1 chunked transfer encoding is horrible, and should
+// be avoided if at all possible.  It necessarily creates extra need for
+// data copies, creates a lot of extra back and forth complexity.  If you're
+// stuck in this code, we feel great sympathy for you.
+//
+// We feel strongly enough about this that we refuse to provide any
+// method to automatically generate chunked transfers.  If you think
+// you need to send chunked transfers (because you have no idea how
+// much data you will send, such as a streaming workload), consider a
+// different method such as WebSocket to send your data.  Unbounded
+// entity body data is just impolite.
+
+enum chunk_state {
+	CS_INIT,   // initial state
+	CS_LEN,    // length
+	CS_EXT,    // random extension text (we ignore)
+	CS_CR,     // carriage return after length (and extensions)
+	CS_DATA,   // actual data
+	CS_TRLR,   // trailer
+	CS_TRLRCR, // CRLF at end of trailer
+	CS_DONE,
+};
+
+struct nng_http_chunks {
+	nni_list         cl_chunks;
+	size_t           cl_maxsz;
+	size_t           cl_size; // parsed size (so far)
+	size_t           cl_line; // bytes since last newline
+	enum chunk_state cl_state;
+};
+
+struct nng_http_chunk {
+	nni_list_node c_node;
+	size_t        c_size;
+	size_t        c_alloc;
+	size_t        c_resid; // residual data to transfer
+	char *        c_data;
+};
+
+int
+nni_http_chunks_init(nni_http_chunks **clp, size_t maxsz)
+{
+	nni_http_chunks *cl;
+
+	if ((cl = NNI_ALLOC_STRUCT(cl)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	NNI_LIST_INIT(&cl->cl_chunks, nni_http_chunk, c_node);
+	cl->cl_maxsz = maxsz;
+	*clp         = cl;
+	return (0);
+}
+
+void
+nni_http_chunks_free(nni_http_chunks *cl)
+{
+	nni_http_chunk *ch;
+	if (cl == NULL) {
+		return;
+	}
+	while ((ch = nni_list_first(&cl->cl_chunks)) != NULL) {
+		nni_list_remove(&cl->cl_chunks, ch);
+		if (ch->c_data != NULL) {
+			nni_free(ch->c_data, ch->c_alloc);
+		}
+		NNI_FREE_STRUCT(ch);
+	}
+	NNI_FREE_STRUCT(cl);
+}
+
+nni_http_chunk *
+nni_http_chunks_iter(nni_http_chunks *cl, nni_http_chunk *last)
+{
+	if (last == NULL) {
+		return (nni_list_first(&cl->cl_chunks));
+	}
+	return (nni_list_next(&cl->cl_chunks, last));
+}
+
+size_t
+nni_http_chunks_size(nni_http_chunks *cl)
+{
+	size_t          tot = 0;
+	nni_http_chunk *ch;
+	NNI_LIST_FOREACH (&cl->cl_chunks, ch) {
+		tot += ch->c_size;
+	}
+	return (tot);
+}
+
+size_t
+nni_http_chunk_size(nni_http_chunk *ch)
+{
+	return (ch->c_size);
+}
+
+void *
+nni_http_chunk_data(nni_http_chunk *ch)
+{
+	return (ch->c_data);
+}
+
+static int
+chunk_ingest_len(nni_http_chunks *cl, char c)
+{
+	if (isdigit(c)) {
+		cl->cl_size *= 16;
+		cl->cl_size += (c - '0');
+	} else if ((c >= 'A') && (c <= 'F')) {
+		cl->cl_size *= 16;
+		cl->cl_size += (c - 'A') + 10;
+	} else if ((c >= 'a') && (c <= 'f')) {
+		cl->cl_size *= 16;
+		cl->cl_size += (c - 'a') + 10;
+	} else if (c == ';') {
+		cl->cl_state = CS_EXT;
+	} else if (c == '\r') {
+		cl->cl_state = CS_CR;
+	} else {
+		return (NNG_EPROTO);
+	}
+	return (0);
+}
+
+static int
+chunk_ingest_ext(nni_http_chunks *cl, char c)
+{
+	if (c == '\r') {
+		cl->cl_state = CS_CR;
+	} else if (!isprint(c)) {
+		return (NNG_EPROTO);
+	}
+	return (0);
+}
+
+static int
+chunk_ingest_newline(nni_http_chunks *cl, char c)
+{
+	nni_http_chunk *chunk;
+
+	if (c != '\n') {
+		return (NNG_EPROTO);
+	}
+	if (cl->cl_size == 0) {
+		cl->cl_line  = 0;
+		cl->cl_state = CS_TRLR;
+		return (0);
+	}
+	if ((cl->cl_maxsz > 0) &&
+	    ((nni_http_chunks_size(cl) + cl->cl_size) > cl->cl_maxsz)) {
+		return (NNG_EMSGSIZE);
+	}
+	if ((chunk = NNI_ALLOC_STRUCT(chunk)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	// two extra bytes to accommodate trailing CRLF
+	if ((chunk->c_data = nni_alloc(cl->cl_size + 2)) == NULL) {
+		NNI_FREE_STRUCT(chunk);
+		return (NNG_ENOMEM);
+	}
+
+	// Data, so allocate a new chunk, stick it on the end of the list,
+	// and note that we have residual data needs.  The residual is
+	// to allow for the trailing CRLF to be consumed.
+	cl->cl_state   = CS_DATA;
+	chunk->c_size  = cl->cl_size;
+	chunk->c_alloc = cl->cl_size + 2;
+	chunk->c_resid = chunk->c_alloc;
+	nni_list_append(&cl->cl_chunks, chunk);
+
+	return (0);
+}
+
+static int
+chunk_ingest_trailer(nni_http_chunks *cl, char c)
+{
+	if (c == '\r') {
+		cl->cl_state = CS_TRLRCR;
+		return (0);
+	}
+	if (!isprint(c)) {
+		return (NNG_EPROTO);
+	}
+	cl->cl_line++;
+	return (0);
+}
+
+static int
+chunk_ingest_trailercr(nni_http_chunks *cl, char c)
+{
+	if (c != '\n') {
+		return (NNG_EPROTO);
+	}
+	if (cl->cl_line == 0) {
+		cl->cl_state = CS_DONE;
+		return (0);
+	}
+	cl->cl_line  = 0;
+	cl->cl_state = CS_TRLR;
+	return (0);
+}
+
+static int
+chunk_ingest_char(nni_http_chunks *cl, char c)
+{
+	int rv;
+	switch (cl->cl_state) {
+	case CS_INIT:
+		if (!isalnum(c)) {
+			rv = NNG_EPROTO;
+			break;
+		}
+		cl->cl_state = CS_LEN;
+		// fallthrough
+	case CS_LEN:
+		rv = chunk_ingest_len(cl, c);
+		break;
+	case CS_EXT:
+		rv = chunk_ingest_ext(cl, c);
+		break;
+	case CS_CR:
+		rv = chunk_ingest_newline(cl, c);
+		break;
+	case CS_TRLR:
+		rv = chunk_ingest_trailer(cl, c);
+		break;
+	case CS_TRLRCR:
+		rv = chunk_ingest_trailercr(cl, c);
+		break;
+	default:
+		// NB: No support for CS_DATA here, as that is handled
+		// in the caller for reasons of efficiency.
+		rv = NNG_EPROTO;
+		break;
+	}
+
+	return (rv);
+}
+
+static int
+chunk_ingest_data(nni_http_chunks *cl, char *buf, size_t n, size_t *lenp)
+{
+	nni_http_chunk *chunk;
+	size_t          offset;
+	char *          dest;
+
+	chunk = nni_list_last(&cl->cl_chunks);
+
+	NNI_ASSERT(chunk != NULL);
+	NNI_ASSERT(cl->cl_state == CS_DATA);
+	NNI_ASSERT(chunk->c_resid <= chunk->c_alloc);
+	NNI_ASSERT(chunk->c_alloc > 2); // not be zero, plus newlines
+
+	dest   = chunk->c_data;
+	offset = chunk->c_alloc - chunk->c_resid;
+	dest += offset;
+
+	if (n >= chunk->c_resid) {
+		n = chunk->c_resid;
+		memcpy(dest, buf, n);
+
+		if ((chunk->c_data[chunk->c_size] != '\r') ||
+		    (chunk->c_data[chunk->c_size + 1] != '\n')) {
+			return (NNG_EPROTO);
+		}
+		chunk->c_resid = 0;
+		cl->cl_state   = CS_INIT;
+		cl->cl_size    = 0;
+		cl->cl_line    = 0;
+		*lenp          = n;
+		return (0);
+	}
+
+	memcpy(dest, buf, n);
+	chunk->c_resid -= n;
+	*lenp = n;
+	return (0);
+}
+
+int
+nni_http_chunks_parse(nni_http_chunks *cl, void *buf, size_t n, size_t *lenp)
+{
+	size_t i   = 0;
+	char * src = buf;
+
+	// Format of this data is <hexdigits> [ ; <ascii> CRLF ]
+	// The <ascii> are chunk extensions, and we don't support any.
+
+	while ((cl->cl_state != CS_DONE) && (i < n)) {
+		int    rv;
+		size_t cnt;
+		switch (cl->cl_state) {
+		case CS_DONE:
+			// Completed parse!
+			break;
+
+		case CS_DATA:
+			if ((rv = chunk_ingest_data(cl, src + i, n, &cnt)) !=
+			    0) {
+				return (rv);
+			}
+			i += cnt;
+			break;
+
+		default:
+			// All others character by character parse through
+			// the state machine grinder.
+			if ((rv = chunk_ingest_char(cl, src[i])) != 0) {
+				return (rv);
+			}
+			i++;
+			break;
+		}
+	}
+
+	*lenp = i;
+	if (cl->cl_state != CS_DONE) {
+		return (NNG_EAGAIN);
+	}
+	return (0);
+}


### PR DESCRIPTION
This is the client side only, although the work is structured to
support server applications.  The chunked API is for now private,
although the intent to is to make it public for applications who
really want to use it.

Note that chunked transfer encoding puts data through extra copies.
First it copies through the buffering area (because I have to be able
to extract variable length strings from inside the data stream), and then
again to reassemble the chunks into a single unified object.

We do assume that the user wants the entire thing as a single object.
This means that using this to pull unbounded data will just silently
consume all memory. Use caution!

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
