### PR TITLE
fixes #1235 framing error in SSL/TLS

### DIFF
--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -1098,6 +1098,8 @@ tls_tcp_send_cb(void *arg)
 	count = nni_aio_count(aio);
 	NNI_ASSERT(count <= conn->tcp_send_len);
 	conn->tcp_send_len -= count;
+	conn->tcp_send_tail += count;
+	conn->tcp_send_tail %= NNG_TLS_MAX_SEND_SIZE;
 	tls_tcp_send_start(conn);
 
 	if (tls_do_handshake(conn)) {
@@ -1180,6 +1182,7 @@ tls_tcp_send_start(tls_conn *conn)
 
 	while (len > 0) {
 		size_t cnt;
+		NNI_ASSERT(nio < 2);
 		if (tail < head) {
 			cnt = head - tail;
 		} else {
@@ -1196,7 +1199,6 @@ tls_tcp_send_start(tls_conn *conn)
 		nio++;
 	}
 	conn->tcp_send_active = true;
-	conn->tcp_send_tail   = tail;
 	nni_aio_set_iov(&conn->tcp_send, nio, iov);
 	nng_stream_send(conn->tcp, &conn->tcp_send);
 }


### PR DESCRIPTION
This was first detected as a stack overrun, but in actuality the
problem could have lead to corruption of TLS messages due to
prematurely recording transmit completion.
