### PR TITLE
Fix typo in websocket/CMakeLists.txt

### DIFF
--- a/src/supplemental/websocket/CMakeLists.txt
+++ b/src/supplemental/websocket/CMakeLists.txt
@@ -13,6 +13,6 @@ if (NNG_SUPP_WEBSOCKET)
                 supplemental/websocket/websocket.c
                 supplemental/websocket/websocket.h)
 else()
-	set(_SRCS supplemental/websocket/stubs.c)
+	set(_SRCS supplemental/websocket/stub.c)
 endif()
 set(NNG_SRCS ${NNG_SRCS} ${_SRCS} PARENT_SCOPE)


### PR DESCRIPTION
This PR fixes a build error when the `NNG_SUPP_WEBSOCKET` option is turned off.