### PR TITLE
Add http server method for getting port number

### DIFF
--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -410,6 +410,7 @@ These functions are intended for use with HTTP server applications.
 |xref:nng_http_hijack.3http.adoc[nng_http_hijack()]|hijack HTTP server connection
 |xref:nng_http_server_add_handler.3http.adoc[nng_http_server_add_handler()]|add HTTP server handler
 |xref:nng_http_server_del_handler.3http.adoc[nng_http_server_del_handler()]|delete HTTP server handler
+|xref:nng_http_server_get_addr.3http.adoc[nng_http_server_get_addr()]|get HTTP server address
 |xref:nng_http_server_get_tls.3http.adoc[nng_http_server_get_tls()]|get HTTP server TLS configuration
 |xref:nng_http_server_hold.3http.adoc[nng_http_server_hold()]|get and hold HTTP server instance
 |xref:nng_http_server_release.3http.adoc[nng_http_server_release()]|release HTTP server instance

--- a/docs/man/nng_http_server_get_addr.3http.adoc
+++ b/docs/man/nng_http_server_get_addr.3http.adoc
@@ -1,0 +1,46 @@
+= nng_http_server_get_addr(3http)
+//
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Capitar IT Group BV <info@capitar.com>
+//
+// This document is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+== NAME
+
+nng_http_server_get_addr - get HTTP server address
+
+== SYNOPSIS
+
+[source, c]
+----
+#include <nng/nng.h>
+#include <nng/supplemental/http/http.h>
+
+int nng_http_server_get_addr(nng_http_server *server, nng_sockaddr *sap);
+----
+
+== DESCRIPTION
+
+`nng_http_server_get_addr()`::
+This function is used to retrieve an xref:nng_sockaddr.5.adoc[`nng_sockaddr`]
+into the value referenced by _sap_ for the server _server_.
+
+== RETURN VALUES
+
+This function returns 0 on success, and non-zero otherwise.
+
+== ERRORS
+
+`NNG_EINVAL`:: Either _server_ or _sap_ parameter is NULL.
+`NNG_ENOTSUP`:: HTTP not supported.
+
+
+== SEE ALSO
+
+[.text-left]
+xref:nng_sockaddr.5.adoc[nng_sockaddr(5)],
+xref:nng.7.adoc[nng(7)]

--- a/include/nng/supplemental/http/http.h
+++ b/include/nng/supplemental/http/http.h
@@ -437,6 +437,11 @@ NNG_DECL int nng_http_server_set_tls(
 NNG_DECL int nng_http_server_get_tls(
     nng_http_server *, struct nng_tls_config **);
 
+// nng_http_server_get_addr obtains the address with which the server was
+// initialized or returns NNG_EINVAL. Useful for instance when the port has
+// been automatically assigned.
+NNG_DECL int nng_http_server_get_addr(nng_http_server *, nng_sockaddr *);
+
 // nng_http_server_set_error_page sets a custom error page (HTML) content
 // to be sent for the given error code.  This is used when the error is
 // generated internally by the framework, or when the application returns

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -9,8 +9,8 @@
 //
 
 #include "core/nng_impl.h"
-#include "nng/supplemental/http/http.h"
 #include "http_api.h"
+#include "nng/supplemental/http/http.h"
 #include "nng/supplemental/tls/tls.h"
 
 // Symbols in this file are "public" versions of the HTTP API.
@@ -775,6 +775,22 @@ nng_http_server_get_tls(nng_http_server *srv, struct nng_tls_config **cfgp)
 #else
 	NNI_ARG_UNUSED(srv);
 	NNI_ARG_UNUSED(cfgp);
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
+nng_http_server_get_addr(nng_http_server *srv, nng_sockaddr *addrp)
+{
+#ifdef NNG_SUPP_HTTP
+	size_t size = sizeof(nng_sockaddr);
+	if (srv == NULL || addrp == NULL)
+		return NNG_EINVAL;
+	return (nni_http_server_getx(
+	    srv, NNG_OPT_LOCADDR, addrp, &size, NNI_TYPE_SOCKADDR));
+#else
+	NNI_ARG_UNUSED(srv);
+	NNI_ARG_UNUSED(addrp);
 	return (NNG_ENOTSUP);
 #endif
 }


### PR DESCRIPTION
When a http server is started with port zero, a port is automatically assigned. This PR just makes it possible to retrieve the port number.