### PR TITLE
ZeroTier transport changes

### DIFF
--- a/include/nng/transport/zerotier/zerotier.h
+++ b/include/nng/transport/zerotier/zerotier.h
@@ -131,6 +131,9 @@
 // option takes no argument really.
 #define NNG_OPT_ZT_CLEAR_LOCAL_ADDRS "zt:clear-local-addrs"
 
+#define NNG_OPT_ZT_UDP4_ADDR "zt:udp4_addr"
+#define NNG_OPT_ZT_UDP6_ADDR "zt:udp6_addr"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -12,6 +12,7 @@
 
 #ifdef NNG_PLATFORM_POSIX
 #include "platform/posix/posix_pollq.h"
+#include "platform/posix/posix_udp.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -33,14 +34,6 @@
 #ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL 0
 #endif
-
-struct nni_plat_udp {
-	nni_posix_pfd *udp_pfd;
-	int            udp_fd;
-	nni_list       udp_recvq;
-	nni_list       udp_sendq;
-	nni_mtx        udp_mtx;
-};
 
 static void
 nni_posix_udp_doerror(nni_plat_udp *udp, int rv)

--- a/src/platform/posix/posix_udp.h
+++ b/src/platform/posix/posix_udp.h
@@ -1,0 +1,19 @@
+//
+// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2019 Capitar IT Group BV <info@capitar.com>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+struct nni_plat_udp {
+	nni_posix_pfd *udp_pfd;
+	int	    udp_fd;
+	nni_list       udp_recvq;
+	nni_list       udp_sendq;
+	nni_mtx	udp_mtx;
+};

--- a/src/transport/zerotier/zerotier.c
+++ b/src/transport/zerotier/zerotier.c
@@ -2958,6 +2958,7 @@ zt_ep_get_udp4_addr(void *arg, void *data, size_t *szp, nni_type t)
 
 	struct sockaddr_in *ssin = (struct sockaddr_in *)&ss;
 
+	sin.s_in.sa_addr = ssin->sin_addr.s_addr;
 	sin.s_in.sa_port = ssin->sin_port;
 
 	return (nni_copyout_sockaddr(&sin, data, szp, t));
@@ -2982,7 +2983,8 @@ zt_ep_get_udp6_addr(void *arg, void *data, size_t *szp, nni_type t)
 
 	struct sockaddr_in6 *ssin = (struct sockaddr_in6 *)&ss;
 
-	sin.s_in.sa_port = ssin->sin6_port;
+	memcpy(&sin.s_in6.sa_addr, ssin->sin6_addr.s6_addr, 16);
+	sin.s_in6.sa_port = ssin->sin6_port;
 
 	return (nni_copyout_sockaddr(&sin, data, szp, t));
 }


### PR DESCRIPTION
Fix for:
- zt_ep_set_add_local_addr
- zt_ep_set_clear_local_addrs

New methods to retrieve udp address used for ZeroTier:
- zt_ep_get_udp4_addr
- zt_ep_get_udp6_addr

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.