### PR TITLE
Use sizeof ws_url in snprintf to avoid overflow warning

### DIFF
--- a/tests/ws.c
+++ b/tests/ws.c
@@ -171,7 +171,7 @@ TestMain("WebSocket Transport", {
 		So(nng_listener_getopt_int(
 		       l1, NNG_OPT_TCP_BOUND_PORT, &port) == 0);
 		So(port != 0);
-		snprintf(ws_url, 1023, "ws://*:%d/two", port);
+		snprintf(ws_url, sizeof(ws_url), "ws://*:%d/two", port);
 		So(nng_listen(s2, ws_url, NULL, 0) == 0);
 	});
 


### PR DESCRIPTION
fixes #1011 

Removes compiler warning regarding overflow