### PR TITLE
Fix bug #868

### DIFF
--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -14,6 +14,11 @@
 
 #ifdef NNG_PLATFORM_WINDOWS
 
+//mingw does not define InterlockedAddNoFence64, use the mingw equivelent
+#ifdef __MINGW32__ || __MINGW64__
+#define InterlockedAddNoFence64(a,b) __atomic_add_fetch(a,b,__ATOMIC_RELAXED)
+#endif
+
 #include <stdlib.h>
 
 void *


### PR DESCRIPTION
fixes #868 Build failed on MinGW (mingw-w64) nng 1.1.1

Define an InterlockedAddNoFence64() function using gcc's atomics on
mingw(32|64)
(https://gcc.gnu.org/onlinedocs/gcc/_005f_005fatomic-Builtins.html)