### PR TITLE
fixes #1202 More than 120 threads was started by NNG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,12 @@ if (NNG_NUM_TASKQ_THREADS)
 endif ()
 mark_as_advanced(NNG_NUM_TASKQ_THREADS)
 
+set(NNG_MAX_TASKQ_THREADS 16 CACHE STRING "Upper bound on taskq threads, 0 for no limit")
+mark_as_advanced(NNG_MAX_TASKQ_THREADS)
+if (NNG_MAX_TASKQ_THREADS)
+    add_definitions(-DNNG_MAX_TASKQ_THREADS=${NNG_MAX_TASKQ_THREADS})
+endif ()
+
 #  Platform checks.
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
@@ -152,7 +158,7 @@ endif ()
 include(CheckAtomicLib)
 CheckAtomicLib()
 if (NOT HAVE_C_ATOMICS_WITHOUT_LIB AND HAVE_C_ATOMICS_WITH_LIB)
-     list(APPEND NNG_LIBS "atomic")
+    list(APPEND NNG_LIBS "atomic")
 endif ()
 
 

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -228,6 +228,11 @@ nni_taskq_sys_init(void)
 #else
 	nthrs = NNG_NUM_TASKQ_THREADS;
 #endif
+#if NNG_MAX_TASKQ_THREADS > 0
+	if (nthrs > NNG_MAX_TASKQ_THREADS) {
+		nthrs = NNG_MAX_TASKQ_THREADS;
+	}
+#endif
 
 	return (nni_taskq_init(&nni_taskq_systq, nthrs));
 }


### PR DESCRIPTION
This introduces a new CMake option, NNG_MAX_TASKQ_THREADS, with
a default value of 16.  The number of taskq workers will generally
be calculated as vcpu * 2.  This new value, if not zero, sets an
upper bound.  Note that the value should be at least two, in order
to ensure no deadlocks occur.
