### PR TITLE
Add uint64 to generated legacy nng_setopt_* functions.

### DIFF
--- a/src/core/options.h
+++ b/src/core/options.h
@@ -255,6 +255,7 @@ extern int nni_chkopt(
 	NNI_LEGACY_DEFTYPEDSET(base, int, int)            \
 	NNI_LEGACY_DEFTYPEDSET(base, bool, bool)          \
 	NNI_LEGACY_DEFTYPEDSET(base, size, size_t)        \
+	NNI_LEGACY_DEFTYPEDSET(base, uint64, uint64_t)    \
 	NNI_LEGACY_DEFTYPEDSET(base, ms, nng_duration)    \
 	NNI_LEGACY_DEFTYPEDSET(base, ptr, void*)          \
 	NNI_LEGACY_DEFSTRINGSET(base)                     \


### PR DESCRIPTION
The functions nng_dialer_setopt_uint64 and nng_dialer_setopt_uint64 are
declared in nng.h but not defined, causing errors at runtime of programs
that expect them to be defined.