### PR TITLE
Remove redundant <sys/time.h> include.

### DIFF
--- a/demo/async/client.c
+++ b/demo/async/client.c
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <time.h>
 
 #include <nng/nng.h>

--- a/demo/async/server.c
+++ b/demo/async/server.c
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <time.h>
 
 #include <nng/nng.h>

--- a/demo/raw/raw.c
+++ b/demo/raw/raw.c
@@ -27,7 +27,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
 #include <time.h>
 
 #include <nng/nng.h>


### PR DESCRIPTION
It is not used but prevents demos from being compiled on Windows.