### PR TITLE
Add support for clang-format custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,24 @@ endif ()
 
 add_subdirectory (docs/man)
 
+find_package(ClangFormat 9.0 EXACT)
+if(ClangFormat_FOUND)
+    set(search_dirs demo etc include perf src test tools)
+    foreach(dir IN LISTS search_dirs)
+        list(APPEND search_paths "${CMAKE_SOURCE_DIR}/${dir}/*.c")
+        list(APPEND search_paths "${CMAKE_SOURCE_DIR}/${dir}/*.h")
+    endforeach()
+    file(GLOB_RECURSE FORMAT_SOURCE_FILES ${search_paths})
+    add_custom_target(format
+                  COMMAND ${CLANG_FORMAT_BIN}
+                          -i
+                          -style=file
+                          ${FORMAT_SOURCE_FILES}
+                  VERBATIM
+                  COMMENT "Auto formatting all source files..."
+    )
+endif()
+
 set (CPACK_PACKAGE_NAME ${PROJECT_NAME})
 set (CPACK_PACKAGE_VERSION ${NNG_PACKAGE_VERSION})
 set (CPACK_PACKAGE_CONTACT "nanomsg@freelists.org")

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -18,10 +18,6 @@
 #   )
 #endif()
 
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0")
-    include_guard(GLOBAL)
-endif()
-
 option (CLANG_FORMAT "Use clang-format to format all source files via custom target `format`" ON)
 
 if (NOT CLANG_FORMAT)

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -1,0 +1,54 @@
+# Copyright 2019 Hugo Lindström <hugolm84@gmail.com>
+#
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+
+# Usage:
+#find_package(ClangFormat 9.0 EXACT)
+#if(ClangFormat_FOUND)
+#   add_custom_target(format
+#       COMMAND ${CLANG_FORMAT_BIN}
+#        -i
+#        -style=file
+#        ${FORMAT_SOURCE_FILES}
+#       VERBATIM
+#       COMMENT "Auto formatting all source files..."
+#   )
+#endif()
+
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.10.0")
+    include_guard(GLOBAL)
+endif()
+
+option (CLANG_FORMAT "Use clang-format to format all source files via custom target `format`" ON)
+
+if (NOT CLANG_FORMAT)
+    return()
+endif()
+
+find_program (CLANG_FORMAT_BIN
+    NAMES
+        "clang-format-${ClangFormat_FIND_VERSION}"
+        "clang-format-${ClangFormat_FIND_VERSION_MAJOR}"
+        "clang-format"
+    HINTS
+        $ENV{ProgramW6432}/LLVM/bin
+        $ENV{ProgramFiles}/LLVM/bin
+)
+
+execute_process (COMMAND ${CLANG_FORMAT} "--version" OUTPUT_VARIABLE CMD_OUTPUT)
+
+if (NOT ${CMD_OUTPUT} MATCHES "${ClangFormat_FIND_VERSION}")
+    if (ClangFormat_FIND_VERSION_EXACT)
+        message (FATAL_ERROR "Could not find clang-format (${ClangFormat_FIND_VERSION})")
+    endif()
+    if (NOT ${CMD_OUTPUT} MATCHES "${ClangFormat_FIND_VERSION_MAJOR}.[0-9]")
+        message (FATAL_ERROR "Could not find clang-format (${ClangFormat_FIND_VERSION_MAJOR})")
+    endif()
+endif()
+
+set (ClangFormat_FOUND TRUE)
+message (STATUS "Clang-Format       : ${CLANG_FORMAT}")
+message (STATUS "    Binary         : ${CLANG_FORMAT_BIN}")


### PR DESCRIPTION
This PR allows a user to format all source files via the custom target `format`. It uses the `.clang-format` file already supported by the project. 
Enable by passing in `-DCLANG_FORMAT=ON` when configuring CMake, specify `format` as build target: `cmake --build . --target format`.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
