### PR TITLE
Allow nng to be consumed in "add_subdirectory" scenarios

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -246,7 +246,7 @@ set_target_properties (${PROJECT_NAME} ${PROJECT_NAME}
 
 target_link_libraries (${PROJECT_NAME} PRIVATE ${NNG_LIBS})
 
-target_include_directories (${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include>)
+target_include_directories (${PROJECT_NAME} INTERFACE $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 install (TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}-target


### PR DESCRIPTION
This change allows to use nng as part of a bigger project using add_subdirectory.

e.g.: somebody adds nng as external dependency using:
```
FetchContent_Declare(
    nng
    URL https://github.com/nanomsg/nng/archive/v1.1.0.zip
)

FetchContent_GetProperties(nng)
if (NOT nng_POPULATED)
    FetchContent_Populate(nng)
    add_subdirectory(${nng_SOURCE_DIR} ${nng_BINARY_DIR})
endif()
```
and then later uses nng as target link library:
`target_link_library(nng_example nng)`

it will find the headers of (e.g. nng.h) using this change
