### PR TITLE
Add option to SUB0 protocol to prefer newer messages when queue is full

### DIFF
--- a/docs/man/nng_sub.7.adoc
+++ b/docs/man/nng_sub.7.adoc
@@ -73,6 +73,13 @@ TIP: To receive all messages, an empty topic (zero length) can be used.
    Note that if the topic was not previously subscribed to with
    `NNG_OPT_SUB_SUBSCRIBE` then an `NNG_ENOENT` error will result.
 
+((`NNG_OPT_SUB_PREFNEW`))::
+
+   (`bool`)
+   This read/write option specifies the behavior of the subscriber when the queue is full.
+   When `true` (the default), the subscriber will make room in the queue by removing the oldest message.
+   When `false`, the subscriber will reject messages if the message queue does not have room.
+
 === Protocol Headers
 
 The _sub_ protocol has no protocol-specific headers.

--- a/include/nng/protocol/pubsub0/sub.h
+++ b/include/nng/protocol/pubsub0/sub.h
@@ -30,6 +30,8 @@ NNG_DECL int nng_sub0_open_raw(nng_socket *);
 #define NNG_OPT_SUB_SUBSCRIBE "sub:subscribe"
 #define NNG_OPT_SUB_UNSUBSCRIBE "sub:unsubscribe"
 
+#define NNG_OPT_SUB_PREFNEW "sub:prefnew"
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This adds a new option (`NNG_OPT_SUB_PREFNEW`) that toggles whether SUB0 contexts ignore new messages when the queue is full or whether they drop an old message in order to make room.

This probably needs some work to be ready to merge into master, so I'm more than willing to make whatever changes necessary.