### PR TITLE
Fixes for MSVC1800

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,12 @@ if (WIN32)
     list(APPEND NNG_LIBS ws2_32 mswsock advapi32)
     nng_check_sym(InitializeConditionVariable windows.h NNG_HAVE_CONDVAR)
     nng_check_sym(snprintf stdio.h NNG_HAVE_SNPRINTF)
-    if (NOT NNG_HAVE_CONDVAR OR NOT NNG_HAVE_SNPRINTF)
+    if(NOT NNG_HAVE_SNPRINTF)
+      add_definitions(-DUSE_NNG_SNPRINTF=1)
+    else()
+      add_definitions(-DUSE_NNG_SNPRINTF=0)
+    endif()
+    if (NOT NNG_HAVE_CONDVAR)
         message(FATAL_ERROR
                 "Modern Windows API support is missing. "
                 "Versions of Windows prior to Vista are not supported.  "

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -25,6 +25,10 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+#if USE_NNG_SNPRINTF
+#include "supplemental/util/nng_snprintf.h"
+#endif
+
 // NNG_DECL is used on declarations to deal with scope.
 // For building Windows DLLs, it should be the appropriate __declspec().
 // For shared libraries with platforms that support hidden visibility,

--- a/include/nng/supplemental/util/nng_snprintf.h
+++ b/include/nng/supplemental/util/nng_snprintf.h
@@ -1,0 +1,42 @@
+#ifndef NNG_SNPRINTF_H
+#define NNG_SNPRINTF_H
+
+#include <stdarg.h>  // NOLINT
+#include <stdio.h>   // NOLINT
+
+#if !defined(__cplusplus) && defined(_MSC_VER)
+#define inline __inline
+#endif  //__cplusplus && _MSC_VER
+
+#ifdef __cplusplus
+extern "C" {
+#endif  //__cplusplus
+
+#if !defined(_TRUNCATE)
+#define _TRUNCATE ((size_t)-1)
+#endif  //_TRUNCATE
+
+inline int nng_snprintf(char* const _Buffer, int const _BufferCount, char const* const _Format, ...) {
+  int ret = 0;
+  va_list args;
+  va_start(args, _Format);
+#if _MSC_VER
+  ret = vsnprintf_s(_Buffer, _BufferCount, _TRUNCATE, _Format, args);
+#else
+  ret = vsnprintf(_Buffer, _BufferCount, _Format, args);
+#endif
+  va_end(args);
+  return ret;
+}
+
+#ifdef USE_NNG_SNPRINTF
+#if USE_NNG_SNPRINTF
+#define snprintf nng_snprintf
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif  //__cplusplus
+
+#endif  // NNG_SNPRINTF_H

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -85,30 +85,30 @@ typedef struct {
 #define NNI_ALLOC_STRUCTS(s, n) nni_zalloc(sizeof(*s) * n)
 #define NNI_FREE_STRUCTS(s, n) nni_free(s, sizeof(*s) * n)
 
-#define NNI_PUT16(ptr, u)                                    \
+#define NNI_PUT16(ptr, n)                                    \
 	do {                                                 \
-		(ptr)[0] = (uint8_t)(((uint16_t)(u)) >> 8u); \
-		(ptr)[1] = (uint8_t)((uint16_t)(u));         \
+		(ptr)[0] = (uint8_t)(((uint16_t)(n)) >> 8u); \
+		(ptr)[1] = (uint8_t)((uint16_t)(n));         \
 	} while (0)
 
-#define NNI_PUT32(ptr, u)                                     \
+#define NNI_PUT32(ptr, n)                                     \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint32_t)(u)) >> 24u); \
-		(ptr)[1] = (uint8_t)(((uint32_t)(u)) >> 16u); \
-		(ptr)[2] = (uint8_t)(((uint32_t)(u)) >> 8u);  \
-		(ptr)[3] = (uint8_t)((uint32_t)(u));          \
+		(ptr)[0] = (uint8_t)(((uint32_t)(n)) >> 24u); \
+		(ptr)[1] = (uint8_t)(((uint32_t)(n)) >> 16u); \
+		(ptr)[2] = (uint8_t)(((uint32_t)(n)) >> 8u);  \
+		(ptr)[3] = (uint8_t)((uint32_t)(n));          \
 	} while (0)
 
-#define NNI_PUT64(ptr, u)                                     \
+#define NNI_PUT64(ptr, n)                                     \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint64_t)(u)) >> 56u); \
-		(ptr)[1] = (uint8_t)(((uint64_t)(u)) >> 48u); \
-		(ptr)[2] = (uint8_t)(((uint64_t)(u)) >> 40u); \
-		(ptr)[3] = (uint8_t)(((uint64_t)(u)) >> 32u); \
-		(ptr)[4] = (uint8_t)(((uint64_t)(u)) >> 24u); \
-		(ptr)[5] = (uint8_t)(((uint64_t)(u)) >> 16u); \
-		(ptr)[6] = (uint8_t)(((uint64_t)(u)) >> 8u);  \
-		(ptr)[7] = (uint8_t)((uint64_t)(u));          \
+		(ptr)[0] = (uint8_t)(((uint64_t)(n)) >> 56u); \
+		(ptr)[1] = (uint8_t)(((uint64_t)(n)) >> 48u); \
+		(ptr)[2] = (uint8_t)(((uint64_t)(n)) >> 40u); \
+		(ptr)[3] = (uint8_t)(((uint64_t)(n)) >> 32u); \
+		(ptr)[4] = (uint8_t)(((uint64_t)(n)) >> 24u); \
+		(ptr)[5] = (uint8_t)(((uint64_t)(n)) >> 16u); \
+		(ptr)[6] = (uint8_t)(((uint64_t)(n)) >> 8u);  \
+		(ptr)[7] = (uint8_t)((uint64_t)(n));          \
 	} while (0)
 
 #define NNI_GET16(ptr, v)                             \

--- a/tests/convey.c
+++ b/tests/convey.c
@@ -59,6 +59,10 @@
 
 #include "convey.h"
 
+#if USE_NNG_SNPRINTF
+#include "nng/supplemental/util/nng_snprintf.h"
+#endif
+
 /*
  * About symbol naming.  We use Go-like conventions to help set expectations,
  * even though we cannot necessarily count on the linker to prevent


### PR DESCRIPTION
Currently, `nng` does not compile with Visual Studio 12.0 2013 (MSVC 1800). This PR attempts to provide a fix for that.

Added optional `nng_snprintf` function, could later be the ONE function used through out, replacing snprintf, _snprintf
Renamed the NNI_PUT macro variable from `u` to `n`, as it clashes with the number suffix.

Discussion: Not sure `nng.h` is the best header to include `nng_snprintf.h` from. Happy to move it elsewhere should you have a better suggestion.
