### PR TITLE
TTL reads could be fewer.

### DIFF
--- a/src/protocol/reqrep0/xrep.c
+++ b/src/protocol/reqrep0/xrep.c
@@ -283,11 +283,14 @@ xrep0_pipe_recv_cb(void *arg)
 	xrep0_sock *s = p->rep;
 	nni_msg *   msg;
 	int         hops;
+	int         ttl;
 
 	if (nni_aio_result(&p->aio_recv) != 0) {
 		nni_pipe_close(p->pipe);
 		return;
 	}
+
+	ttl = nni_atomic_get(&s->ttl);
 
 	msg = nni_aio_get_msg(&p->aio_recv);
 	nni_aio_set_msg(&p->aio_recv, NULL);
@@ -302,7 +305,7 @@ xrep0_pipe_recv_cb(void *arg)
 	for (;;) {
 		bool     end = 0;
 		uint8_t *body;
-		if (hops > (int)nni_atomic_get(&s->ttl)) {
+		if (hops > ttl) {
 			// This isn't malformed, but it has gone through
 			// too many hops.  Do not disconnect, because we
 			// can legitimately receive messages with too many

--- a/src/protocol/survey0/respond.c
+++ b/src/protocol/survey0/respond.c
@@ -480,12 +480,14 @@ resp0_pipe_recv_cb(void *arg)
 	nni_aio *   aio;
 	int         hops;
 	size_t      len;
+	int         ttl;
 
 	if (nni_aio_result(&p->aio_recv) != 0) {
 		nni_pipe_close(p->npipe);
 		return;
 	}
 
+	ttl = nni_atomic_get(&s->ttl);
 	msg = nni_aio_get_msg(&p->aio_recv);
 	nni_msg_set_pipe(msg, p->id);
 
@@ -495,7 +497,7 @@ resp0_pipe_recv_cb(void *arg)
 		bool     end = 0;
 		uint8_t *body;
 
-		if (hops > nni_atomic_get(&s->ttl)) {
+		if (hops > ttl) {
 			goto drop;
 		}
 		hops++;

--- a/src/protocol/survey0/xrespond.c
+++ b/src/protocol/survey0/xrespond.c
@@ -273,13 +273,12 @@ xresp0_recv_cb(void *arg)
 	int          hops;
 	int          ttl;
 
-	ttl = nni_atomic_get(&s->ttl);
-
 	if (nni_aio_result(p->aio_recv) != 0) {
 		nni_pipe_close(p->npipe);
 		return;
 	}
 
+	ttl = nni_atomic_get(&s->ttl);
 	msg = nni_aio_get_msg(p->aio_recv);
 	nni_aio_set_msg(p->aio_recv, NULL);
 	nni_msg_set_pipe(msg, p->id);


### PR DESCRIPTION
Specifically, we don't need to read the atomic value each loop
iteration.  We can just get it when a message is first received,
and then use that value.  This should make receiving through proxies
a little more efficient.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
