### PR TITLE
Add Vcpkg instructions

### DIFF
--- a/docs/BUILD_CROSSCOMPILE.adoc
+++ b/docs/BUILD_CROSSCOMPILE.adoc
@@ -36,7 +36,7 @@ More details for Android are located in the <<BUILD_ANDROID.adoc>> file.
 
 More details for iOS (and tvOS, etc.) are located in the <<BUILD_IOS.adoc>> file.
 
-== Building nng for Windows or Linux or MACOS - Using vcpkg
+== Cross-compiling for Windows or Linux or MACOS - Using vcpkg
 
 You can download and install nng using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 

--- a/docs/BUILD_CROSSCOMPILE.adoc
+++ b/docs/BUILD_CROSSCOMPILE.adoc
@@ -35,3 +35,15 @@ More details for Android are located in the <<BUILD_ANDROID.adoc>> file.
 == Cross-compiling for iOS
 
 More details for iOS (and tvOS, etc.) are located in the <<BUILD_IOS.adoc>> file.
+
+== Building nng for Windows or Linux or MACOS - Using vcpkg
+
+You can download and install nng using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install nng
+
+The nng port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
Nng is available as a port in vcpkg, a C++ library manager that simplifies installation for nng and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build nng, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
