### PR TITLE
Fixes surprising possible ordering of nng_pipe_notify events.

### DIFF
--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -59,11 +59,17 @@ nni_pipe_sys_fini(void)
 static void
 pipe_destroy(nni_pipe *p)
 {
+	nni_sock *s;
+	nni_mtx  *pipe_cbs_mtx;
 	if (p == NULL) {
 		return;
 	}
+	s = p->p_sock;
+	pipe_cbs_mtx = nni_sock_pipe_cbs_mtx(s);
 
+	nni_mtx_lock(pipe_cbs_mtx);
 	nni_pipe_run_cb(p, NNG_PIPE_EV_REM_POST);
+	nni_mtx_unlock(pipe_cbs_mtx);
 
 	// Make sure any unlocked holders are done with this.
 	// This happens during initialization for example.

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -62,6 +62,8 @@ extern uint32_t nni_sock_flags(nni_sock *);
 // types.)  The second argument is a mask of events for which the callback
 // should be executed.
 extern void nni_sock_set_pipe_cb(nni_sock *sock, int, nng_pipe_cb, void *);
+// the pipe_cbs_mtx must be held whenever pipe callback functions are called.
+extern nni_mtx *nni_sock_pipe_cbs_mtx(nni_sock *);
 
 // nni_ctx_open is used to open/create a new context structure.
 // Contexts are not supported by most protocols, but for those that do,


### PR DESCRIPTION
On nng_pipe_notify events, it was possible for events to fire in an
unexpected order: pre-connect, post-*remove*, and finally
post-*connect*.  This can cause errors in the wild if a resource is
attained in pre-connect and released in post-remove, as the resource
cannot be used in the post-connect event if the race is exercised.

Now, events will fire strictly in the order of pre-connect,
post-connect, and post-remove.  If the pipe is closed in
pre-connect, post-connect and post-remove will not be called.
