### PR TITLE
fixes #894 nng_pipe_notify could use nng_pipe_ev typedef instead of int

### DIFF
--- a/docs/man/nng_pipe_notify.3.adoc
+++ b/docs/man/nng_pipe_notify.3.adoc
@@ -1,7 +1,8 @@
 = nng_pipe_notify(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2019 Devolutions <info@devolutions.net>
 //
 // This document is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -19,15 +20,15 @@ nng_pipe_notify - register pipe notification callback
 ----
 #include <nng/nng.h>
 
-enum {
+typedef enum {
         NNG_PIPE_EV_ADD_PRE,
         NNG_PIPE_EV_ADD_POST,
         NNG_PIPE_EV_REM_POST,
-};
+} nng_pipe_ev;
 
-typedef void (*nng_pipe_cb)(nng_pipe, int, void *);
+typedef void (*nng_pipe_cb)(nng_pipe, nng_pipe_ev, void *);
 
-int nng_pipe_notify(nng_socket s, int ev, nng_pipe_cb cb, void *arg);
+int nng_pipe_notify(nng_socket s, nng_pipe_ev ev, nng_pipe_cb cb, void *arg);
 ----
 
 == DESCRIPTION

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -232,12 +232,12 @@ typedef enum {
 	NNG_PIPE_EV_NUM,      // Used internally, must be last.
 } nng_pipe_ev;
 
-typedef void (*nng_pipe_cb)(nng_pipe, int, void *);
+typedef void (*nng_pipe_cb)(nng_pipe, nng_pipe_ev, void *);
 
 // nng_pipe_notify registers a callback to be executed when the
 // given event is triggered.  To watch for different events, register
 // multiple times.  Each event can have at most one callback registered.
-NNG_DECL int nng_pipe_notify(nng_socket, int, nng_pipe_cb, void *);
+NNG_DECL int nng_pipe_notify(nng_socket, nng_pipe_ev, nng_pipe_cb, void *);
 
 // nng_getopt_string is special -- it allocates a string to hold the
 // resulting string, which should be freed with nng_strfree when it is

--- a/src/nng.c
+++ b/src/nng.c
@@ -1017,7 +1017,7 @@ nng_getopt_string(nng_socket s, const char *name, char **valp)
 }
 
 int
-nng_pipe_notify(nng_socket s, int ev, nng_pipe_cb cb, void *arg)
+nng_pipe_notify(nng_socket s, nng_pipe_ev ev, nng_pipe_cb cb, void *arg)
 {
 	int       rv;
 	nni_sock *sock;


### PR DESCRIPTION
fixes #894 nng_pipe_notify could use nng_pipe_ev typedef instead of int

`nng_pipe_notify()` uses `nng_pipe_ev` enum typedef instead of `int`