### PR TITLE
fix typo in nng_cv_wait example

### DIFF
--- a/docs/man/nng_cv_wait.3supp.adoc
+++ b/docs/man/nng_cv_wait.3supp.adoc
@@ -61,7 +61,7 @@ The following example demonstrates use of this function:
 ----
     nng_mtx_lock(m);
     condition_true = true;
-    cv_wake(cv);
+    nng_cv_wake(cv);
     nng_mtx_unlock(m);
 ----
 


### PR DESCRIPTION
`cv_wake` should be `nng_cv_wake`