### PR TITLE
Changes to the posix poller to ensure that fini is always safe.

### DIFF
--- a/src/platform/posix/posix_ipc.h
+++ b/src/platform/posix/posix_ipc.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -29,6 +29,7 @@ struct nni_ipc_conn {
 	nni_mtx         mtx;
 	nni_aio *       dial_aio;
 	nni_ipc_dialer *dialer;
+	nni_reap_item   reap;
 };
 
 struct nni_ipc_dialer {
@@ -37,11 +38,12 @@ struct nni_ipc_dialer {
 	bool              closed;
 	nni_mtx           mtx;
 	nng_sockaddr      sa;
-	int               refcnt;
-	bool              fini;
+	nni_atomic_u64    ref;
+	nni_atomic_bool   fini;
 };
 
-extern int  nni_posix_ipc_init(nni_ipc_conn **, nni_posix_pfd *);
+extern int  nni_posix_ipc_alloc(nni_ipc_conn **, nni_ipc_dialer *);
+extern void nni_posix_ipc_init(nni_ipc_conn *, nni_posix_pfd *);
 extern void nni_posix_ipc_start(nni_ipc_conn *);
 extern void nni_posix_ipc_dialer_rele(nni_ipc_dialer *);
 

--- a/src/platform/posix/posix_ipclisten.c
+++ b/src/platform/posix/posix_ipclisten.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -124,19 +124,21 @@ ipc_listener_doaccept(ipc_listener *l)
 			}
 		}
 
-		if ((rv = nni_posix_pfd_init(&pfd, newfd)) != 0) {
-			close(newfd);
+		if ((rv = nni_posix_ipc_alloc(&c, NULL)) != 0) {
+			(void) close(newfd);
 			nni_aio_list_remove(aio);
 			nni_aio_finish_error(aio, rv);
 			continue;
 		}
 
-		if ((rv = nni_posix_ipc_init(&c, pfd)) != 0) {
-			nni_posix_pfd_fini(pfd);
+		if ((rv = nni_posix_pfd_init(&pfd, newfd)) != 0) {
+			nng_stream_free(&c->stream);
 			nni_aio_list_remove(aio);
 			nni_aio_finish_error(aio, rv);
 			continue;
 		}
+
+		nni_posix_ipc_init(c, pfd);
 
 		nni_aio_list_remove(aio);
 		nni_posix_ipc_start(c);

--- a/src/platform/posix/posix_pollq_epoll.c
+++ b/src/platform/posix/posix_pollq_epoll.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Liam Staskawicz <liam@stask.net>
 //
@@ -191,28 +191,27 @@ nni_posix_pfd_fini(nni_posix_pfd *pfd)
 
 	// We have to synchronize with the pollq thread (unless we are
 	// on that thread!)
-	if (!nni_thr_is_self(&pq->thr)) {
+	NNI_ASSERT(!nni_thr_is_self(&pq->thr));
 
-		uint64_t one = 1;
+	uint64_t one = 1;
 
-		nni_mtx_lock(&pq->mtx);
-		nni_list_append(&pq->reapq, pfd);
+	nni_mtx_lock(&pq->mtx);
+	nni_list_append(&pq->reapq, pfd);
 
-		// Wake the remote side.  For now we assume this always
-		// succeeds.  The only failure modes here occur when we
-		// have already excessively signaled this (2^64 times
-		// with no read!!), or when the evfd is closed, or some
-		// kernel bug occurs.  Those errors would manifest as
-		// a hang waiting for the poller to reap the pfd in fini,
-		// if it were possible for them to occur.  (Barring other
-		// bugs, it isn't.)
-		(void) write(pq->evfd, &one, sizeof(one));
+	// Wake the remote side.  For now we assume this always
+	// succeeds.  The only failure modes here occur when we
+	// have already excessively signaled this (2^64 times
+	// with no read!!), or when the evfd is closed, or some
+	// kernel bug occurs.  Those errors would manifest as
+	// a hang waiting for the poller to reap the pfd in fini,
+	// if it were possible for them to occur.  (Barring other
+	// bugs, it isn't.)
+	(void) write(pq->evfd, &one, sizeof(one));
 
-		while (!pfd->closed) {
-			nni_cv_wait(&pfd->cv);
-		}
-		nni_mtx_unlock(&pq->mtx);
+	while (!pfd->closed) {
+		nni_cv_wait(&pfd->cv);
 	}
+	nni_mtx_unlock(&pq->mtx);
 
 	// We're exclusive now.
 

--- a/src/platform/posix/posix_tcp.h
+++ b/src/platform/posix/posix_tcp.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -27,7 +27,21 @@ struct nni_tcp_conn {
 	nni_tcp_dialer *dialer;
 	nni_reap_item   reap;
 };
-extern int  nni_posix_tcp_init(nni_tcp_conn **, nni_posix_pfd *);
+
+struct nni_tcp_dialer {
+	nni_list                connq; // pending connections
+	bool                    closed;
+	bool                    nodelay;
+	bool                    keepalive;
+	struct sockaddr_storage src;
+	size_t                  srclen;
+	nni_mtx                 mtx;
+	nni_atomic_u64          ref;
+	nni_atomic_bool         fini;
+};
+
+extern int  nni_posix_tcp_alloc(nni_tcp_conn **, nni_tcp_dialer *);
+extern void nni_posix_tcp_init(nni_tcp_conn *, nni_posix_pfd *);
 extern void nni_posix_tcp_start(nni_tcp_conn *, int, int);
 extern void nni_posix_tcp_dialer_rele(nni_tcp_dialer *);
 

--- a/src/platform/posix/posix_tcplisten.c
+++ b/src/platform/posix/posix_tcplisten.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -136,19 +136,22 @@ tcp_listener_doaccept(nni_tcp_listener *l)
 			}
 		}
 
-		if ((rv = nni_posix_pfd_init(&pfd, newfd)) != 0) {
+		if ((rv = nni_posix_tcp_alloc(&c, NULL)) != 0) {
 			close(newfd);
 			nni_aio_list_remove(aio);
 			nni_aio_finish_error(aio, rv);
 			continue;
 		}
 
-		if ((rv = nni_posix_tcp_init(&c, pfd)) != 0) {
-			nni_posix_pfd_fini(pfd);
+		if ((rv = nni_posix_pfd_init(&pfd, newfd)) != 0) {
+			close(newfd);
+			nng_stream_free(&c->stream);
 			nni_aio_list_remove(aio);
 			nni_aio_finish_error(aio, rv);
 			continue;
 		}
+
+		nni_posix_tcp_init(c, pfd);
 
 		ka = l->keepalive ? 1 : 0;
 		nd = l->nodelay ? 1 : 0;

--- a/src/supplemental/tcp/tcp.c
+++ b/src/supplemental/tcp/tcp.c
@@ -155,12 +155,15 @@ tcp_dialer_free(void *arg)
 		return;
 	}
 
+	nni_aio_stop(d->resaio);
+	nni_aio_stop(d->conaio);
+	nni_aio_fini(d->resaio);
+	nni_aio_fini(d->conaio);
+
 	if (d->d != NULL) {
 		nni_tcp_dialer_close(d->d);
 		nni_tcp_dialer_fini(d->d);
 	}
-	nni_aio_fini(d->resaio);
-	nni_aio_fini(d->conaio);
 	nni_mtx_fini(&d->mtx);
 	nni_strfree(d->host);
 	nni_strfree(d->port);


### PR DESCRIPTION
We reap the connections when closing, to ensure that the clean up is
done outside the pollq thread.  This also reduces pressure on the
pollq, we think.  But more importantly it eliminates some complex
code that was meant to avoid deadlocks, but ultimately created other
use-after-free challenges.  This work is an enabler for further
simplifications in the aio/task logic.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
