### PR TITLE
The toplevel sets threads already, not needed here.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ set (NNG_SRCS
 
 if (NNG_PLATFORM_POSIX)
     find_package (Threads REQUIRED)
+    list(APPEND NNG_LIBS Threads::Threads)
 
     set (NNG_SRCS ${NNG_SRCS}
         platform/posix/posix_impl.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,6 @@ set (NNG_SRCS
 
 if (NNG_PLATFORM_POSIX)
     find_package (Threads REQUIRED)
-    set(NNG_LIBS Threads::Threads)
 
     set (NNG_SRCS ${NNG_SRCS}
         platform/posix/posix_impl.h


### PR DESCRIPTION
I'm working on updating my Python bindings to use the new source code layout (splitting out `include`), and found out that nng no longer builds correctly on the Docker image I use to build packages on CI.  I [made an issue in pynng](https://github.com/codypiersall/pynng/issues/15) and I have tracked down the breaking change to https://github.com/nanomsg/nng/commit/77984b14a65c0a7387c97f3d36f947dd17358744.

To be honest I'm not really sure what's going on.  For some reason, in the Docker image, the test programs aren't getting linked with `librt` for `clock_gettime()`, but I'm not seeing the issue on my actual Linux box.

As far as I can tell, this change fixes the issues, but I really don't know why.  I don't know much about CMake.  There's probably a better fix :-).