### PR TITLE
fixes #769 How to limit worker threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,16 @@ if (NNG_ENABLE_STATS)
 endif()
 mark_as_advanced(NNG_ENABLE_STATS)
 
+if (NNG_RESOLV_CONCURRENCY)
+    add_definitions(-DNNG_RESOLV_CONCURRENCY=${NNG_RESOLV_CONCURRENCY})
+endif()
+mark_as_advanced(NNG_RESOLV_CONCURRENCY)
+
+if (NNG_NUM_TASKQ_THREADS)
+    add_definitions(-DNNG_NUM_TASKQ_THREADS=${NNG_NUM_TASKQ_THREADS})
+endif()
+mark_as_advanced(NNG_NUM_TASKQ_THREADS)
+
 #  Platform checks.
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -266,10 +266,14 @@ nni_taskq_sys_init(void)
 {
 	int nthrs;
 
+#ifndef NNG_NUM_TASKQ_THREADS
 	nthrs = nni_plat_ncpu() * 2;
 	if (nthrs < 2) {
 		nthrs = 2;
 	}
+#else
+	nthrs = NNG_NUM_TASKQ_THREADS;
+#endif
 
 	return (nni_taskq_init(&nni_taskq_systq, nthrs));
 }

--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -34,15 +34,15 @@
 // changed with this define.  Note that some platforms may not have a
 // thread-safe getaddrinfo().  In that case they should set this to 1.
 
-#ifndef NNG_POSIX_RESOLV_CONCURRENCY
-#define NNG_POSIX_RESOLV_CONCURRENCY 4
+#ifndef NNG_RESOLV_CONCURRENCY
+#define NNG_RESOLV_CONCURRENCY 4
 #endif
 
 static nni_mtx  resolv_mtx;
 static nni_cv   resolv_cv;
 static bool     resolv_fini;
 static nni_list resolv_aios;
-static nni_thr  resolv_thrs[NNG_POSIX_RESOLV_CONCURRENCY];
+static nni_thr  resolv_thrs[NNG_RESOLV_CONCURRENCY];
 
 typedef struct resolv_item resolv_item;
 struct resolv_item {
@@ -383,14 +383,14 @@ nni_posix_resolv_sysinit(void)
 
 	resolv_fini = false;
 
-	for (int i = 0; i < NNG_POSIX_RESOLV_CONCURRENCY; i++) {
+	for (int i = 0; i < NNG_RESOLV_CONCURRENCY; i++) {
 		int rv = nni_thr_init(&resolv_thrs[i], resolv_worker, NULL);
 		if (rv != 0) {
 			nni_posix_resolv_sysfini();
 			return (rv);
 		}
 	}
-	for (int i = 0; i < NNG_POSIX_RESOLV_CONCURRENCY; i++) {
+	for (int i = 0; i < NNG_RESOLV_CONCURRENCY; i++) {
 		nni_thr_run(&resolv_thrs[i]);
 	}
 
@@ -405,7 +405,7 @@ nni_posix_resolv_sysfini(void)
 	nni_cv_wake(&resolv_cv);
 	nni_mtx_unlock(&resolv_mtx);
 
-	for (int i = 0; i < NNG_POSIX_RESOLV_CONCURRENCY; i++) {
+	for (int i = 0; i < NNG_RESOLV_CONCURRENCY; i++) {
 		nni_thr_fini(&resolv_thrs[i]);
 	}
 	nni_cv_fini(&resolv_cv);

--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -22,15 +22,15 @@
 // host file, WINS, or other naming services.  As a result, we just build
 // our own limited asynchronous resolver with threads.
 
-#ifndef NNG_WIN_RESOLV_CONCURRENCY
-#define NNG_WIN_RESOLV_CONCURRENCY 4
+#ifndef NNG_RESOLV_CONCURRENCY
+#define NNG_RESOLV_CONCURRENCY 4
 #endif
 
 static nni_mtx  resolv_mtx;
 static nni_cv   resolv_cv;
 static bool     resolv_fini;
 static nni_list resolv_aios;
-static nni_thr  resolv_thrs[NNG_WIN_RESOLV_CONCURRENCY];
+static nni_thr  resolv_thrs[NNG_RESOLV_CONCURRENCY];
 
 typedef struct resolv_item resolv_item;
 struct resolv_item {
@@ -355,14 +355,14 @@ nni_win_resolv_sysinit(void)
 	nni_aio_list_init(&resolv_aios);
 
 	resolv_fini = false;
-	for (int i = 0; i < NNG_WIN_RESOLV_CONCURRENCY; i++) {
+	for (int i = 0; i < NNG_RESOLV_CONCURRENCY; i++) {
 		int rv = nni_thr_init(&resolv_thrs[i], resolv_worker, NULL);
 		if (rv != 0) {
 			nni_win_resolv_sysfini();
 			return (rv);
 		}
 	}
-	for (int i = 0; i < NNG_WIN_RESOLV_CONCURRENCY; i++) {
+	for (int i = 0; i < NNG_RESOLV_CONCURRENCY; i++) {
 		nni_thr_run(&resolv_thrs[i]);
 	}
 	return (0);
@@ -375,7 +375,7 @@ nni_win_resolv_sysfini(void)
 	resolv_fini = true;
 	nni_cv_wake(&resolv_cv);
 	nni_mtx_unlock(&resolv_mtx);
-	for (int i = 0; i < NNG_WIN_RESOLV_CONCURRENCY; i++) {
+	for (int i = 0; i < NNG_RESOLV_CONCURRENCY; i++) {
 		nni_thr_fini(&resolv_thrs[i]);
 	}
 	nni_cv_fini(&resolv_cv);


### PR DESCRIPTION
Although there are a number of recommendations in #769 on how to reduce the memory footprint, I am submitting a PR that deals mostly with just the title: provide a mechanism for limiting the number of worker threads. This PR exposes CMake variables to set the number of resolver and taskq threads, respectively. Maybe a separate Issue is warranted, for tracking change to default stack sizes of various internal threads?

I tested this using the async demo on a Ubuntu VM running on Windows. By default, 25 threads are created on my machine for the async demo, and with these changes I was able to reduce the number of resolver threads to 1 and the number of taskq threads to 2:

```
$ cmake -G Ninja -DNNG_RESOLV_CONCURRENCY=1 -DNNG_NUM_TASKQ_THREADS=2 ..
```

With these changes, I was able to run the async demo with 8 total threads instead of 25.

Reducing the memory footprint of nng is really important to my team for using nng on an embedded target, and this was an easy way for us to move in the right direction. 