### PR TITLE
fix #946 Use after free in TLS

### DIFF
--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -172,11 +172,13 @@ extern void nni_atomic_flag_reset(nni_atomic_flag *);
 typedef struct nni_atomic_u64 nni_atomic_u64;
 
 extern void     nni_atomic_init64(nni_atomic_u64 *);
-extern void     nni_atomic_inc64(nni_atomic_u64 *, uint64_t);
-extern void     nni_atomic_dec64(nni_atomic_u64 *, uint64_t);
+extern void     nni_atomic_add64(nni_atomic_u64 *, uint64_t);
+extern void     nni_atomic_sub64(nni_atomic_u64 *, uint64_t);
 extern uint64_t nni_atomic_get64(nni_atomic_u64 *);
 extern void     nni_atomic_set64(nni_atomic_u64 *, uint64_t);
 extern uint64_t nni_atomic_swap64(nni_atomic_u64 *, uint64_t);
+extern uint64_t nni_atomic_dec64_nv(nni_atomic_u64 *);
+extern void     nni_atomic_inc64(nni_atomic_u64 *);
 
 //
 // Clock Support

--- a/src/core/stats.c
+++ b/src/core/stats.c
@@ -152,13 +152,13 @@ nni_stat_init_atomic(nni_stat_item *stat, const char *name, const char *desc)
 void
 nni_stat_inc_atomic(nni_stat_item *stat, uint64_t inc)
 {
-	nni_atomic_inc64(&stat->si_atomic, inc);
+	nni_atomic_add64(&stat->si_atomic, inc);
 }
 
 void
 nni_stat_dec_atomic(nni_stat_item *stat, uint64_t inc)
 {
-	nni_atomic_dec64(&stat->si_atomic, inc);
+	nni_atomic_sub64(&stat->si_atomic, inc);
 }
 #endif
 

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -128,13 +128,13 @@ nni_atomic_flag_reset(nni_atomic_flag *f)
 }
 
 void
-nni_atomic_inc64(nni_atomic_u64 *v, uint64_t bump)
+nni_atomic_add64(nni_atomic_u64 *v, uint64_t bump)
 {
 	InterlockedAddNoFence64(&v->v, (LONGLONG) bump);
 }
 
 void
-nni_atomic_dec64(nni_atomic_u64 *v, uint64_t bump)
+nni_atomic_sub64(nni_atomic_u64 *v, uint64_t bump)
 {
 	// Windows lacks a sub, so we add the negative.
 	InterlockedAddNoFence64(&v->v, (0ll - (LONGLONG) bump));
@@ -163,6 +163,18 @@ void
 nni_atomic_init64(nni_atomic_u64 *v)
 {
 	InterlockedExchange64(&v->v, 0);
+}
+
+void
+nni_atomic_inc64(nni_atomic_u64 *v)
+{
+	(void) InterlockedIncrementAcquire64(&v->v);
+}
+
+uint64_t
+nni_atomic_dec64_nv(nni_atomic_u64 *v)
+{
+	return ((uint64_t)(InterlockedDecrementRelease64(&v->v)));
 }
 
 static unsigned int __stdcall nni_plat_thr_main(void *arg)

--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -160,14 +160,14 @@ tls_dialer_set_config(void *arg, const void *buf, size_t sz, nni_type t)
 	if (cfg == NULL) {
 		return (NNG_EINVAL);
 	}
-	nni_mtx_lock(&d->lk);
-	old = d->cfg;
 	nng_tls_config_hold(cfg);
+
+	nni_mtx_lock(&d->lk);
+	old    = d->cfg;
 	d->cfg = cfg;
 	nni_mtx_unlock(&d->lk);
-	if (old != NULL) {
-		nng_tls_config_free(old);
-	}
+
+	nng_tls_config_free(old);
 	return (0);
 }
 
@@ -432,14 +432,15 @@ tls_listener_set_config(void *arg, const void *buf, size_t sz, nni_type t)
 		return (NNG_EINVAL);
 	}
 
-	nni_mtx_lock(&l->lk);
-	old = l->cfg;
 	nng_tls_config_hold(cfg);
+
+	nni_mtx_lock(&l->lk);
+	old    = l->cfg;
 	l->cfg = cfg;
 	nni_mtx_unlock(&l->lk);
-	if (old != NULL) {
-		nng_tls_config_free(old);
-	}
+
+	nng_tls_config_free(old);
+
 	return (0);
 }
 


### PR DESCRIPTION
This also introduces a more efficient reference counting usage based
on atomics, rather than locks.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
