### PR TITLE
Add support for Clang-Tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+---
+Checks:          '-*,clang-diagnostic-*,clang-analyzer-*,bugprone-*,readability-*,performance-*,-clang-analyzer-osx.*,-clang-analyzer-optin.*'
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,15 @@ endif ()
 
 add_subdirectory (docs/man)
 
+find_package (ClangTidy 9.0 EXACT)
+if (ClangTidy_FOUND)
+    set_target_properties (${PROJECT_NAME}
+        PROPERTIES
+            C_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+            CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+    )
+endif ()
+
 set (CPACK_PACKAGE_NAME ${PROJECT_NAME})
 set (CPACK_PACKAGE_VERSION ${NNG_PACKAGE_VERSION})
 set (CPACK_PACKAGE_CONTACT "nanomsg@freelists.org")

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -1,0 +1,64 @@
+# Copyright 2019 Hugo Lindström <hugolm84@gmail.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+
+# Usage:
+#find_package (ClangTidy 9.0)
+#if (CLANG_TIDY)
+#    set_target_properties (${PROJECT_NAME}
+#        PROPERTIES
+#            C_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+#            CXX_CLANG_TIDY "${CLANG_TIDY_COMMAND}"
+#    )
+#endif ()
+
+include_guard(GLOBAL)
+
+option (CLANG_TIDY "Use ClangTidy for static code analysis" OFF)
+option (CLANG_TIDY_FIX "Automatically attempt to fix clang-tidy suggestions and errors" OFF)
+
+if (NOT CLANG_TIDY)
+    return()
+endif()
+
+find_program (CLANG_TIDY_BIN
+    NAMES
+        "clang-tidy-${ClangTidy_FIND_VERSION}"
+        "clang-tidy-${ClangTidy_FIND_VERSION_MAJOR}"
+        "clang-tidy"
+)
+
+execute_process (COMMAND ${CLANG_TIDY_BIN} "--version" OUTPUT_VARIABLE CMD_OUTPUT)
+
+if (NOT ${CMD_OUTPUT} MATCHES "${ClangTidy_FIND_VERSION}")
+    if(ClangTidy_FIND_VERSION_EXACT)
+        message (FATAL_ERROR "Could not find clang-tidy (${ClangTidy_FIND_VERSION})")
+    endif()
+    if(NOT ${CMD_OUTPUT} MATCHES "${ClangTidy_FIND_VERSION_MAJOR}.[0-9]")
+        message (FATAL_ERROR "Could not find clang-tidy (${ClangTidy_FIND_VERSION_MAJOR})")
+    endif()
+endif()
+
+set (ClangTidy_FOUND TRUE)
+set (CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set (CLANG_TIDY_COMMAND "${CLANG_TIDY_BIN}")
+
+message (STATUS "Clang-Tidy         : ${CLANG_TIDY}")
+message (STATUS "    Binary         : ${CLANG_TIDY_BIN}")
+
+if (CLANG_TIDY_FIX)
+    set(CLANG_TIDY_COMMAND  ${CLANG_TIDY_COMMAND} "-fix" "-fix-errors")
+endif()
+
+if (C_CLANG_TIDY_EXTRA_FLAGS)
+    set (CLANG_TIDY_COMMAND "${CLANG_TIDY_COMMAND}" "${C_CLANG_TIDY_EXTRA_FLAGS}")
+endif()
+
+if (CXX_CLANG_TIDY_EXTRA_FLAGS)
+    set (CLANG_TIDY_COMMAND "${CLANG_TIDY_COMMAND}" "${CXX_CLANG_TIDY_EXTRA_FLAGS}")
+endif()
+
+message (STATUS "    Command        : ${CLANG_TIDY_COMMAND}")

--- a/cmake/FindClangTidy.cmake
+++ b/cmake/FindClangTidy.cmake
@@ -15,8 +15,6 @@
 #    )
 #endif ()
 
-include_guard(GLOBAL)
-
 option (CLANG_TIDY "Use ClangTidy for static code analysis" OFF)
 option (CLANG_TIDY_FIX "Automatically attempt to fix clang-tidy suggestions and errors" OFF)
 


### PR DESCRIPTION
This PR adds support for Clang-Tidy by simply passing `-DCLANG_TIDY=ON` when configuring CMake. 
If you want to let Clang-Tidy try to fix the suggestions, warnings and errors Automagically&#8482; just pass `-DCLANG_TIDY_FIX=ON`.

Build as usual using `cmake --build .` (or `ninja`, `make` etc)

I took the liberty to choose the clang-tidy checks at my own liking. Should any of them not be suitable for this project, please comment.
 
Tested on Linux, OSX and Windows. 

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
