### PR TITLE
fixes #903 Stream get_string implementation missing

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1043,6 +1043,7 @@ NNG_DECL int  nng_stream_get_int(nng_stream *, const char *, int *);
 NNG_DECL int  nng_stream_get_ms(nng_stream *, const char *, nng_duration *);
 NNG_DECL int  nng_stream_get_size(nng_stream *, const char *, size_t *);
 NNG_DECL int  nng_stream_get_uint64(nng_stream *, const char *, uint64_t *);
+NNG_DECL int  nng_stream_get_string(nng_stream *, const char *, char **);
 NNG_DECL int  nng_stream_get_ptr(nng_stream *, const char *, void **);
 NNG_DECL int  nng_stream_get_addr(nng_stream *, const char *, nng_sockaddr *);
 NNG_DECL int  nng_stream_set(nng_stream *, const char *, const void *, size_t);
@@ -1076,6 +1077,8 @@ NNG_DECL int nng_stream_dialer_get_size(
     nng_stream_dialer *, const char *, size_t *);
 NNG_DECL int nng_stream_dialer_get_uint64(
     nng_stream_dialer *, const char *, uint64_t *);
+NNG_DECL int nng_stream_dialer_get_string(
+    nng_stream_dialer *, const char *, char **);
 NNG_DECL int nng_stream_dialer_get_ptr(
     nng_stream_dialer *, const char *, void **);
 NNG_DECL int nng_stream_dialer_get_addr(
@@ -1117,6 +1120,8 @@ NNG_DECL int nng_stream_listener_get_size(
     nng_stream_listener *, const char *, size_t *);
 NNG_DECL int nng_stream_listener_get_uint64(
     nng_stream_listener *, const char *, uint64_t *);
+NNG_DECL int nng_stream_listener_get_string(
+    nng_stream_listener *, const char *, char **);
 NNG_DECL int nng_stream_listener_get_ptr(
     nng_stream_listener *, const char *, void **);
 NNG_DECL int nng_stream_listener_get_addr(

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -308,6 +308,7 @@ nni_stream_checkopt(const char *scheme, const char *name, const void *data,
 	DEFTYPEDGET(base, bool, bool, NNI_TYPE_BOOL)           \
 	DEFTYPEDGET(base, size, size_t, NNI_TYPE_SIZE)         \
 	DEFTYPEDGET(base, uint64, uint64_t, NNI_TYPE_UINT64)   \
+	DEFTYPEDGET(base, string, char *, NNI_TYPE_STRING)     \
 	DEFTYPEDGET(base, ptr, void *, NNI_TYPE_POINTER)       \
 	DEFTYPEDGET(base, ms, nng_duration, NNI_TYPE_DURATION) \
 	DEFTYPEDGET(base, addr, nng_sockaddr, NNI_TYPE_SOCKADDR)


### PR DESCRIPTION
fixes #903 Stream get_string implementation missing

This will probably conflict with #901.  In case the get/set naming is intentional and desired, making this independent of that.
If #901 is accepted, just make the one line change from here and delete this PR.  =)