### PR TITLE
fixes #931 nng_ctx_send can block forever

### DIFF
--- a/src/core/idhash.c
+++ b/src/core/idhash.c
@@ -98,11 +98,13 @@ static size_t
 nni_hash_find_index(nni_idhash *h, uint64_t id)
 {
 	size_t index;
+	size_t start;
 	if (h->ih_count == 0) {
 		return ((size_t) -1);
 	}
 
 	index = NNI_IDHASH_INDEX(h, id);
+	start = index;
 	for (;;) {
 		// The value of ihe_key is only valid if ihe_val is not NULL.
 		if ((h->ih_entries[index].ihe_key == id) &&
@@ -113,7 +115,13 @@ nni_hash_find_index(nni_idhash *h, uint64_t id)
 			return ((size_t) -1);
 		}
 		index = NNI_IDHASH_NEXTPROBE(h, index);
+
+		if (index == start) {
+			break;
+		}
 	}
+
+	return ((size_t) -1);
 }
 
 static int


### PR DESCRIPTION
fixes #931 `nng_ctx_send` can block forever

This implements the first solution I suggested in the issue (having the `for` loop exit after probing all slots). I have not had a chance to test this in the system that I originally found the bug in but I will do so tomorrow.