### PR TITLE
fixes #815 Eliminate socket filters on message queues

### DIFF
--- a/docs/man/nng_inproc.7.adoc
+++ b/docs/man/nng_inproc.7.adoc
@@ -1,6 +1,6 @@
 = nng_inproc(7)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -53,17 +53,23 @@ that URI.
 
 === Socket Address
 
-When using an `<<nng_sockaddr.5#,nng_sockaddr>>` structure,
+When using an xref:nng_sockaddr.5.adoc[`nng_sockaddr`] structure,
 the actual structure is of type
-`<<nng_sockaddr_inproc.5#,nng_sockaddr_inproc>>`.
+xref:nng_sockaddr_inproc.5.adoc[`nng_sockaddr_inproc`].
 
 === Transport Options
 
 The _inproc_ transport has no special options.
 
+NOTE: While _inproc_ accepts the option
+xref:nng_options.5.adoc#NNG_OPT_RECVMAXSZ[`NNG_OPT_RECVMAXSZ`] for
+compatibility, the value of the option is ignored with no enforcement.
+As _inproc_ peers are in the same address space, they are implicitly trusted,
+and thus it makes no sense to spend cycles protecting a program from itself.
+
 == SEE ALSO
 
 [.text-left]
-<<nng_inproc_register.3#,nng_inproc_register(3)>>,
-<<nng_sockaddr_inproc.5#,nng_sockaddr_inproc(5)>>,
-<<nng.7#,nng(7)>>
+xref:nng_inproc_register.3.adoc[nng_inproc_register(3)],
+xref:nng_sockaddr_inproc.5.adoc[nng_sockaddr_inproc(5)],
+xref:nng.7.adoc[nng(7)]

--- a/src/core/msgqueue.h
+++ b/src/core/msgqueue.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -48,19 +48,6 @@ extern int nni_msgq_tryput(nni_msgq *, nni_msg *);
 // message queue, and for that side behaves like nni_msgq_set_error.
 // Readers (nni_msgq_put*) are unaffected.
 extern void nni_msgq_set_get_error(nni_msgq *, int);
-
-// nni_msgq_filter is a callback function used to filter messages.
-// The function is called on entry (put) or exit (get).  The void
-// argument is an opaque pointer supplied with the function at registration
-// time.  The primary use for these functions is to support the protocol
-// socket needs.
-typedef nni_msg *(*nni_msgq_filter)(void *, nni_msg *);
-
-// nni_msgq_set_filter sets the filter on the queue.  Messages
-// are filtered through this just before they are returned via the get
-// functions.  If the filter returns NULL, then the message is silently
-// discarded instead, and any get waiters remain waiting.
-extern void nni_msgq_set_filter(nni_msgq *, nni_msgq_filter, void *);
 
 // nni_msgq_close closes the queue.  After this all operates on the
 // message queue will return NNG_ECLOSED.  Messages inside the queue

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -104,18 +104,6 @@ struct nni_proto_sock_ops {
 
 	// Receive a message.
 	void (*sock_recv)(void *, nni_aio *);
-
-	// Message filter.  This may be NULL, but if it isn't, then
-	// messages coming into the system are routed here just before being
-	// delivered to the application.  To drop the message, the protocol
-	// should return NULL, otherwise the message (possibly modified).
-	nni_msg *(*sock_filter)(void *, nni_msg *);
-
-	// Socket draining is intended to permit protocols to "drain"
-	// before exiting.  For protocols where draining makes no
-	// sense, this may be NULL.  (Example: REQ and SURVEYOR should
-	// not drain, because they cannot receive a reply!)
-	void (*sock_drain)(void *, nni_aio *);
 
 	// Options. Must not be NULL. Final entry should have NULL name.
 	nni_option *sock_options;

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -571,11 +571,6 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 	(void) nni_sock_setopt(
 	    s, NNG_OPT_TCP_KEEPALIVE, &on, sizeof(on), NNI_TYPE_BOOL);
 
-	if (s->s_sock_ops.sock_filter != NULL) {
-		nni_msgq_set_filter(
-		    s->s_urq, s->s_sock_ops.sock_filter, s->s_data);
-	}
-
 	*sp = s;
 	return (rv);
 }

--- a/tests/set_recvmaxsize.c
+++ b/tests/set_recvmaxsize.c
@@ -15,36 +15,35 @@
 #define RCVBUFSIZE 200
 
 const char *addrs[] = {
-    "inproc:///tmp/inproctmp_setrecvmaxsz",
-    "ipc:///tmp/ipctemp_setrecvmaxsz",
-    "tcp://127.0.0.1:43895",
-    "ws://127.0.0.1:43897",
+	"ipc:///tmp/ipctemp_setrecvmaxsz",
+	"tcp://127.0.0.1:43895",
+	"ws://127.0.0.1:43897",
 };
 
 TestMain("recvmaxsize", {
 	// we don't actually care what the content of the message is.
-	char msg[SNDBUFSIZE];
-	char rcvbuf[RCVBUFSIZE];
-	size_t rcvsize = RCVBUFSIZE;
-	nng_socket s0;
-	nng_socket s1;
+	char         msg[SNDBUFSIZE];
+	char         rcvbuf[RCVBUFSIZE];
+	size_t       rcvsize = RCVBUFSIZE;
+	nng_socket   s0;
+	nng_socket   s1;
 	nng_listener l;
-    int numproto = sizeof addrs / sizeof *addrs;
-    Convey("recvmaxsize can be set after listening", {
-        for (int i = 0; i < numproto; i++) {
-            const char *addr = addrs[i];
-            So(nng_pair1_open(&s0) == 0);
-            So(nng_setopt_ms(s0, NNG_OPT_RECVTIMEO, 100) == 0);
-            So(nng_setopt_size(s0, NNG_OPT_RECVMAXSZ, 200) == 0);
-            So(nng_listen(s0, addr, &l, 0) == 0);
-            So(nng_setopt_size(s0, NNG_OPT_RECVMAXSZ, 100) == 0);
+	int          numproto = sizeof addrs / sizeof *addrs;
+	Convey("recvmaxsize can be set after listening", {
+		for (int i = 0; i < numproto; i++) {
+			const char *addr = addrs[i];
+			So(nng_pair1_open(&s0) == 0);
+			So(nng_setopt_ms(s0, NNG_OPT_RECVTIMEO, 100) == 0);
+			So(nng_setopt_size(s0, NNG_OPT_RECVMAXSZ, 200) == 0);
+			So(nng_listen(s0, addr, &l, 0) == 0);
+			So(nng_setopt_size(s0, NNG_OPT_RECVMAXSZ, 100) == 0);
 
-            So(nng_pair1_open(&s1) == 0);
-            So(nng_dial(s1, addr, NULL, 0) == 0);
-            So(nng_send(s1, msg, 150, 0) == 0);
-            So(nng_recv(s0, rcvbuf, &rcvsize, 0) == NNG_ETIMEDOUT);
-            So(nng_close(s0) == 0);
-            So(nng_close(s1) == 0);
-        }
-    });
+			So(nng_pair1_open(&s1) == 0);
+			So(nng_dial(s1, addr, NULL, 0) == 0);
+			So(nng_send(s1, msg, 150, 0) == 0);
+			So(nng_recv(s0, rcvbuf, &rcvsize, 0) == NNG_ETIMEDOUT);
+			So(nng_close(s0) == 0);
+			So(nng_close(s1) == 0);
+		}
+	});
 })


### PR DESCRIPTION
This also eliminates the enforcement of NNG_OPT_RECVMAXSZ for inproc,
which never really made much sense.  This helps inproc go faster.
While here, also clean up the entry point for protocols to support
a drain option, since we don't use that anywhere.
