### PR TITLE
fixes #844 WebSocket wildcard host errors

### DIFF
--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -339,6 +339,12 @@ extern void nni_tcp_resolv(const char *, const char *, int, int, nni_aio *);
 // service names using UDP.
 extern void nni_udp_resolv(const char *, const char *, int, int, nni_aio *);
 
+// nni_parse_ip parses an IP address, without a port.
+extern int nni_parse_ip(const char *, nng_sockaddr *);
+
+// nni_parse_ip_port parses an IP address with an optional port appended.
+extern int nni_parse_ip_port(const char *, nng_sockaddr *);
+
 //
 // IPC (UNIX Domain Sockets & Named Pipes) Support.
 //

--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -314,6 +314,108 @@ resolv_worker(void *notused)
 		NNI_FREE_STRUCT(item);
 	}
 	nni_mtx_unlock(&resolv_mtx);
+}
+
+int
+parse_ip(const char *addr, nng_sockaddr *sa, bool want_port)
+{
+	struct addrinfo  hints;
+	struct addrinfo *results;
+	int              rv;
+	bool             v6      = false;
+	bool             wrapped = false;
+	char *           port;
+	char *           host;
+	char *           buf;
+	size_t           buf_len;
+
+	if (addr == NULL) {
+		addr = "";
+	}
+
+	buf_len = strlen(addr) + 1;
+	if ((buf = nni_alloc(buf_len)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	memcpy(buf, addr, buf_len);
+	host = buf;
+	if (*host == '[') {
+		v6      = true;
+		wrapped = true;
+		host++;
+	} else {
+		char *s;
+		for (s = host; *s != '\0'; s++) {
+			if (*s == '.') {
+				break;
+			}
+			if (*s == ':') {
+				v6 = true;
+				break;
+			}
+		}
+	}
+	for (port = host; *port != '\0'; port++) {
+		if (wrapped) {
+			if (*port == ']') {
+				*port++ = '\0';
+				wrapped = false;
+				break;
+			}
+		} else if (!v6) {
+			if (*port == ':') {
+				break;
+			}
+		}
+	}
+
+	if (wrapped) {
+		// Never got the closing bracket.
+		rv = NNG_EADDRINVAL;
+		goto done;
+	}
+
+	if ((!want_port) && (*port != '\0')) {
+		rv = NNG_EADDRINVAL;
+		goto done;
+	} else if (*port == ':') {
+		*port++ = '\0';
+	}
+
+	if (*port == '\0') {
+		port = "0";
+	}
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_flags =
+	    AI_ADDRCONFIG | AI_NUMERICSERV | AI_NUMERICHOST | AI_PASSIVE;
+	if (v6) {
+		hints.ai_family = AF_INET6;
+	}
+
+	rv = getaddrinfo(host, port, &hints, &results);
+	if ((rv != 0) || (results == NULL)) {
+		rv = nni_win_error(rv);
+		goto done;
+	}
+	nni_win_sockaddr2nn(sa, (void *) results->ai_addr);
+	freeaddrinfo(results);
+
+done:
+	nni_free(buf, buf_len);
+	return (rv);
+}
+
+int
+nni_parse_ip(const char *addr, nni_sockaddr *sa)
+{
+	return (parse_ip(addr, sa, false));
+}
+
+int
+nni_parse_ip_port(const char *addr, nni_sockaddr *sa)
+{
+	return (parse_ip(addr, sa, true));
 }
 
 int

--- a/src/supplemental/tcp/tcp.c
+++ b/src/supplemental/tcp/tcp.c
@@ -439,7 +439,7 @@ nni_tcp_listener_alloc(nng_stream_listener **lp, const nng_url *url)
 	h = url->u_hostname;
 
 	// Wildcard special case, which means bind to INADDR_ANY.
-	if ((h != NULL) && ((strcmp(h, "*") == 0) || (strlen(h) == 0))) {
+	if ((h != NULL) && ((strcmp(h, "*") == 0) || (strcmp(h, "") == 0))) {
 		h = NULL;
 	}
 	nni_tcp_resolv(h, url->u_port, af, 1, aio);


### PR DESCRIPTION
fixes #1224 wss fails on IPV6 address

This fixes bugs and inconsistencies in the way addresses are
handled for HTTP (and consequently websocket).  The Host:
address line needs to look at numeric IPs and treat wildcards
as if they are not specified, and needs to understand the IPv6
address format using brackets (e.g. [::1]:80).
