### PR TITLE
fixes some typos in documentation

### DIFF
--- a/docs/CONTRIBUTING.adoc
+++ b/docs/CONTRIBUTING.adoc
@@ -16,7 +16,7 @@ defect, or sending us a message, you agree and certify that:
            repository.)  This grant shall include a right to use for any
            patents covering content in the submission.
 
-        ** You are not aware of any legal encumberances to the use of the
+        ** You are not aware of any legal encumbrances to the use of the
            submission (such as patents held by others) unless explicitly
            stated otherwise.
 
@@ -41,7 +41,7 @@ when filing issues:
 
 * Include CMake configuration used to build NNG.
 
-* Inclue expected results or behavior, and observed results or behavior.
+* Include expected results or behavior, and observed results or behavior.
 
 * If at all possible, a reproducible test case is helpful. We prefer test
   cases as the minimal amount of C code to demonstrate the defect.
@@ -93,7 +93,7 @@ of `clang-format` as older versions can differ in their output.
            PR with partial work in progress, unless you have reached a 
            milestone that can stand on its own merit.)
 
-	** Each commit in a PR should also be "complete", so that the
+	** Each commit in a PR should also be "complete", so that
            a release could be cut in between your commits without
            leaving the tree in a broken or dysfunctional state.
 

--- a/docs/man/nng_ctx.5.adoc
+++ b/docs/man/nng_ctx.5.adoc
@@ -40,7 +40,7 @@ to a completely different request.
 
 IMPORTANT: The `nng_ctx` structure is always passed by value (both
 for input parameters and return values), and should be treated opaquely.
-Passing structures this way ensures gives the compiler a chance to perform
+Passing structures this way gives the compiler a chance to perform
 accurate type checks in functions passing values of this type.
 
 All contexts share the same socket, and so some options, as well as the

--- a/docs/man/nng_dialer.5.adoc
+++ b/docs/man/nng_dialer.5.adoc
@@ -40,7 +40,7 @@ by a single xref:nng_socket.5.adoc[`nng_socket`].
 
 IMPORTANT: The `nng_dialer` structure is always passed by value (both
 for input parameters and return values), and should be treated opaquely.
-Passing structures this way ensures gives the compiler a chance to perform
+Passing structures this way gives the compiler a chance to perform
 accurate type checks in functions passing values of this type.
 
 TIP: A given xref:nng_socket.5.adoc[`nng_socket`] may have multiple dialer

--- a/docs/man/nng_listener.5.adoc
+++ b/docs/man/nng_listener.5.adoc
@@ -37,7 +37,7 @@ by a single xref:nng_socket.5.adoc[`nng_socket`].
 
 IMPORTANT: The `nng_listener` structure is always passed by value (both
 for input parameters and return values), and should be treated opaquely.
-Passing structures this way ensures gives the compiler a chance to perform
+Passing structures this way gives the compiler a chance to perform
 accurate type checks in functions passing values of this type.
 
 TIP: A given xref:nng_socket.5.adoc[`nng_socket`] may have multiple listener

--- a/docs/man/nng_pipe.5.adoc
+++ b/docs/man/nng_pipe.5.adoc
@@ -34,7 +34,7 @@ and therefore are also automatically associated with a single socket.
 
 IMPORTANT: The `nng_pipe` structure is always passed by value (both
 for input parameters and return values), and should be treated opaquely.
-Passing structures this way ensures gives the compiler a chance to perform
+Passing structures this way gives the compiler a chance to perform
 accurate type checks in functions passing values of this type.
 
 TIP: Most applications should never concern themselves with individual pipes.

--- a/docs/man/nng_send.3.adoc
+++ b/docs/man/nng_send.3.adoc
@@ -29,7 +29,7 @@ length _size_ using the xref:nng_socket.5.adoc[socket] _s_.
 
 NOTE: The semantics of what sending a message means vary from protocol to
 protocol, so examination of the protocol documentation is encouraged.
-(For example, with an xref:nng_pub.7.adoc[_nng_] socket the data is broadcast, so that
+(For example, with an xref:nng_pub.7.adoc[_pub_] socket the data is broadcast, so that
 any peers who have a suitable subscription will be able to receive it using
 xref:nng_recv.3.adoc[`nng_recv()`] or a similar function.)
 Furthermore, some protocols may not support sending data (such as

--- a/docs/man/nng_socket.5.adoc
+++ b/docs/man/nng_socket.5.adoc
@@ -36,7 +36,7 @@ and is responsible for any state machines or other protocol-specific logic.
 
 IMPORTANT: The `nng_socket` structure is always passed by value (both
 for input parameters and return values), and should be treated opaquely.
-Passing structures this way ensures gives the compiler a chance to perform
+Passing structures this way gives the compiler a chance to perform
 accurate type checks in functions passing values of this type.
 
 Each `nng_socket` is created by a protocol-specific constructor, such as

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1108,7 +1108,7 @@ typedef struct nng_url {
 // members.  It can be freed with nng_url_free.
 NNG_DECL int nng_url_parse(nng_url **, const char *);
 
-// nng_url_free frees a URL structure that was created by nng_url_parse9().
+// nng_url_free frees a URL structure that was created by nng_url_parse().
 NNG_DECL void nng_url_free(nng_url *);
 
 // nng_url_clone clones a URL structure.


### PR DESCRIPTION
This fixes some typos in the documentation that I noticed while learning how to use this great library. Since English is not my native language, I may be wrong in some cases - so just ignore my changes in this case.