### PR TITLE
fixes #954 large message fails with no error message

### DIFF
--- a/docs/man/nng_options.5.adoc
+++ b/docs/man/nng_options.5.adoc
@@ -190,6 +190,9 @@ large message, without sending any data.
 This option can be set for the socket, but may be overridden for on a
 per-dialer or per-listener basis.
 +
+IMPORTANT: Applications on hostile networks should set this to a non-zero
+value to prevent denial-of-service attacks.
++
 NOTE: Some transports may have further message size restrictions.
 
 [[NNG_OPT_RECVTIMEO]]

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -514,7 +514,7 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 	s->s_rcvtimeo  = -1;
 	s->s_reconn    = NNI_SECOND;
 	s->s_reconnmax = 0;
-	s->s_rcvmaxsz  = 1024 * 1024; // 1 MB by default
+	s->s_rcvmaxsz  = 0; // unlimited by default
 	s->s_id        = 0;
 	s->s_refcnt    = 0;
 	s->s_self_id   = proto->proto_self;


### PR DESCRIPTION
This removes the default 1MB limit on maximum receive sizes.
Applications intended for deployment in insecure or hostile
environments should choose a sensible default for NNG_OPT_RECVMAXSZ.
