### PR TITLE
fixes #1241 SIGSEGV in RepReq's rep0 recv - use after free

### DIFF
--- a/src/protocol/reqrep0/req.c
+++ b/src/protocol/reqrep0/req.c
@@ -311,6 +311,8 @@ req0_recv_cb(void *arg)
 
 	// Schedule another receive while we are processing this.
 	nni_mtx_lock(&s->mtx);
+
+	// NB: If close was called, then this will just abort.
 	nni_pipe_recv(p->pipe, &p->aio_recv);
 
 	// Look for a context to receive it.


### PR DESCRIPTION
This also affects the respondent protocol.  Examination of the other
protocols did not turn up any evidence of the same issue.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
