### PR TITLE
fixes #1156 Message cloning could help reduce copies a lot

### DIFF
--- a/src/core/message.h
+++ b/src/core/message.h
@@ -60,6 +60,20 @@ extern uint64_t nni_msg_header_chop_u64(nni_msg *);
 extern void     nni_msg_set_pipe(nni_msg *, uint32_t);
 extern uint32_t nni_msg_get_pipe(const nni_msg *);
 
+// Reference counting messages. This allows the same message to be
+// cheaply reused instead of copied over and over again.  Callers of
+// this functionality MUST be certain to use nni_msg_unique() before
+// passing a message out of their control (e.g. to user programs.)
+// Failure to do so will likely result in corruption.
+extern void nni_msg_clone(nni_msg *);
+extern nni_msg *nni_msg_unique(nni_msg *);
+// nni_msg_pull_up ensures that the message is unique, and that any
+// header present is "pulled up" into the message body.  If the function
+// cannot do this for any reason (out of space in the body), then NULL
+// is returned.  It is the responsibility of the caller to free the
+// original message in that case (same semantics as realloc).
+extern nni_msg *nni_msg_pull_up(nni_msg *);
+
 // These should only be used when the transport or protocol is absolutely
 // certain that there is adequate room.   There is about 32 bytes of
 // header and trailer space for a newly allocated message, and transports


### PR DESCRIPTION
This introduces reference counting on messages to reduce the data copies.
This should have a marked improvement when moving large messages through
the system, or when publishing to many subscribers.  For inproc, when
using large messages, the copy time can be the dominant factor; for example
using REQ/REP over inproc with 1M messages, we saw latencies in the 100us+
range.  With this change, on the same hardware, the latencies dropped down
to around 28 us.

For this PR, we are going to want  to pay particular attention to the sanitizers. 
I think I've taken care to get this correct, but the proof will be in the pudding.