### PR TITLE
fixes #1163 compat tests are very brittle

### DIFF
--- a/src/compat/nanomsg/CMakeLists.txt
+++ b/src/compat/nanomsg/CMakeLists.txt
@@ -1,6 +1,5 @@
 #
-# Copyright 2018 Capitar IT Group BV <info@capitar.com>
-# Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+# Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 #
 # This software is supplied under the terms of the MIT License, a
 # copy of which should be located in the distribution where this
@@ -8,8 +7,9 @@
 # found online at https://opensource.org/licenses/MIT.
 #
 
-set(COMPAT_SOURCES compat/nanomsg/nn.c)
+#set(COMPAT_SOURCES compat/nanomsg/nn.c)
+nng_sources(nn.c)
 
-set(NNG_SRCS ${NNG_SRCS} ${COMPAT_SOURCES} PARENT_SCOPE)
+#set(NNG_SRCS ${NNG_SRCS} ${COMPAT_SOURCES} PARENT_SCOPE)
 
-nng_test(compat_tcp)
+nng_test(compat_tcp_test)

--- a/src/compat/nanomsg/compat_testutil.h
+++ b/src/compat/nanomsg/compat_testutil.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -39,6 +39,36 @@ extern "C" {
 		    err_ = expect, "%s fails with %s", #cond, #expect);  \
 		TEST_MSG("%s: expected %s, got %s (%d)", #cond, #expect, \
 		    expect, nng_strerror(err_), result_);                \
+	} while (0)
+
+// These macros use some details of the socket and pipe which are not public.
+// We do that to facilitate testing.  Don't rely on this equivalence in your
+// own application code.
+
+#define TEST_NN_MARRY(s1, s2)                                          \
+	do {                                                           \
+		int        rv_;                                        \
+		nng_socket s1_, s2_;                                   \
+		s1_.id = s1;                                           \
+		s2_.id = s2;                                           \
+                                                                       \
+		TEST_CHECK_(testutil_marry(s1_, s2_) == 0, "marry %s", \
+		    nng_strerror(rv_));                                \
+	} while (0)
+
+#define TEST_NN_MARRY_EX(s1, s2, url, p1, p2)                          \
+	do {                                                           \
+		int        rv_;                                        \
+		nng_socket s1_, s2_;                                   \
+		nng_pipe   p1_, p2_;                                   \
+		s1_.id = s1;                                           \
+		s2_.id = s2;                                           \
+		rv_    = testutil_marry_ex(s1_, s2_, url, &p1_, &p2_); \
+		TEST_CHECK_(rv_ == 0, "marry %s", nng_strerror(rv_));  \
+		p1 = p1_.id;                                           \
+		p2 = p2_.id;                                           \
+		TEST_CHECK(p1 >= 0);                                   \
+		TEST_CHECK(p2 >= 0);                                   \
 	} while (0)
 
 #ifdef __cplusplus

--- a/src/protocol/reqrep0/xreq_test.c
+++ b/src/protocol/reqrep0/xreq_test.c
@@ -234,7 +234,7 @@ test_xreq_recv_header(void)
 	TEST_NNG_PASS(nng_setopt_ms(rep, NNG_OPT_SENDTIMEO, 1000));
 	TEST_NNG_PASS(nng_setopt_ms(rep, NNG_OPT_SENDTIMEO, 1000));
 
-	TEST_NNG_PASS(testutil_marry_ex(req, rep, &p1, &p2));
+	TEST_NNG_PASS(testutil_marry_ex(req, rep, NULL, &p1, &p2));
 
 	// Simulate a few hops.
 	TEST_NNG_PASS(nng_msg_alloc(&m, 0));
@@ -276,7 +276,7 @@ test_xreq_close_during_recv(void)
 	TEST_NNG_PASS(nng_setopt_int(req, NNG_OPT_RECVBUF, 5));
 	TEST_NNG_PASS(nng_setopt_int(rep, NNG_OPT_SENDBUF, 20));
 
-	TEST_NNG_PASS(testutil_marry_ex(req, rep, &p1, &p2));
+	TEST_NNG_PASS(testutil_marry_ex(req, rep, NULL, &p1, &p2));
 	TEST_CHECK(nng_pipe_id(p1) > 0);
 	TEST_CHECK(nng_pipe_id(p2) > 0);
 
@@ -307,7 +307,7 @@ test_xreq_close_pipe_during_send(void)
 	TEST_NNG_PASS(nng_setopt_int(rep, NNG_OPT_RECVBUF, 5));
 	TEST_NNG_PASS(nng_setopt_int(req, NNG_OPT_SENDBUF, 20));
 
-	TEST_NNG_PASS(testutil_marry_ex(req, rep, &p1, &p2));
+	TEST_NNG_PASS(testutil_marry_ex(req, rep, NULL, &p1, &p2));
 	TEST_CHECK(nng_pipe_id(p1) > 0);
 	TEST_CHECK(nng_pipe_id(p2) > 0);
 
@@ -329,7 +329,7 @@ test_xreq_ttl_option(void)
 	nng_socket  rep;
 	int         v;
 	bool        b;
-	size_t      sz  = sizeof(v);
+	size_t      sz;
 	const char *opt = NNG_OPT_MAXTTL;
 
 	TEST_NNG_PASS(nng_req0_open_raw(&rep));

--- a/src/protocol/survey0/xsurvey_test.c
+++ b/src/protocol/survey0/xsurvey_test.c
@@ -227,7 +227,7 @@ test_xsurvey_recv_header(void)
 	nng_socket resp;
 	nng_socket surv;
 	nng_msg *  m;
-	nng_pipe   p1, p2;
+	nng_pipe   p;
 	uint32_t   id;
 
 	TEST_NNG_PASS(nng_respondent0_open_raw(&resp));
@@ -237,11 +237,11 @@ test_xsurvey_recv_header(void)
 	TEST_NNG_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 1000));
 	TEST_NNG_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 1000));
 
-	TEST_NNG_PASS(testutil_marry_ex(surv, resp, &p1, &p2));
+	TEST_NNG_PASS(testutil_marry_ex(surv, resp, NULL, NULL, &p));
 
 	// Simulate a few hops.
 	TEST_NNG_PASS(nng_msg_alloc(&m, 0));
-	TEST_NNG_PASS(nng_msg_header_append_u32(m, nng_pipe_id(p2)));
+	TEST_NNG_PASS(nng_msg_header_append_u32(m, nng_pipe_id(p)));
 	TEST_NNG_PASS(nng_msg_header_append_u32(m, 0x2));
 	TEST_NNG_PASS(nng_msg_header_append_u32(m, 0x1));
 	TEST_NNG_PASS(nng_msg_header_append_u32(m, 0x80000123u));
@@ -279,7 +279,7 @@ test_xsurvey_close_during_recv(void)
 	TEST_NNG_PASS(nng_setopt_int(surv, NNG_OPT_RECVBUF, 1));
 	TEST_NNG_PASS(nng_setopt_int(resp, NNG_OPT_SENDBUF, 20));
 
-	TEST_NNG_PASS(testutil_marry_ex(surv, resp, &p1, &p2));
+	TEST_NNG_PASS(testutil_marry_ex(surv, resp, NULL, &p1, &p2));
 	TEST_CHECK(nng_pipe_id(p1) > 0);
 	TEST_CHECK(nng_pipe_id(p2) > 0);
 
@@ -310,7 +310,7 @@ test_xsurvey_close_pipe_during_send(void)
 	TEST_NNG_PASS(nng_setopt_int(resp, NNG_OPT_RECVBUF, 5));
 	TEST_NNG_PASS(nng_setopt_int(surv, NNG_OPT_SENDBUF, 20));
 
-	TEST_NNG_PASS(testutil_marry_ex(surv, resp, &p1, &p2));
+	TEST_NNG_PASS(testutil_marry_ex(surv, resp, NULL, &p1, &p2));
 	TEST_CHECK(nng_pipe_id(p1) > 0);
 	TEST_CHECK(nng_pipe_id(p2) > 0);
 
@@ -332,7 +332,7 @@ test_xsurvey_ttl_option(void)
 	nng_socket  s;
 	int         v;
 	bool        b;
-	size_t      sz  = sizeof(v);
+	size_t      sz;
 	const char *opt = NNG_OPT_MAXTTL;
 
 	TEST_NNG_PASS(nng_surveyor0_open_raw(&s));
@@ -403,7 +403,7 @@ TEST_LIST = {
 	{ "xsurvey close during recv", test_xsurvey_close_during_recv },
 	{ "xsurvey close pipe during send",
 	    test_xsurvey_close_pipe_during_send },
-	{ "xsurvey ttl option",  test_xsurvey_ttl_option },
-	{ "xsurvey broadcast",  test_xsurvey_broadcast },
+	{ "xsurvey ttl option", test_xsurvey_ttl_option },
+	{ "xsurvey broadcast", test_xsurvey_broadcast },
 	{ NULL, NULL },
 };

--- a/tests/testutil.c
+++ b/tests/testutil.c
@@ -328,19 +328,24 @@ married(nng_pipe p, nng_pipe_ev ev, void *arg)
 int
 testutil_marry(nng_socket s1, nng_socket s2)
 {
-	return (testutil_marry_ex(s1, s2, NULL, NULL));
+	return (testutil_marry_ex(s1, s2, NULL, NULL, NULL));
 }
 
 int
-testutil_marry_ex(nng_socket s1, nng_socket s2, nng_pipe *p1, nng_pipe *p2)
+testutil_marry_ex(
+    nng_socket s1, nng_socket s2, const char *url, nng_pipe *p1, nng_pipe *p2)
 {
 	struct marriage_notice note;
 	nng_time               timeout;
 	int                    rv;
 	char                   addr[32];
 
-	(void) snprintf(addr, sizeof(addr), "inproc://marry%04x%04x%04x%04x",
-	    nng_random(), nng_random(), nng_random(), nng_random());
+	if (url == NULL) {
+		(void) snprintf(addr, sizeof(addr),
+		    "inproc://marry%04x%04x%04x%04x", nng_random(),
+		    nng_random(), nng_random(), nng_random());
+		url = addr;
+	}
 
 	note.cnt1 = 0;
 	note.cnt2 = 0;
@@ -354,8 +359,8 @@ testutil_marry_ex(nng_socket s1, nng_socket s2, nng_pipe *p1, nng_pipe *p2)
 	          s1, NNG_PIPE_EV_ADD_POST, married, &note)) != 0) ||
 	    ((rv = nng_pipe_notify(
 	          s2, NNG_PIPE_EV_ADD_POST, married, &note)) != 0) ||
-	    ((rv = nng_listen(s1, addr, NULL, 0)) != 0) ||
-	    ((rv = nng_dial(s2, addr, NULL, 0)) != 0)) {
+	    ((rv = nng_listen(s1, url, NULL, 0)) != 0) ||
+	    ((rv = nng_dial(s2, url, NULL, 0)) != 0)) {
 		goto done;
 	}
 

--- a/tests/testutil.h
+++ b/tests/testutil.h
@@ -51,8 +51,10 @@ extern void testutil_scratch_addr(const char *, size_t, char *);
 extern int testutil_marry(nng_socket, nng_socket);
 
 // testutil_marry_ex is like testutil_marry, but returns the pipes that
-// were connected.  The pipe pointers may be NULL if not needed.
-extern int testutil_marry_ex(nng_socket, nng_socket, nng_pipe *, nng_pipe *);
+// were connected, and includes an optional URL.  The pipe pointers and the
+// URL may be NULL if not needed.
+extern int testutil_marry_ex(
+    nng_socket, nng_socket, const char *, nng_pipe *, nng_pipe *);
 
 // TEST_NNG_PASS tests for NNG success.  It reports the failure if it
 // did not.


### PR DESCRIPTION
This only addresses the newly rewitten compat_tcp test, but it
sets the groundwork for the other tests, so that when they are
updated to the new acutest.h they can use the new marry code to
establish connections cleanly and safely.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
