### PR TITLE
fixes #1004 Warning found by clang --analyze

### DIFF
--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -846,12 +846,14 @@ ws_read_finish_str(nni_ws *ws)
 				// This eats the entire iov.
 				n = iov->iov_len;
 			}
-			memcpy(iov->iov_buf, frame->buf, n);
-			iov->iov_buf = ((uint8_t *) iov->iov_buf) + n;
-			iov->iov_len -= n;
-			if (iov->iov_len == 0) {
-				iov++;
-				niov--;
+			if (n != 0) {
+				memcpy(iov->iov_buf, frame->buf, n);
+				iov->iov_buf = ((uint8_t *) iov->iov_buf) + n;
+				iov->iov_len -= n;
+				if (iov->iov_len == 0) {
+					iov++;
+					niov--;
+				}
 			}
 
 			if (frame->len == n) {


### PR DESCRIPTION
It's possible for an empty chunk to have a NULL data pointer.
Even when copying zero bytes, this makes clang somewhat unhappy.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
