### PR TITLE
fixes condition for the nng_rep_open_raw macro

### DIFF
--- a/include/nng/protocol/reqrep0/rep.h
+++ b/include/nng/protocol/reqrep0/rep.h
@@ -22,7 +22,7 @@ NNG_DECL int nng_rep0_open_raw(nng_socket *);
 #define nng_rep_open nng_rep0_open
 #endif
 
-#ifndef nng_rep_open
+#ifndef nng_rep_open_raw
 #define nng_rep_open_raw nng_rep0_open_raw
 #endif
 


### PR DESCRIPTION
Maybe it doesn't make a difference in the end, but I think it's more correct this way.