### PR TITLE
fix #1252

### DIFF
--- a/src/core/message.c
+++ b/src/core/message.c
@@ -578,7 +578,6 @@ nni_msg_header_append_u32(nni_msg *m, uint32_t val)
 void
 nni_msg_clear(nni_msg *m)
 {
-	m->m_header_len = 0;
 	nni_chunk_clear(&m->m_body);
 }
 

--- a/tests/message.c
+++ b/tests/message.c
@@ -91,10 +91,13 @@ TestMain("Message Tests", {
 		});
 
 		Convey("Clearing the body works", {
+			nng_msg_header_append(msg, "bogus", 6);
 			So(nng_msg_append(msg, "bogus", 6) == 0);
 			So(nng_msg_len(msg) == 6);
 			nng_msg_clear(msg);
 			So(nng_msg_len(msg) == 0);
+			// It shouldn't clear the header
+			So(nng_msg_header_len(msg) == 6);
 		});
 
 		Convey("We cannot delete more header than exists", {


### PR DESCRIPTION
- nng_msg_clear should only clear the message body and not the head.  Add test to verify

fixes #1252 