### PR TITLE
Fix error checks

### DIFF
--- a/demo/async/client.c
+++ b/demo/async/client.c
@@ -53,7 +53,7 @@ client(const char *url, const char *msecstr)
 		fatal("nng_req0_open", rv);
 	}
 
-	if ((rv = nng_dial(sock, url, NULL, 0)) < 0) {
+	if ((rv = nng_dial(sock, url, NULL, 0)) != 0) {
 		fatal("nng_dial", rv);
 	}
 

--- a/demo/raw/raw.c
+++ b/demo/raw/raw.c
@@ -174,7 +174,7 @@ client(const char *url, const char *msecstr)
 		fatal("nng_req0_open", rv);
 	}
 
-	if ((rv = nng_dial(sock, url, NULL, 0)) < 0) {
+	if ((rv = nng_dial(sock, url, NULL, 0)) != 0) {
 		fatal("nng_dial", rv);
 	}
 


### PR DESCRIPTION
Issue: starting the client(s) first, and the server afterwards blocks communication in these demo samples.

Most error codes in `nng_errno_enum` are positve values, so the existing error check would not catch something like `NNG_ECONNREFUSED`, the execution would proceed, and the communication would get blocked.

With this change, if the server is not able to receive, the client would exit with `fatal` instead of hanging.

