### PR TITLE
Support NNG_OPT_IPC_PEER_PID on modern macOS systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ else ()
     nng_check_sym(SO_PEERCRED sys/socket.h NNG_HAVE_SOPEERCRED)
     nng_check_struct_member(sockpeercred uid sys/socket.h NNG_HAVE_SOCKPEERCRED)
     nng_check_sym(LOCAL_PEERCRED sys/un.h NNG_HAVE_LOCALPEERCRED)
+    nng_check_sym(LOCAL_PEERPID sys/un.h NNG_HAVE_LOCALPEERPID)
     nng_check_sym(getpeerucred ucred.h NNG_HAVE_GETPEERUCRED)
     nng_check_sym(atomic_flag_test_and_set stdatomic.h NNG_HAVE_STDATOMIC)
 

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -318,7 +318,7 @@ ipc_peerid(ipc_conn *c, uint64_t *euid, uint64_t *egid, uint64_t *prid,
     uint64_t *znid)
 {
 	int fd = nni_posix_pfd_fd(c->pfd);
-#if defined(NNG_HAVE_GETPEEREID)
+#if defined(NNG_HAVE_GETPEEREID) && !defined(NNG_HAVE_LOCALPEERCRED)
 	uid_t uid;
 	gid_t gid;
 
@@ -373,7 +373,7 @@ ipc_peerid(ipc_conn *c, uint64_t *euid, uint64_t *egid, uint64_t *prid,
 	*egid = xu.cr_gid;
 	*prid = (uint64_t) -1;
 	*znid = (uint64_t) -1;
-#if defined(LOCAL_PEERPID) // present (undocumented) on macOS
+#if defined(NNG_HAVE_LOCALPEERPID) // documented on macOS since 10.8
 	{
 		pid_t pid;
 		if (getsockopt(fd, SOL_LOCAL, LOCAL_PEERPID, &pid, &len) ==
@@ -381,7 +381,7 @@ ipc_peerid(ipc_conn *c, uint64_t *euid, uint64_t *egid, uint64_t *prid,
 			*prid = (uint64_t) pid;
 		}
 	}
-#endif                     // LOCAL_PEERPID
+#endif                     // NNG_HAVE_LOCALPEERPID
 	return (0);
 #else
 	if (fd < 0) {

--- a/tests/ipc.c
+++ b/tests/ipc.c
@@ -63,7 +63,8 @@ check_props(nng_msg *msg)
 	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_GID, &id) == 0);
 	So(id == (uint64_t) getgid());
 
-#if defined(NNG_HAVE_SOPEERCRED) || defined(NNG_HAVE_GETPEERUCRED)
+#if defined(NNG_HAVE_SOPEERCRED) || defined(NNG_HAVE_GETPEERUCRED) || \
+    (defined(NNG_HAVE_LOCALPEERCRED) && defined(NNG_HAVE_LOCALPEERPID))
 	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_PID, &id) == 0);
 	So(id == (uint64_t) getpid());
 #else


### PR DESCRIPTION
fixes #1255 macOS support for NNG_OPT_IPC_PEER_PID

`ipc_peerid` in posix_ipcconn.c uses `getpeereid` even on systems with the `LOCAL_PEERCRED` socket option. If `LOCAL_PEERCRED` is available, use it instead and allow retrieving the peer PID if `LOCAL_PEERPID` is available.

`LOCAL_PEERPID` is documented on macOS since 10.8. 

We assume anyone building nng on a Mac is using >10.8. At runtime, the option may still be available in the kernel depending on the macOS version, but otherwise, the existing behaviour is retained (return `NNG_ENOTSUP`)

Finally, the check for `LOCAL_PEERID` is elevated into `NNG_HAVE_LOCALPEERPID` so we can check in the ipc unit test.
