### PR TITLE
fixes #923 #935 RECVBUF/SENDBUF has variable type

### DIFF
--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -314,22 +314,22 @@ pub0_sock_set_sendbuf(void *arg, const void *buf, size_t sz, nni_type t)
 {
 	pub0_sock *sock = arg;
 	pub0_pipe *p;
-	size_t     val;
+	int        val;
 	int        rv;
 
-	if ((rv = nni_copyin_size(&val, buf, sz, 1, 8192, t)) != 0) {
+	if ((rv = nni_copyin_int(&val, buf, sz, 1, 8192, t)) != 0) {
 		return (rv);
 	}
 
 	nni_mtx_lock(&sock->mtx);
-	sock->sendbuf = val;
+	sock->sendbuf = (size_t) val;
 	NNI_LIST_FOREACH (&sock->pipes, p) {
 		// If we fail part way thru (should only be ENOMEM), we
 		// stop short.  The others would likely fail for ENOMEM as
 		// well anyway.  There is a weird effect here where the
 		// buffers may have been set for *some* of the pipes, but
 		// we have no way to correct, or even report, partial failure.
-		if ((rv = nni_lmq_resize(&p->sendq, val)) != 0) {
+		if ((rv = nni_lmq_resize(&p->sendq, (size_t) val)) != 0) {
 			break;
 		}
 	}
@@ -341,11 +341,11 @@ static int
 pub0_sock_get_sendbuf(void *arg, void *buf, size_t *szp, nni_type t)
 {
 	pub0_sock *sock = arg;
-	size_t     val;
+	int        val;
 	nni_mtx_lock(&sock->mtx);
-	val = sock->sendbuf;
+	val = (int) sock->sendbuf;
 	nni_mtx_unlock(&sock->mtx);
-	return (nni_copyout_size(val, buf, szp, t));
+	return (nni_copyout_int(val, buf, szp, t));
 }
 
 static nni_proto_pipe_ops pub0_pipe_ops = {

--- a/src/protocol/pubsub0/sub.c
+++ b/src/protocol/pubsub0/sub.c
@@ -434,12 +434,12 @@ sub0_ctx_get_recvbuf(void *arg, void *buf, size_t *szp, nni_type t)
 {
 	sub0_ctx * ctx  = arg;
 	sub0_sock *sock = ctx->sock;
-	size_t     val;
+	int        val;
 	nni_mtx_lock(&sock->lk);
-	val = nni_lmq_cap(&ctx->lmq);
+	val = (int) nni_lmq_cap(&ctx->lmq);
 	nni_mtx_unlock(&sock->lk);
 
-	return (nni_copyout_size(val, buf, szp, t));
+	return (nni_copyout_int(val, buf, szp, t));
 }
 
 static int
@@ -447,14 +447,14 @@ sub0_ctx_set_recvbuf(void *arg, const void *buf, size_t sz, nni_type t)
 {
 	sub0_ctx * ctx  = arg;
 	sub0_sock *sock = ctx->sock;
-	size_t     val;
+	int        val;
 	int        rv;
 
-	if ((rv = nni_copyin_size(&val, buf, sz, 1, 8192, t)) != 0) {
+	if ((rv = nni_copyin_int(&val, buf, sz, 1, 8192, t)) != 0) {
 		return (rv);
 	}
 	nni_mtx_lock(&sock->lk);
-	if ((rv = nni_lmq_resize(&ctx->lmq, val)) != 0) {
+	if ((rv = nni_lmq_resize(&ctx->lmq, (size_t) val)) != 0) {
 		nni_mtx_unlock(&sock->lk);
 		return (rv);
 	}
@@ -462,7 +462,7 @@ sub0_ctx_set_recvbuf(void *arg, const void *buf, size_t sz, nni_type t)
 	// If we change the socket, then this will change the queue for
 	// any new contexts. (Previously constructed contexts are unaffected.)
 	if (sock->ctx == ctx) {
-		sock->recvbuflen = val;
+		sock->recvbuflen = (size_t) val;
 	}
 	nni_mtx_unlock(&sock->lk);
 	return (0);


### PR DESCRIPTION
fixes #923,  fixes #935 RECVBUF/SENDBUF has variable type

Based on my previous experiences with pull requests here (and my understanding of SemVer), the documentation has the final say on things. In this case, the documentation says that the the options are of type `int` even though, logically, they are `size_t`.

I did nothing to account for the potential differences between the types but I really just copied the `nng_socket` implementation and that has apparently been good enough.