### PR TITLE
fixes #867 doc references to non-existant NNG_OPT_LINGER

### DIFF
--- a/docs/man/nng_close.3.adoc
+++ b/docs/man/nng_close.3.adoc
@@ -26,8 +26,7 @@ int nng_close(nng_socket s);
 
 The `nng_close()` function closes the supplied socket, _s_.
 Messages that have been submitted for sending may be flushed or delivered,
-depending upon the transport and the setting of the
-`<<nng_options.5#NNG_OPT_LINGER,NNG_OPT_LINGER>>` option.
+depending upon the transport.
 
 Further attempts to use the socket after this call returns will result
 in `NNG_ECLOSED`.

--- a/docs/man/nng_ctx_close.3.adoc
+++ b/docs/man/nng_ctx_close.3.adoc
@@ -26,8 +26,7 @@ int nng_ctx_close(nng_ctx ctx);
 
 The `nng_ctx_close()` function closes the context _ctx_.
 Messages that have been submitted for sending may be flushed or delivered,
-depending upon the transport and the setting of the
-`<<nng_options.5#NNG_OPT_LINGER,NNG_OPT_LINGER>>` option.
+depending upon the transport.
 
 Further attempts to use the context after this call returns will result
 in `NNG_ECLOSED`.

--- a/docs/man/nng_dial.3.adoc
+++ b/docs/man/nng_dial.3.adoc
@@ -26,7 +26,7 @@ int nng_dial(nng_socket s, const char *url, nng_dialer *dp, int flags);
 
 The `nng_dial()` function creates a newly initialized
 `<<nng_dialer.5#,nng_dialer>>` object,
-associated with socket _s_, and configured to listen at the
+associated with socket _s_, and configured to dial the
 address specified by _url_, and starts it.
 If the value of _dp_ is not `NULL`, then
 the newly created dialer is stored at the address indicated by _dp_.

--- a/docs/man/nng_pipe_close.3.adoc
+++ b/docs/man/nng_pipe_close.3.adoc
@@ -26,8 +26,7 @@ int nng_pipe_close(nng_pipe p);
 
 The `nng_pipe_close()` function closes the supplied pipe, _p_.
 Messages that have been submitted for sending may be flushed or delivered,
-depending upon the transport and the setting of the
-`<<nng_options.5#NNG_OPT_LINGER,NNG_OPT_LINGER>>` option.
+depending upon the transport.
 
 Further attempts to use the pipe after this call returns will result
 in `NNG_ECLOSED`.

--- a/docs/man/nng_pipe_getopt.3.adoc
+++ b/docs/man/nng_pipe_getopt.3.adoc
@@ -21,7 +21,7 @@ nng_pipe_getopt - get pipe option
 
 int nng_pipe_getopt(nng_pipe p, const char *opt, void *val, size_t *valszp);
 
-int nng_pipe_getopt_bool(nng_pipe p, const char *opt, int *bvalp);
+int nng_pipe_getopt_bool(nng_pipe p, const char *opt, bool *bvalp);
 
 int nng_pipe_getopt_int(nng_pipe p, const char *opt, int *ivalp);
 

--- a/docs/man/nng_recv.3.adoc
+++ b/docs/man/nng_recv.3.adoc
@@ -19,7 +19,7 @@ nng_recv - recv data
 ----
 #include <nng/nng.h>
 
-int nng_recv(nng_socket s, void *data, size_t *sizep int flags);
+int nng_recv(nng_socket s, void *data, size_t *sizep, int flags);
 ----
 
 == DESCRIPTION

--- a/docs/man/nng_strfree.3.adoc
+++ b/docs/man/nng_strfree.3.adoc
@@ -11,7 +11,7 @@
 
 == NAME
 
-nng_free - free memory
+nng_strfree - free memory
 
 == SYNOPSIS
 


### PR DESCRIPTION
fixes #867 doc references to non-existant NNG_OPT_LINGER

Probably doesn't need additional warning/text, just remove references to NNG_OPT_LINGER and fix some other minor typos I've come across.