### PR TITLE
fixes #1105 pollable can be inlined, and use atomics

### DIFF
--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -189,13 +189,18 @@ extern uint64_t nni_atomic_swap64(nni_atomic_u64 *, uint64_t);
 extern uint64_t nni_atomic_dec64_nv(nni_atomic_u64 *);
 extern void     nni_atomic_inc64(nni_atomic_u64 *);
 
+// nni_atomic_cas64 is a compare and swap.  The second argument is the
+// value to compare against, and the third is the new value. Returns
+// true if the value was set.
+extern bool     nni_atomic_cas64(nni_atomic_u64 *, uint64_t, uint64_t);
+
 //
 // Clock Support
 //
 
 // nn_plat_clock returns a number of milliseconds since some arbitrary time
 // in the past.  The values returned by nni_clock must use the same base
-// as the times used in nni_plat_cond_waituntil.  The nni_plat_clock() must
+// as the times used in nni_plat_cond_until.  The nni_plat_clock() must
 // return values > 0, and must return values smaller than 2^63.  (We could
 // relax this last constraint, but there is no reason to, and leaves us the
 // option of using negative values for other purposes in the future.)
@@ -213,9 +218,9 @@ uint32_t nni_random(void);
 
 // nni_plat_init is called to allow the platform the chance to
 // do any necessary initialization.  This routine MUST be idempotent,
-// and threadsafe, and will be called before any other API calls, and
+// and thread-safe, and will be called before any other API calls, and
 // may be called at any point thereafter.  It is permitted to return
-// an error if some critical failure inializing the platform occurs,
+// an error if some critical failure initializing the platform occurs,
 // but once this succeeds, all future calls must succeed as well, unless
 // nni_plat_fini has been called.
 //
@@ -274,7 +279,7 @@ extern int nni_tcp_dialer_getopt(
 extern int nni_tcp_listener_init(nni_tcp_listener **);
 
 // nni_tcp_listener_fini frees the listener and all associated resources.
-// It implictly closes the listener as well.
+// It implicitly closes the listener as well.
 extern void nni_tcp_listener_fini(nni_tcp_listener *);
 
 // nni_tcp_listener_close closes the listener.  This will unbind

--- a/src/core/pollable.h
+++ b/src/core/pollable.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2017 Garrett D'Amore <garrett@damore.org>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -13,8 +13,6 @@
 #include "core/defs.h"
 #include "core/list.h"
 
-// For the sake of simplicity, we just maintain a single global timer thread.
-
 typedef struct nni_pollable nni_pollable;
 
 extern int  nni_pollable_alloc(nni_pollable **);
@@ -22,5 +20,17 @@ extern void nni_pollable_free(nni_pollable *);
 extern void nni_pollable_raise(nni_pollable *);
 extern void nni_pollable_clear(nni_pollable *);
 extern int  nni_pollable_getfd(nni_pollable *, int *);
+
+// nni_pollable implementation details are private.  Only here for inlining.
+// We have joined to the write and read file descriptors into a a single
+// atomic 64 so we can update them together (and we can use cas to be sure
+// that such updates are always safe.)
+struct nni_pollable {
+	nni_atomic_u64  p_fds;
+	nni_atomic_bool p_raised;
+};
+
+extern void nni_pollable_init(nni_pollable *);
+extern void nni_pollable_fini(nni_pollable *);
 
 #endif // CORE_POLLABLE_H

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -213,6 +213,14 @@ nni_atomic_dec64_nv(nni_atomic_u64 *v)
 #endif
 }
 
+bool
+nni_atomic_cas64(nni_atomic_u64 *v, uint64_t comp, uint64_t new)
+{
+	uint64_t old;
+	old = InterlockedCompareExchange64(&v->v, (LONG64)new, (LONG64)comp);
+	return (old == comp);
+}
+
 static unsigned int __stdcall nni_plat_thr_main(void *arg)
 {
 	nni_plat_thr *thr = arg;

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -213,7 +213,7 @@ pair1_pipe_start(void *arg)
 	nni_mtx_unlock(&s->mtx);
 
 	// Schedule a getq.  In polyamorous mode we get on the per pipe
-	// sendq, as the socket distributes to us. In monogamous mode
+	// send_queue, as the socket distributes to us. In monogamous mode
 	// we bypass and get from the upper writeq directly (saving a
 	// set of context switches).
 	if (s->poly) {
@@ -343,7 +343,7 @@ pair1_sock_getq_cb(void *arg)
 	// Try a non-blocking send.  If this fails we just discard the
 	// message.  We have to do this to avoid head-of-line blocking
 	// for messages sent to other pipes.  Note that there is some
-	// buffering in the sendq.
+	// buffering in the send_queue.
 	if (nni_msgq_tryput(p->sendq, msg) != 0) {
 		nni_msg_free(msg);
 	}
@@ -426,7 +426,7 @@ pair1_pipe_send_cb(void *arg)
 		return;
 	}
 
-	// In polyamorous mode, we want to get from the sendq; in
+	// In polyamorous mode, we want to get from the send_queue; in
 	// monogamous we get from upper writeq.
 	nni_msgq_aio_get(s->poly ? p->sendq : s->uwq, p->aio_getq);
 }

--- a/src/protocol/pubsub0/pub.c
+++ b/src/protocol/pubsub0/pub.c
@@ -289,7 +289,7 @@ pub0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_type t)
 	int        fd;
 	int        rv;
 	nni_mtx_lock(&sock->mtx);
-	// PUB sockets are *always* sendable.
+	// PUB sockets are *always* writable.
 	nni_pollable_raise(sock->sendable);
 	rv = nni_pollable_getfd(sock->sendable, &fd);
 	nni_mtx_unlock(&sock->mtx);

--- a/src/protocol/reqrep0/rep_test.c
+++ b/src/protocol/reqrep0/rep_test.c
@@ -74,7 +74,7 @@ test_rep_poll_writeable(void)
 	// Still not writable.
 	TEST_CHECK(testutil_pollfd(fd) == false);
 
-	// If we get a job, *then* we become writeable
+	// If we get a job, *then* we become writable
 	TEST_NNG_SEND_STR(req, "abc");
 	TEST_NNG_RECV_STR(rep, "abc");
 	TEST_CHECK(testutil_pollfd(fd) == true);


### PR DESCRIPTION
This also introduces an nni_atomic_cas64 to help with lock-free designs.
Some mechanical renaming was done in some of the protocols for spelling.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
