### PR TITLE
fixes #825 TCP public API should use generic setopt/getopt

### DIFF
--- a/include/nng/supplemental/tcp/tcp.h
+++ b/include/nng/supplemental/tcp/tcp.h
@@ -58,22 +58,13 @@ NNG_DECL void nng_tcp_send(nng_tcp *, nng_aio *);
 // the iov's and resubmit as needed.
 NNG_DECL void nng_tcp_recv(nng_tcp *, nng_aio *);
 
-// nng_tcp_sockname obtains an nng_sockaddr associated with our local address.
-NNG_DECL int nng_tcp_sockname(nng_tcp *, nng_sockaddr *);
+// nng_tcp_getopt is used to retrieve socket options, using the named
+// option values, like NNG_OPT_TCP_NODELAY or NNG_OPT_REMADDR.
+NNG_DECL int nng_tcp_getopt(nng_tcp *, const char *, void *, size_t *);
 
-// nng_tcp_peername obtains an nng_sockaddr associated with our peer.
-NNG_DECL int nng_tcp_peername(nng_tcp *, nng_sockaddr *);
-
-// nng_tcp_set_nodelay is used to disable Nagle's algorithm (true) or
-// enable it.  For latency sensitive applications, disable it.  For
-// throughput operations involving tiny messages, leave it enabled.  We
-// usually recommend disabling it.
-NNG_DECL int nng_tcp_set_nodelay(nng_tcp *, bool);
-
-// nng_set_keepalive is used to enable the use of TCP keepalives.
-// At the moment there is no further tuning, because the tunables here
-// tend to be fairly platform specific.
-NNG_DECL int nng_tcp_set_keepalive(nng_tcp *, bool);
+// nng_tcp_setopt is used to set socket options, using the named
+// option values, like NNG_OPT_TCP_KEEPALIVE.
+NNG_DECL int nng_tcp_setopt(nng_tcp *, const char *, const void *, size_t);
 
 // nng_tcp_dialer_alloc is used to allocate a TCP dialer.
 NNG_DECL int nng_tcp_dialer_alloc(nng_tcp_dialer **);
@@ -91,14 +82,6 @@ NNG_DECL void nng_tcp_dialer_close(nng_tcp_dialer *);
 // the dialer after this call.
 NNG_DECL void nng_tcp_dialer_free(nng_tcp_dialer *);
 
-// nng_tcp_dialer_set_source is used to set the source address that the
-// dialer should dial from.  The port component of the socket address is
-// ignored, as a source port is always chosen at random.  If this is not
-// called, then a system specific default source address is chosen.
-// (Usually the local interface IP address chosen based on the route to
-// the destination.)
-NNG_DECL int nng_tcp_dialer_set_source(nng_tcp_dialer *, const nng_sockaddr *);
-
 // nng_tcp_dialer_dial attempts to create a new connection (nng_tcp *)
 // may making an outbound connect call.  If this succeeds, the aio
 // will return a suitable nng_tcp * in the first output of the aio.
@@ -106,6 +89,19 @@ NNG_DECL int nng_tcp_dialer_set_source(nng_tcp_dialer *, const nng_sockaddr *);
 // is stored in the 2nd argument.
 NNG_DECL void nng_tcp_dialer_dial(
     nng_tcp_dialer *, const nng_sockaddr *, nng_aio *);
+
+// nng_tcp_dialer_getopt gets an option.
+NNG_DECL int nng_tcp_dialer_getopt(
+    nng_tcp_dialer *, const char *, void *, size_t *);
+
+// nng_tcp_dialer_setopt sets an option.  This can be done to set the
+// initial values of NNG_OPT_TCP_NODELAY or NNG_OPT_TCP_KEEPALIVE for
+// created connections, for example.  Also, the NNG_OPT_LOCADDR can
+// be set, which sets the source address new connections will be
+// established from -- except that the port is ignored as it is always
+// randomly chosen.
+NNG_DECL int nng_tcp_dialer_setopt(
+    nng_tcp_dialer *, const char *, const void *, size_t);
 
 // nng_tcp_listener_alloc creates a listener.
 NNG_DECL int nng_tcp_listener_alloc(nng_tcp_listener **);
@@ -139,6 +135,18 @@ NNG_DECL int nng_tcp_listener_listen(nng_tcp_listener *, nng_sockaddr *);
 // nng_tcp * object), and returns it in the nng_aio as the first output
 // on success.
 NNG_DECL void nng_tcp_listener_accept(nng_tcp_listener *, nng_aio *);
+
+// nng_tcp_listener_getopt gets an option.  A good example of this is to
+// obtain the NNG_OPT_LOCADDR local address after starting the listener
+// on a wild card port (0).
+NNG_DECL int nng_tcp_listener_getopt(
+    nng_tcp_listener *, const char *, void *, size_t *);
+
+// nng_tcp_listener_setopt sets an option.  This can be done to set the
+// initial values of NNG_OPT_TCP_NODELAY or NNG_OPT_TCP_KEEPALIVE for
+// created connections, for example.
+NNG_DECL int nng_tcp_listener_setopt(
+    nng_tcp_listener *, const char *, const void *, size_t);
 
 #ifdef __cplusplus
 }

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -263,6 +263,18 @@ extern int nni_tcp_conn_set_nodelay(nni_tcp_conn *, bool);
 // keepalive probes.  Tuning of these keepalives is currently unsupported.
 extern int nni_tcp_conn_set_keepalive(nni_tcp_conn *, bool);
 
+// nni_tcp_conn_setopt is like setsockopt, but uses string names. These
+// are the same names from the TCP transport, generally.  Examples are
+// NNG_OPT_TCP_NODELAY and NNG_OPT_TCP_KEEPALIVE.
+extern int nni_tcp_conn_setopt(
+    nni_tcp_conn *, const char *, const void *, size_t, nni_type);
+
+// nni_tcp_conn_getopt is like getsockopt, but uses string names.
+// We support NNG_OPT_REMADDR and NNG_OPT_LOCADDR (with argument type
+// nng_sockaddr), and NNG_OPT_TCP_NODELAY and NNG_OPT_TCP_KEEPALIVE.
+extern int nni_tcp_conn_getopt(
+    nni_tcp_conn *, const char *, void *, size_t *, nni_type);
+
 // nni_tcp_dialer_init creates a new dialer object.
 extern int nni_tcp_dialer_init(nni_tcp_dialer **);
 
@@ -275,20 +287,23 @@ extern void nni_tcp_dialer_fini(nni_tcp_dialer *);
 // connection will be aborted.
 extern void nni_tcp_dialer_close(nni_tcp_dialer *);
 
-// nni_tcp_dialer_set_src_addr sets the source address to use for outgoing
-// connections.  Only the IP (or IPv6) address may be specified; the port
-// must be zero.  This must be called before calling nni_tcp_dialer_dial.
-// The source address must be associated with one of the addresses on the
-// local system -- this is not checked until bind() is called just prior to
-// the connect() call.  Likewise the address family must be the same as the
-// address used when dialing, or errors will occur.
-extern int nni_tcp_dialer_set_src_addr(nni_tcp_dialer *, const nng_sockaddr *);
-
 // nni_tcp_dialer_dial attempts to create an outgoing connection,
 // asynchronously, to the address specified. On success, the first (and only)
 // output will be an nni_tcp_conn * associated with the remote server.
 extern void nni_tcp_dialer_dial(
     nni_tcp_dialer *, const nni_sockaddr *, nni_aio *);
+
+// nni_tcp_dialer_getopt gets an option from the dialer.
+extern int nni_tcp_dialer_setopt(
+    nni_tcp_dialer *, const char *, const void *, size_t, nni_type);
+
+// nni_tcp_dialer_setopt sets an option on the dialer. There is special
+// support for NNG_OPT_LOCADDR, which will be the source address (if legal)
+// for new connections, except that the port will be ignored.  The
+// NNG_OPT_TCP_NODELAY and NNG_OPT_TCP_KEEPALIVE options work to set the
+// initial values of those options on newly created connections.
+extern int nni_tcp_dialer_getopt(
+    nni_tcp_dialer *, const char *, void *, size_t *, nni_type);
 
 // nni_tcp_listener_init creates a new listener object, unbound.
 extern int nni_tcp_listener_init(nni_tcp_listener **);
@@ -312,6 +327,16 @@ extern int nni_tcp_listener_listen(nni_tcp_listener *, nni_sockaddr *);
 // On success, the first (and only) output will be an nni_tcp_conn *
 // associated with the remote peer.
 extern void nni_tcp_listener_accept(nni_tcp_listener *, nni_aio *);
+
+// nni_tcp_listener_getopt gets an option from the listener.
+extern int nni_tcp_listener_setopt(
+    nni_tcp_listener *, const char *, const void *, size_t, nni_type);
+
+// nni_tcp_listener_setopt sets an option on the listener.  The most common
+// use for this is to retrieve the setting of the NNG_OPT_TCP_LOCADDR
+// address after binding to wild card port (0).
+extern int nni_tcp_listener_getopt(
+    nni_tcp_listener *, const char *, void *, size_t *, nni_type);
 
 // nni_ntop obtains the IP address for the socket (enclosing it
 // in brackets if it is IPv6) and port.  Enough space for both must

--- a/src/platform/posix/posix_tcp.h
+++ b/src/platform/posix/posix_tcp.h
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -10,7 +11,6 @@
 
 #include "core/nng_impl.h"
 
-#ifdef NNG_PLATFORM_POSIX
 #include "platform/posix/posix_aio.h"
 
 struct nni_tcp_conn {
@@ -27,6 +27,8 @@ struct nni_tcp_conn {
 struct nni_tcp_dialer {
 	nni_list                connq; // pending connections
 	bool                    closed;
+	bool                    nodelay;
+	bool                    keepalive;
 	struct sockaddr_storage src;
 	size_t                  srclen;
 	nni_mtx                 mtx;
@@ -37,10 +39,10 @@ struct nni_tcp_listener {
 	nni_list       acceptq;
 	bool           started;
 	bool           closed;
+	bool           nodelay;
+	bool           keepalive;
 	nni_mtx        mtx;
 };
 
 extern int  nni_posix_tcp_conn_init(nni_tcp_conn **, nni_posix_pfd *);
-extern void nni_posix_tcp_conn_start(nni_tcp_conn *);
-
-#endif // NNG_PLATFORM_POSIX
+extern void nni_posix_tcp_conn_start(nni_tcp_conn *, int, int);

--- a/src/platform/posix/posix_tcplisten.c
+++ b/src/platform/posix/posix_tcplisten.c
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -9,8 +10,6 @@
 //
 
 #include "core/nng_impl.h"
-
-#ifdef NNG_PLATFORM_POSIX
 
 #include <arpa/inet.h>
 #include <errno.h>
@@ -82,6 +81,8 @@ tcp_listener_doaccept(nni_tcp_listener *l)
 		int            newfd;
 		int            fd;
 		int            rv;
+		int            nd;
+		int            ka;
 		nni_posix_pfd *pfd;
 		nni_tcp_conn * c;
 
@@ -139,8 +140,10 @@ tcp_listener_doaccept(nni_tcp_listener *l)
 			continue;
 		}
 
+		ka = l->keepalive ? 1 : 0;
+		nd = l->nodelay ? 1 : 0;
 		nni_aio_list_remove(aio);
-		nni_posix_tcp_conn_start(c);
+		nni_posix_tcp_conn_start(c, nd, ka);
 		nni_aio_set_output(aio, 0, c);
 		nni_aio_finish(aio, 0, 0);
 	}
@@ -315,4 +318,109 @@ nni_tcp_listener_accept(nni_tcp_listener *l, nni_aio *aio)
 	nni_mtx_unlock(&l->mtx);
 }
 
-#endif // NNG_PLATFORM_POSIX
+static int
+tcp_listener_get_locaddr(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_tcp_listener *l = arg;
+	nng_sockaddr      sa;
+	nni_mtx_lock(&l->mtx);
+	if (l->started) {
+		struct sockaddr_storage ss;
+		socklen_t               len = sizeof(ss);
+		(void) getsockname(
+		    nni_posix_pfd_fd(l->pfd), (void *) &ss, &len);
+		(void) nni_posix_sockaddr2nn(&sa, &ss);
+	} else {
+		sa.s_family = NNG_AF_UNSPEC;
+	}
+	nni_mtx_unlock(&l->mtx);
+	return (nni_copyout_sockaddr(&sa, buf, szp, t));
+}
+
+static int
+tcp_listener_set_nodelay(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_tcp_listener *l = arg;
+	int               rv;
+	bool              b;
+
+	if (((rv = nni_copyin_bool(&b, buf, sz, t)) != 0) || (l == NULL)) {
+		return (rv);
+	}
+	nni_mtx_lock(&l->mtx);
+	l->nodelay = b;
+	nni_mtx_unlock(&l->mtx);
+	return (0);
+}
+
+static int
+tcp_listener_get_nodelay(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	bool              b;
+	nni_tcp_listener *l = arg;
+	nni_mtx_lock(&l->mtx);
+	b = l->nodelay;
+	nni_mtx_unlock(&l->mtx);
+	return (nni_copyout_bool(b, buf, szp, t));
+}
+
+static int
+tcp_listener_set_keepalive(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_tcp_listener *l = arg;
+	int               rv;
+	bool              b;
+
+	if (((rv = nni_copyin_bool(&b, buf, sz, t)) != 0) || (l == NULL)) {
+		return (rv);
+	}
+	nni_mtx_lock(&l->mtx);
+	l->keepalive = b;
+	nni_mtx_unlock(&l->mtx);
+	return (0);
+}
+
+static int
+tcp_listener_get_keepalive(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	bool              b;
+	nni_tcp_listener *l = arg;
+	nni_mtx_lock(&l->mtx);
+	b = l->keepalive;
+	nni_mtx_unlock(&l->mtx);
+	return (nni_copyout_bool(b, buf, szp, t));
+}
+
+static const nni_option tcp_listener_options[] = {
+	{
+	    .o_name = NNG_OPT_LOCADDR,
+	    .o_get  = tcp_listener_get_locaddr,
+	},
+	{
+	    .o_name = NNG_OPT_TCP_NODELAY,
+	    .o_set  = tcp_listener_set_nodelay,
+	    .o_get  = tcp_listener_get_nodelay,
+	},
+	{
+	    .o_name = NNG_OPT_TCP_KEEPALIVE,
+	    .o_set  = tcp_listener_set_keepalive,
+	    .o_get  = tcp_listener_get_keepalive,
+	},
+	{
+	    .o_name = NULL,
+	},
+};
+
+int
+nni_tcp_listener_getopt(
+    nni_tcp_listener *l, const char *name, void *buf, size_t *szp, nni_type t)
+{
+	return (nni_getopt(tcp_listener_options, name, l, buf, szp, t));
+}
+
+int
+nni_tcp_listener_setopt(nni_tcp_listener *l, const char *name, const void *buf,
+    size_t sz, nni_type t)
+{
+	return (nni_setopt(tcp_listener_options, name, l, buf, sz, t));
+}

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -75,9 +75,7 @@ struct nni_plat_flock {
 
 extern int nni_win_error(int);
 
-extern int  nni_win_tcp_conn_init(nni_tcp_conn **, SOCKET);
-extern void nni_win_tcp_conn_set_addrs(
-    nni_tcp_conn *, const SOCKADDR_STORAGE *, const SOCKADDR_STORAGE *);
+extern int nni_win_tcp_conn_init(nni_tcp_conn **, SOCKET);
 
 extern int  nni_win_io_sysinit(void);
 extern void nni_win_io_sysfini(void);

--- a/src/platform/windows/win_tcp.h
+++ b/src/platform/windows/win_tcp.h
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -15,7 +16,7 @@
 
 #include "core/nng_impl.h"
 
-#ifdef NNG_PLATFORM_WINDOWS
+#include <nng/transport/tcp/tcp.h>
 
 struct nni_tcp_conn {
 	SOCKET            s;
@@ -42,6 +43,8 @@ struct nni_tcp_dialer {
 	LPFN_CONNECTEX   connectex; // looked up name via ioctl
 	nni_list         aios;      // in flight connections
 	bool             closed;
+	bool             nodelay;   // initial value for child conns
+	bool             keepalive; // initial value for child conns
 	SOCKADDR_STORAGE src;
 	size_t           srclen;
 	nni_mtx          mtx;
@@ -53,6 +56,8 @@ struct nni_tcp_listener {
 	nni_list                  aios;
 	bool                      closed;
 	bool                      started;
+	bool                      nodelay;   // initial value for child conns
+	bool                      keepalive; // initial value for child conns
 	LPFN_ACCEPTEX             acceptex;
 	LPFN_GETACCEPTEXSOCKADDRS getacceptexsockaddrs;
 	SOCKADDR_STORAGE          ss;
@@ -60,10 +65,6 @@ struct nni_tcp_listener {
 	nni_reap_item             reap;
 };
 
-extern int  nni_win_tcp_conn_init(nni_tcp_conn **, SOCKET);
-extern void nni_win_tcp_conn_set_addrs(
-    nni_tcp_conn *, const SOCKADDR_STORAGE *, const SOCKADDR_STORAGE *);
-
-#endif // NNG_PLATFORM_WINDOWS
+extern int nni_win_tcp_conn_init(nni_tcp_conn **, SOCKET);
 
 #endif // NNG_PLATFORM_WIN_WINTCP_H

--- a/src/platform/windows/win_tcplisten.c
+++ b/src/platform/windows/win_tcplisten.c
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -9,8 +10,6 @@
 //
 
 #include "core/nng_impl.h"
-
-#ifdef NNG_PLATFORM_WINDOWS
 
 #include <malloc.h>
 #include <stdbool.h>
@@ -76,6 +75,8 @@ tcp_accept_cb(nni_win_io *io, int rv, size_t cnt)
 	SOCKADDR *        sa1;
 	SOCKADDR *        sa2;
 	DWORD             yes;
+	BOOL              nd;
+	BOOL              ka;
 
 	NNI_ARG_UNUSED(cnt);
 
@@ -92,6 +93,8 @@ tcp_accept_cb(nni_win_io *io, int rv, size_t cnt)
 	if (c->conn_rv != 0) {
 		rv = c->conn_rv;
 	}
+	nd = l->nodelay ? TRUE : FALSE;
+	ka = l->keepalive ? TRUE : FALSE;
 	nni_mtx_unlock(&l->mtx);
 
 	if (rv != 0) {
@@ -109,6 +112,13 @@ tcp_accept_cb(nni_win_io *io, int rv, size_t cnt)
 	yes = 1;
 	(void) setsockopt(c->s, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
 	    (char *) &yes, sizeof(yes));
+
+	(void) setsockopt(
+	    c->s, SOL_SOCKET, SO_KEEPALIVE, (char *) &ka, sizeof(ka));
+
+	(void) setsockopt(
+	    c->s, IPPROTO_TCP, TCP_NODELAY, (char *) &nd, sizeof(nd));
+
 	nni_aio_set_output(aio, 0, c);
 	nni_aio_finish(aio, 0, 0);
 }
@@ -129,6 +139,11 @@ nni_tcp_listener_init(nni_tcp_listener **lp)
 		nni_tcp_listener_fini(l);
 		return (rv);
 	}
+
+	// We assume these defaults -- not everyone will agree, but anyone
+	// can change them.
+	l->keepalive = false;
+	l->nodelay   = true;
 
 	*lp = l;
 	return (0);
@@ -313,4 +328,105 @@ nni_tcp_listener_accept(nni_tcp_listener *l, nni_aio *aio)
 	nni_mtx_unlock(&l->mtx);
 }
 
-#endif // NNG_PLATFORM_WINDOWS
+static int
+tcp_listener_get_locaddr(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_tcp_listener *l = arg;
+	nng_sockaddr      sa;
+	nni_mtx_lock(&l->mtx);
+	if (l->started) {
+		nni_win_sockaddr2nn(&sa, &l->ss);
+	} else {
+		sa.s_family = NNG_AF_UNSPEC;
+	}
+	nni_mtx_unlock(&l->mtx);
+	return (nni_copyout_sockaddr(&sa, buf, szp, t));
+}
+
+static int
+tcp_listener_set_nodelay(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_tcp_listener *l = arg;
+	int               rv;
+	bool              b;
+
+	if (((rv = nni_copyin_bool(&b, buf, sz, t)) != 0) || (l == NULL)) {
+		return (rv);
+	}
+	nni_mtx_lock(&l->mtx);
+	l->nodelay = b;
+	nni_mtx_unlock(&l->mtx);
+	return (0);
+}
+
+static int
+tcp_listener_get_nodelay(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	bool              b;
+	nni_tcp_listener *l = arg;
+	nni_mtx_lock(&l->mtx);
+	b = l->nodelay;
+	nni_mtx_unlock(&l->mtx);
+	return (nni_copyout_bool(b, buf, szp, t));
+}
+
+static int
+tcp_listener_set_keepalive(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_tcp_listener *l = arg;
+	int               rv;
+	bool              b;
+
+	if (((rv = nni_copyin_bool(&b, buf, sz, t)) != 0) || (l == NULL)) {
+		return (rv);
+	}
+	nni_mtx_lock(&l->mtx);
+	l->keepalive = b;
+	nni_mtx_unlock(&l->mtx);
+	return (0);
+}
+
+static int
+tcp_listener_get_keepalive(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	bool              b;
+	nni_tcp_listener *l = arg;
+	nni_mtx_lock(&l->mtx);
+	b = l->keepalive;
+	nni_mtx_unlock(&l->mtx);
+	return (nni_copyout_bool(b, buf, szp, t));
+}
+
+static const nni_option tcp_listener_options[] = {
+	{
+	    .o_name = NNG_OPT_LOCADDR,
+	    .o_get  = tcp_listener_get_locaddr,
+	},
+	{
+	    .o_name = NNG_OPT_TCP_NODELAY,
+	    .o_set  = tcp_listener_set_nodelay,
+	    .o_get  = tcp_listener_get_nodelay,
+	},
+	{
+	    .o_name = NNG_OPT_TCP_KEEPALIVE,
+	    .o_set  = tcp_listener_set_keepalive,
+	    .o_get  = tcp_listener_get_keepalive,
+	},
+	{
+	    .o_name = NULL,
+	},
+};
+
+int
+nni_tcp_listener_getopt(
+    nni_tcp_listener *l, const char *name, void *buf, size_t *szp, nni_type t)
+{
+	return (nni_getopt(tcp_listener_options, name, l, buf, szp, t));
+}
+
+int
+nni_tcp_listener_setopt(nni_tcp_listener *l, const char *name, const void *buf,
+    size_t sz, nni_type t)
+{
+	return (nni_setopt(tcp_listener_options, name, l, buf, sz, t));
+}

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -12,9 +13,8 @@
 #define NNG_SUPPLEMENTAL_HTTP_HTTP_API_H
 
 #include "core/nng_impl.h"
-#include "nng/supplemental/tls/tls.h"
-
-#include "nng/supplemental/http/http.h"
+#include <nng/supplemental/http/http.h>
+#include <nng/supplemental/tls/tls.h>
 
 // This represents the "internal" HTTP API.  It should not be used
 // or exposed to applications directly.
@@ -102,6 +102,10 @@ extern int nni_http_conn_init_tls(
 
 extern void nni_http_conn_close(nni_http_conn *);
 extern void nni_http_conn_fini(nni_http_conn *);
+extern int  nni_http_conn_getopt(
+     nni_http_conn *, const char *, void *, size_t *, nni_type);
+extern int nni_http_conn_setopt(
+    nni_http_conn *, const char *, const void *, size_t, nni_type);
 
 // Reading messages -- the caller must supply a preinitialized (but otherwise
 // idle) message.  We recommend the caller store this in the aio's user data.
@@ -161,11 +165,6 @@ extern void nni_http_read(nni_http_conn *, nni_aio *);
 extern void nni_http_read_full(nni_http_conn *, nni_aio *);
 extern void nni_http_write(nni_http_conn *, nni_aio *);
 extern void nni_http_write_full(nni_http_conn *, nni_aio *);
-extern int  nni_http_sock_addr(nni_http_conn *, nni_sockaddr *);
-extern int  nni_http_peer_addr(nni_http_conn *, nni_sockaddr *);
-
-// nni_http_tls_verified returns true if the peer has been verified using TLS.
-extern bool nni_http_tls_verified(nni_http_conn *);
 
 // nni_http_server will look for an existing server with the same
 // name and port, or create one if one does not exist.  The servers

--- a/src/supplemental/tcp/tcp.c
+++ b/src/supplemental/tcp/tcp.c
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -51,27 +52,17 @@ nng_tcp_recv(nng_tcp *tcp, nng_aio *aio)
 }
 
 int
-nng_tcp_sockname(nng_tcp *tcp, nng_sockaddr *sa)
+nng_tcp_getopt(nng_tcp *tcp, const char *name, void *buf, size_t *szp)
 {
-	return (nni_tcp_conn_sockname((void *) tcp, sa));
+	return (nni_tcp_conn_getopt(
+	    (void *) tcp, name, buf, szp, NNI_TYPE_OPAQUE));
 }
 
 int
-nng_tcp_peername(nng_tcp *tcp, nng_sockaddr *sa)
+nng_tcp_setopt(nng_tcp *tcp, const char *name, const void *buf, size_t sz)
 {
-	return (nni_tcp_conn_peername((void *) tcp, sa));
-}
-
-int
-nng_tcp_set_nodelay(nng_tcp *tcp, bool nodelay)
-{
-	return (nni_tcp_conn_set_nodelay((void *) tcp, nodelay));
-}
-
-int
-nng_tcp_set_keepalive(nng_tcp *tcp, bool ka)
-{
-	return (nni_tcp_conn_set_keepalive((void *) tcp, ka));
+	return (
+	    nni_tcp_conn_setopt((void *) tcp, name, buf, sz, NNI_TYPE_OPAQUE));
 }
 
 int
@@ -99,12 +90,6 @@ void
 nng_tcp_dialer_free(nng_tcp_dialer *d)
 {
 	nni_tcp_dialer_fini((void *) d);
-}
-
-int
-nng_tcp_dialer_set_source(nng_tcp_dialer *d, const nng_sockaddr *sa)
-{
-	return (nni_tcp_dialer_set_src_addr((void *) d, sa));
 }
 
 void
@@ -150,4 +135,20 @@ void
 nng_tcp_listener_accept(nng_tcp_listener *l, nng_aio *aio)
 {
 	nni_tcp_listener_accept((void *) l, aio);
+}
+
+int
+nng_tcp_listener_getopt(
+    nng_tcp_listener *l, const char *name, void *buf, size_t *szp)
+{
+	return (nni_tcp_listener_getopt(
+	    (void *) l, name, buf, szp, NNI_TYPE_OPAQUE));
+}
+
+int
+nng_tcp_listener_setopt(
+    nng_tcp_listener *l, const char *name, const void *buf, size_t sz)
+{
+	return (nni_tcp_listener_setopt(
+	    (void *) l, name, buf, sz, NNI_TYPE_OPAQUE));
 }

--- a/src/supplemental/tls/none/tls.c
+++ b/src/supplemental/tls/none/tls.c
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -17,8 +18,9 @@
 // We provide stub functions only to satisfy linkage.
 
 #include "core/nng_impl.h"
-#include "nng/supplemental/tls/tls.h"
 #include "supplemental/tls/tls_api.h"
+
+#include <nng/supplemental/tls/tls.h>
 
 void
 nni_tls_config_fini(nng_tls_config *cfg)
@@ -72,40 +74,34 @@ nni_tls_recv(nni_tls *tp, nni_aio *aio)
 	nni_aio_finish_error(aio, NNG_ENOTSUP);
 }
 
-int
-nni_tls_peername(nni_tls *tp, nni_sockaddr *sa)
-{
-	NNI_ARG_UNUSED(tp);
-	NNI_ARG_UNUSED(sa);
-	return (NNG_ENOTSUP);
-}
-
-int
-nni_tls_sockname(nni_tls *tp, nni_sockaddr *sa)
-{
-	NNI_ARG_UNUSED(tp);
-	NNI_ARG_UNUSED(sa);
-	return (NNG_ENOTSUP);
-}
-
 void
 nni_tls_close(nni_tls *tp)
 {
 	NNI_ARG_UNUSED(tp);
 }
 
-const char *
-nni_tls_ciphersuite_name(nni_tls *tp)
+int
+nni_tls_getopt(
+    nni_tls *tp, const char *name, void *buf, size_t *szp, nni_type t)
 {
 	NNI_ARG_UNUSED(tp);
-	return (NULL);
+	NNI_ARG_UNUSED(name);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(szp);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
 }
 
-bool
-nni_tls_verified(nni_tls *tp)
+int
+nni_tls_setopt(
+    nni_tls *tp, const char *name, const void *buf, size_t sz, nni_type t)
 {
 	NNI_ARG_UNUSED(tp);
-	return (false);
+	NNI_ARG_UNUSED(name);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
 }
 
 int

--- a/src/supplemental/tls/tls_api.h
+++ b/src/supplemental/tls/tls_api.h
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -12,6 +13,8 @@
 #define NNG_SUPPLEMENTAL_TLS_TLS_API_H
 
 #include <stdbool.h>
+
+#include <nng/supplemental/tls/tls.h>
 
 // nni_tls represents the context for a single TLS stream.
 typedef struct nni_tls nni_tls;
@@ -36,19 +39,10 @@ extern void nni_tls_close(nni_tls *);
 extern void nni_tls_fini(nni_tls *);
 extern void nni_tls_send(nni_tls *, nng_aio *);
 extern void nni_tls_recv(nni_tls *, nng_aio *);
-extern int  nni_tls_sockname(nni_tls *, nni_sockaddr *);
-extern int  nni_tls_peername(nni_tls *, nni_sockaddr *);
-extern int  nni_tls_set_nodelay(nni_tls *, bool);
-extern int  nni_tls_set_keepalive(nni_tls *, bool);
 
-// nni_tls_verified returns true if the peer, or false if the peer did not
-// verify.  (During the handshake phase, the peer is not verified, so this
-// might return false if executed too soon.  The verification status will
-// be accurate once the handshake is finished, however.
-extern bool nni_tls_verified(nni_tls *);
-
-// nni_tls_ciphersuite_name returns the name of the ciphersuite in use.
-extern const char *nni_tls_ciphersuite_name(nni_tls *);
+extern int nni_tls_setopt(
+    nni_tls *, const char *, const void *, size_t, nni_type);
+extern int nni_tls_getopt(nni_tls *, const char *, void *, size_t *, nni_type);
 
 // TBD: getting additional peer certificate information...
 

--- a/src/supplemental/websocket/websocket.h
+++ b/src/supplemental/websocket/websocket.h
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -52,18 +53,16 @@ extern int  nni_ws_dialer_get_tls(nni_ws_dialer *, nng_tls_config **);
 // not confirm the server's response at the HTTP level.  (It can still issue
 // a websocket close).
 
-extern void          nni_ws_send_msg(nni_ws *, nng_aio *);
-extern void          nni_ws_recv_msg(nni_ws *, nng_aio *);
-extern nng_http_res *nni_ws_response(nni_ws *);
-extern nng_http_req *nni_ws_request(nni_ws *);
-extern int           nni_ws_sock_addr(nni_ws *, nni_sockaddr *);
-extern int           nni_ws_peer_addr(nni_ws *, nni_sockaddr *);
-extern void          nni_ws_close(nni_ws *);
-extern void          nni_ws_close_error(nni_ws *, uint16_t);
-extern void          nni_ws_fini(nni_ws *);
-extern const char *  nni_ws_response_headers(nni_ws *);
-extern const char *  nni_ws_request_headers(nni_ws *);
-extern bool          nni_ws_tls_verified(nni_ws *);
+extern void        nni_ws_send_msg(nni_ws *, nng_aio *);
+extern void        nni_ws_recv_msg(nni_ws *, nng_aio *);
+extern void        nni_ws_close(nni_ws *);
+extern void        nni_ws_close_error(nni_ws *, uint16_t);
+extern void        nni_ws_fini(nni_ws *);
+extern const char *nni_ws_response_headers(nni_ws *);
+extern const char *nni_ws_request_headers(nni_ws *);
+extern int nni_ws_getopt(nni_ws *, const char *, void *, size_t *, nni_type);
+extern int nni_ws_setopt(
+    nni_ws *, const char *, const void *, size_t, nni_type);
 
 // The implementation will send periodic PINGs, and respond with PONGs.
 

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2018 Devolutions <info@devolutions.net>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -93,6 +94,7 @@ TestMain("TCP Transport", {
 	Convey("We can bind to port zero", {
 		nng_socket   s1;
 		nng_socket   s2;
+		nng_sockaddr sa;
 		nng_listener l;
 		char *       addr;
 
@@ -105,6 +107,10 @@ TestMain("TCP Transport", {
 		So(nng_listen(s1, "tcp://127.0.0.1:0", &l, 0) == 0);
 		So(nng_listener_getopt_string(l, NNG_OPT_URL, &addr) == 0);
 		So(memcmp(addr, "tcp://", 6) == 0);
+		So(nng_listener_getopt_sockaddr(l, NNG_OPT_LOCADDR, &sa) == 0);
+		So(sa.s_in.sa_family == NNG_AF_INET);
+		So(sa.s_in.sa_port != 0);
+		So(sa.s_in.sa_addr = htonl(0x7f000001));
 		So(nng_dial(s2, addr, NULL, 0) == 0);
 		nng_strfree(addr);
 	});


### PR DESCRIPTION
This changes much of the internal API for TCP option handling, and
includes hooks for some of this in various consumers.  Note that the
consumers still need to have additional work done to complete them,
which will be part of providing public "raw" TLS and WebSocket APIs.

We would also like to finish addressing the call sites of
nni_tcp_listener_start() that assume the sockaddr is modified --
it would be superior to use the NNG_OPT_LOCADDR option.  Thaat will be
addressed in a follow up PR.
