### PR TITLE
Feature/uri length ordering

### DIFF
--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -3,6 +3,7 @@
 // Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
+// Copyright 2020 Dirac Research <robert.bielik@dirac.com>
 //
 // This document is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this

--- a/docs/man/nng_http_handler_alloc.3http.adoc
+++ b/docs/man/nng_http_handler_alloc.3http.adoc
@@ -2,6 +2,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2020 Dirac Research <robert.bielik@dirac.com>
 //
 // This document is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -111,9 +112,13 @@ If no such index file exists, then an `NNG_HTTP_STATUS_NOT_FOUND` (404) error is
 sent back to the client.
 
 The `Content-Type` will be set automatically based upon the extension
-of the requested file name.
-If a content type cannot be determined from
+of the requested file name. If a content type cannot be determined from
 the extension, then `application/octet-stream` is used.
+
+The directory handler is created as a tree handler initially in exclusive mode (see
+xref:nng_http_handler_set_tree.3http.adoc[nng_http_handler_set_tree_exclusive
+]). This can be changed by calling xref:nng_http_handler_set_tree.3http.adoc
+[nng_http_handler_set_tree(3http)] after creating the directory handler.
 
 === File Handler
 
@@ -178,6 +183,7 @@ xref:nng_http_handler_free.3http.adoc[nng_http_handler_free(3http)],
 xref:nng_http_handler_set_host.3http.adoc[nng_http_handler_set_host(3http)],
 xref:nng_http_handler_set_method.3http.adoc[nng_http_handler_set_method(3http)],
 xref:nng_http_handler_set_tree.3http.adoc[nng_http_handler_set_tree(3http)],
+xref:nng_http_handler_set_tree.3http.adoc[nng_http_handler_set_tree_exclusive(3http)],
 xref:nng_http_res_alloc.3http.adoc[nng_http_res_alloc(3http)],
 xref:nng_http_res_alloc_error.3http.adoc[nng_http_res_alloc_error(3http)],
 xref:nng_http_server_add_handler.3http.adoc[nng_http_server_add_handler(3http)],

--- a/docs/man/nng_http_handler_set_tree.3http.adoc
+++ b/docs/man/nng_http_handler_set_tree.3http.adoc
@@ -2,6 +2,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2020 Dirac Research <robert.bielik@dirac.com>
 //
 // This document is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -21,6 +22,8 @@ nng_http_handler_set_tree - set HTTP handler to match trees
 #include <nng/supplemental/http/http.h>
 
 int nng_http_handler_set_tree(nng_http_handler *handler);
+
+int nng_http_handler_set_tree_exclusive(nng_http_handler *handler);
 ----
 
 == DESCRIPTION
@@ -29,7 +32,12 @@ The `nng_http_handler_set_tree()` function causes the _handler_ to be
 matched if the Request URI sent by the client is a logical child of
 the path for _handler_.
 
-TIP: This method is useful when constructing API handlers where a single
+The `nng_http_handler_set_tree_exclusive()` function is similar to `nng_http_server_set_tree()`
+with the distinction that the _handler_ will be considered to *exclusively* handling its 
+Request URI. Other handlers will be tested against _handler_ when being added to a server, 
+possibly resulting in a URI conflict error.
+
+TIP: These methods are useful when constructing API handlers where a single
 service address (path) supports dynamically generated children.
 
 == RETURN VALUES

--- a/include/nng/supplemental/http/http.h
+++ b/include/nng/supplemental/http/http.h
@@ -1,6 +1,7 @@
 //
 // Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
+// Copyright 2020 Dirac Research <robert.bielik@dirac.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -371,6 +372,14 @@ NNG_DECL int nng_http_handler_collect_body(nng_http_handler *, bool, size_t);
 // called for all child paths supplied.  By default the handler is only
 // called for an exact path match.
 NNG_DECL int nng_http_handler_set_tree(nng_http_handler *);
+
+// nng_http_handler_set_tree_exclusive indicates that the handler is being
+// registered for a heirarchical tree *exclusively*, rather than just a single
+// path, so it will be called for all child paths supplied. By default the
+// handler is only called for an exact path match. Exclusive means that any
+// other handler on a conflicting path will induce an address conflict error
+// when added to a server.
+NNG_DECL int nng_http_handler_set_tree_exclusive(nng_http_handler *);
 
 // nng_http_handler_set_data is used to store additional data, along with
 // a possible clean up routine.  (The clean up is a custom deallocator and

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -301,6 +301,13 @@ extern void nni_http_handler_collect_body(nni_http_handler *, bool, size_t);
 // will probably need to inspect the URL of the request.
 extern int nni_http_handler_set_tree(nni_http_handler *);
 
+// nni_http_handler_set_tree_exclusive marks the handler as servicing the
+// entire tree (e.g. a directory) exclusively, rather than just a leaf node.
+// When servicing a tree exclusively, other handlers sharing parts of the uri
+// will induce an address conflict when adding them to a server. The handler
+// will probably need to inspect the URL of the request.
+extern int nni_http_handler_set_tree_exclusive(nni_http_handler *);
+
 // nni_http_handler_set_host limits the handler to only being called for
 // the given Host: field.  This can be used to set up multiple virtual
 // hosts.  Note that host names must match exactly.  If NULL or an empty

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -636,6 +636,17 @@ nng_http_handler_set_tree(nng_http_handler *h)
 }
 
 int
+nng_http_handler_set_tree_exclusive(nng_http_handler *h)
+{
+#ifdef NNG_SUPP_HTTP
+	return (nni_http_handler_set_tree_exclusive(h));
+#else
+	NNI_ARG_UNUSED(h);
+	return (NNG_ENOTSUP);
+#endif
+}
+
+int
 nng_http_handler_set_data(nng_http_handler *h, void *dat, void (*dtor)(void *))
 {
 #ifdef NNG_SUPP_HTTP

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -3,6 +3,7 @@
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 QXSoftware <lh563566994@126.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
+// Copyright 2020 Dirac Research <robert.bielik@dirac.com>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -37,6 +38,7 @@ struct nng_http_handler {
 	char *          method;
 	char *          host;
 	bool            tree;
+	bool            tree_exclusive;
 	nni_atomic_u64  ref;
 	nni_atomic_bool busy;
 	size_t          maxbody;
@@ -110,11 +112,12 @@ nni_http_handler_init(
 		return (NNG_ENOMEM);
 	}
 	NNI_LIST_NODE_INIT(&h->node);
-	h->cb      = cb;
-	h->data    = NULL;
-	h->dtor    = NULL;
-	h->host    = NULL;
-	h->tree    = false;
+	h->cb             = cb;
+	h->data           = NULL;
+	h->dtor           = NULL;
+	h->host           = NULL;
+	h->tree           = false;
+	h->tree_exclusive = false;
 	h->maxbody = 1024 * 1024; // By default we accept up to 1MB of body
 	h->getbody = true;
 	*hp        = h;
@@ -177,7 +180,19 @@ nni_http_handler_set_tree(nni_http_handler *h)
 	if (nni_atomic_get_bool(&h->busy) != 0) {
 		return (NNG_EBUSY);
 	}
-	h->tree = true;
+	h->tree           = true;
+	h->tree_exclusive = false;
+	return (0);
+}
+
+int
+nni_http_handler_set_tree_exclusive(nni_http_handler *h)
+{
+	if (nni_atomic_get_bool(&h->busy) != 0) {
+		return (NNG_EBUSY);
+	}
+	h->tree           = true;
+	h->tree_exclusive = true;
 	return (0);
 }
 
@@ -1115,8 +1130,8 @@ nni_http_server_add_handler(nni_http_server *s, nni_http_handler *h)
 	}
 
 	nni_mtx_lock(&s->mtx);
-	// General rule for finding a conflict is that if either string
-	// is a strict substring of the other, then we have a
+	// General rule for finding a conflict is that if either uri
+	// string is an exact duplicate of the other, then we have a
 	// collision.  (But only if the methods match, and the host
 	// matches.)  Note that a wild card host matches both.
 	NNI_LIST_FOREACH (&s->handlers, h2) {
@@ -1146,26 +1161,54 @@ nni_http_server_add_handler(nni_http_server *s, nni_http_handler *h)
 		while ((len2 > 0) && (h2->uri[len2 - 1] == '/')) {
 			len2--; // ignore trailing '/'
 		}
-		if (strncmp(h->uri, h2->uri, len > len2 ? len2 : len) != 0) {
-			continue; // prefixes don't match.
-		}
 
-		if (len2 > len) {
-			if ((h2->uri[len] == '/') && (h->tree)) {
-				nni_mtx_unlock(&s->mtx);
-				return (NNG_EADDRINUSE);
+		if ((h2->tree && h2->tree_exclusive) ||
+		    (h->tree && h->tree_exclusive)) {
+			// Old behavior
+			if (strncmp(h->uri, h2->uri,
+			        len > len2 ? len2 : len) != 0) {
+				continue; // prefixes don't match.
 			}
-		} else if (len > len2) {
-			if ((h->uri[len2] == '/') && (h2->tree)) {
+
+			if (len2 > len) {
+				if ((h2->uri[len] == '/') && (h->tree)) {
+					nni_mtx_unlock(&s->mtx);
+					return (NNG_EADDRINUSE);
+				}
+			} else if (len > len2) {
+				if ((h->uri[len2] == '/') && (h2->tree)) {
+					nni_mtx_unlock(&s->mtx);
+					return (NNG_EADDRINUSE);
+				}
+			} else {
 				nni_mtx_unlock(&s->mtx);
 				return (NNG_EADDRINUSE);
 			}
 		} else {
+			if (len != len2) {
+				continue; // length mismatch
+			}
+
+			if (strcmp(h->uri, h2->uri) != 0) {
+				continue; // not a duplicate
+			}
+
 			nni_mtx_unlock(&s->mtx);
 			return (NNG_EADDRINUSE);
 		}
 	}
-	nni_list_append(&s->handlers, h);
+
+	// Maintain list of handlers in longest uri first order
+	NNI_LIST_FOREACH (&s->handlers, h2) {
+		size_t len2 = strlen(h2->uri);
+		if (len > len2) {
+			nni_list_insert_before(&s->handlers, h, h2);
+			break;
+		}
+	}
+	if (h2 == NULL) {
+		nni_list_append(&s->handlers, h);
+	}
 
 	// Note that we have borrowed the reference count on the handler.
 	// Thus we own it, and if the server is destroyed while we have it,
@@ -1533,7 +1576,7 @@ nni_http_handler_init_directory(
 	// We don't permit a body for getting a file.
 	nni_http_handler_collect_body(h, true, 0);
 
-	if (((rv = nni_http_handler_set_tree(h)) != 0) ||
+	if (((rv = nni_http_handler_set_tree_exclusive(h)) != 0) ||
 	    ((rv = nni_http_handler_set_data(h, hf, http_file_free)) != 0)) {
 		http_file_free(hf);
 		nni_http_handler_fini(h);


### PR DESCRIPTION
Adds possibility to have multiple handlers with same prefix, ordered in descending length. So you can serve a directory at "/" while having a GET handler serving "/rest-api". This makes sure that no CORS problems occur.

Also, this PR makes the nngcat bash scripts "executable" in git.

I concluded that no changes are needed to the nng_http_server_add_handler documentation, as what stands there is still applicable.