### PR TITLE
nng_msg_dup correctly duplicates pipe (mentioned in #862)

### DIFF
--- a/src/core/message.c
+++ b/src/core/message.c
@@ -469,6 +469,7 @@ nni_msg_dup(nni_msg **dup, const nni_msg *src)
 		memcpy(newmo->mo_val, mo->mo_val, mo->mo_sz);
 		nni_list_append(&m->m_options, newmo);
 	}
+	m->m_pipe = src->m_pipe;
 
 	*dup = m;
 	return (0);

--- a/tests/message.c
+++ b/tests/message.c
@@ -186,6 +186,16 @@ TestMain("Message Tests", {
 			So(strcmp(nng_msg_body(m2), "back2basics") == 0);
 		});
 
+		Convey("Message dup copies pipe", {
+			nng_pipe p  = NNG_PIPE_INITIALIZER;
+			nng_msg *m2;
+			memset(&p, 0x22, sizeof(p));
+			nng_msg_set_pipe(msg, p);
+			So(nng_msg_dup(&m2, msg) == 0);
+			p = nng_msg_get_pipe(m2);
+			So(nng_pipe_id(p) == 0x22222222);
+		});
+
 		Convey("Missing option fails properly", {
 			char   buf[128];
 			size_t sz = sizeof(buf);


### PR DESCRIPTION
This was mentioned as a possible cause of #862, but doesn't actually fix it.
A couple dozen of messages can be exchanged without issue, but eventually one gets delivered through the wrong pipe.