### PR TITLE
add -fPIC to please the linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,7 @@ nng_check_sym (strncasecmp string.h NNG_HAVE_STRNCASECMP)
 # resolve.
 if (NOT(BUILD_SHARED_LIBS))
     set (NNG_STATIC_LIB ON)
+    set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     message(STATUS "Building static libs")
 endif()
 


### PR DESCRIPTION
compiling for the node.js binding, linker complains about symbols and wants recompile w/ `-fPIC`

```bash
  SOLINK_MODULE(target) Release/obj.target/nodenng.node
/usr/bin/ld: ../deps/lib/libnng.a(socket.c.o): relocation R_X86_64_PC32 against symbol `nni_dialer_reap' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make: *** [nodenng.target.mk:134: Release/obj.target/nodenng.node] Error 1
make: Leaving directory '/home/shark/reqshark/nngnode/node_modules/nodenng/build'
```

may we add `-fPIC` flag to the linker?

if so cmake way to do that is `set(CMAKE_POSITION_INDEPENDENT_CODE ON)`

otherwise i'll have to compile it as a shared lib... :(
