### PR TITLE
MSVC1800 does not like mixing macro variable names and suffixes

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -87,27 +87,27 @@ typedef struct {
 
 #define NNI_PUT16(ptr, u)                                    \
 	do {                                                 \
-		(ptr)[0] = (uint8_t)(((uint16_t)(u)) >> 8u); \
+		(ptr)[0] = (uint8_t)(((uint16_t)(u)) >> 8U); \
 		(ptr)[1] = (uint8_t)((uint16_t)(u));         \
 	} while (0)
 
 #define NNI_PUT32(ptr, u)                                     \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint32_t)(u)) >> 24u); \
-		(ptr)[1] = (uint8_t)(((uint32_t)(u)) >> 16u); \
-		(ptr)[2] = (uint8_t)(((uint32_t)(u)) >> 8u);  \
+		(ptr)[0] = (uint8_t)(((uint32_t)(u)) >> 24U); \
+		(ptr)[1] = (uint8_t)(((uint32_t)(u)) >> 16U); \
+		(ptr)[2] = (uint8_t)(((uint32_t)(u)) >> 8U);  \
 		(ptr)[3] = (uint8_t)((uint32_t)(u));          \
 	} while (0)
 
 #define NNI_PUT64(ptr, u)                                     \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint64_t)(u)) >> 56u); \
-		(ptr)[1] = (uint8_t)(((uint64_t)(u)) >> 48u); \
-		(ptr)[2] = (uint8_t)(((uint64_t)(u)) >> 40u); \
-		(ptr)[3] = (uint8_t)(((uint64_t)(u)) >> 32u); \
-		(ptr)[4] = (uint8_t)(((uint64_t)(u)) >> 24u); \
-		(ptr)[5] = (uint8_t)(((uint64_t)(u)) >> 16u); \
-		(ptr)[6] = (uint8_t)(((uint64_t)(u)) >> 8u);  \
+		(ptr)[0] = (uint8_t)(((uint64_t)(u)) >> 56U); \
+		(ptr)[1] = (uint8_t)(((uint64_t)(u)) >> 48U); \
+		(ptr)[2] = (uint8_t)(((uint64_t)(u)) >> 40U); \
+		(ptr)[3] = (uint8_t)(((uint64_t)(u)) >> 32U); \
+		(ptr)[4] = (uint8_t)(((uint64_t)(u)) >> 24U); \
+		(ptr)[5] = (uint8_t)(((uint64_t)(u)) >> 16U); \
+		(ptr)[6] = (uint8_t)(((uint64_t)(u)) >> 8U);  \
 		(ptr)[7] = (uint8_t)((uint64_t)(u));          \
 	} while (0)
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -85,30 +85,30 @@ typedef struct {
 #define NNI_ALLOC_STRUCTS(s, n) nni_zalloc(sizeof(*s) * n)
 #define NNI_FREE_STRUCTS(s, n) nni_free(s, sizeof(*s) * n)
 
-#define NNI_PUT16(ptr, u)                                    \
+#define NNI_PUT16(ptr, n)                                   \
 	do {                                                 \
-		(ptr)[0] = (uint8_t)(((uint16_t)(u)) >> 8U); \
-		(ptr)[1] = (uint8_t)((uint16_t)(u));         \
+		(ptr)[0] = (uint8_t)(((uint16_t)(n)) >> 8U); \
+		(ptr)[1] = (uint8_t)((uint16_t)(n));         \
 	} while (0)
 
-#define NNI_PUT32(ptr, u)                                     \
+#define NNI_PUT32(ptr, n)                                    \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint32_t)(u)) >> 24U); \
-		(ptr)[1] = (uint8_t)(((uint32_t)(u)) >> 16U); \
-		(ptr)[2] = (uint8_t)(((uint32_t)(u)) >> 8U);  \
-		(ptr)[3] = (uint8_t)((uint32_t)(u));          \
+		(ptr)[0] = (uint8_t)(((uint32_t)(n)) >> 24U); \
+		(ptr)[1] = (uint8_t)(((uint32_t)(n)) >> 16U); \
+		(ptr)[2] = (uint8_t)(((uint32_t)(n)) >> 8U);  \
+		(ptr)[3] = (uint8_t)((uint32_t)(n));          \
 	} while (0)
 
-#define NNI_PUT64(ptr, u)                                     \
+#define NNI_PUT64(ptr, n)                                    \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint64_t)(u)) >> 56U); \
-		(ptr)[1] = (uint8_t)(((uint64_t)(u)) >> 48U); \
-		(ptr)[2] = (uint8_t)(((uint64_t)(u)) >> 40U); \
-		(ptr)[3] = (uint8_t)(((uint64_t)(u)) >> 32U); \
-		(ptr)[4] = (uint8_t)(((uint64_t)(u)) >> 24U); \
-		(ptr)[5] = (uint8_t)(((uint64_t)(u)) >> 16U); \
-		(ptr)[6] = (uint8_t)(((uint64_t)(u)) >> 8U);  \
-		(ptr)[7] = (uint8_t)((uint64_t)(u));          \
+		(ptr)[0] = (uint8_t)(((uint64_t)(n)) >> 56U); \
+		(ptr)[1] = (uint8_t)(((uint64_t)(n)) >> 48U); \
+		(ptr)[2] = (uint8_t)(((uint64_t)(n)) >> 40U); \
+		(ptr)[3] = (uint8_t)(((uint64_t)(n)) >> 32U); \
+		(ptr)[4] = (uint8_t)(((uint64_t)(n)) >> 24U); \
+		(ptr)[5] = (uint8_t)(((uint64_t)(n)) >> 16U); \
+		(ptr)[6] = (uint8_t)(((uint64_t)(n)) >> 8U);  \
+		(ptr)[7] = (uint8_t)((uint64_t)(n));          \
 	} while (0)
 
 #define NNI_GET16(ptr, v)                             \

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -87,27 +87,27 @@ typedef struct {
 
 #define NNI_PUT16(ptr, n)                                   \
 	do {                                                 \
-		(ptr)[0] = (uint8_t)(((uint16_t)(n)) >> 8U); \
+		(ptr)[0] = (uint8_t)(((uint16_t)(n)) >> 8u); \
 		(ptr)[1] = (uint8_t)((uint16_t)(n));         \
 	} while (0)
 
 #define NNI_PUT32(ptr, n)                                    \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint32_t)(n)) >> 24U); \
-		(ptr)[1] = (uint8_t)(((uint32_t)(n)) >> 16U); \
-		(ptr)[2] = (uint8_t)(((uint32_t)(n)) >> 8U);  \
+		(ptr)[0] = (uint8_t)(((uint32_t)(n)) >> 24u); \
+		(ptr)[1] = (uint8_t)(((uint32_t)(n)) >> 16u); \
+		(ptr)[2] = (uint8_t)(((uint32_t)(n)) >> 8u);  \
 		(ptr)[3] = (uint8_t)((uint32_t)(n));          \
 	} while (0)
 
 #define NNI_PUT64(ptr, n)                                    \
 	do {                                                  \
-		(ptr)[0] = (uint8_t)(((uint64_t)(n)) >> 56U); \
-		(ptr)[1] = (uint8_t)(((uint64_t)(n)) >> 48U); \
-		(ptr)[2] = (uint8_t)(((uint64_t)(n)) >> 40U); \
-		(ptr)[3] = (uint8_t)(((uint64_t)(n)) >> 32U); \
-		(ptr)[4] = (uint8_t)(((uint64_t)(n)) >> 24U); \
-		(ptr)[5] = (uint8_t)(((uint64_t)(n)) >> 16U); \
-		(ptr)[6] = (uint8_t)(((uint64_t)(n)) >> 8U);  \
+		(ptr)[0] = (uint8_t)(((uint64_t)(n)) >> 56u); \
+		(ptr)[1] = (uint8_t)(((uint64_t)(n)) >> 48u); \
+		(ptr)[2] = (uint8_t)(((uint64_t)(n)) >> 40u); \
+		(ptr)[3] = (uint8_t)(((uint64_t)(n)) >> 32u); \
+		(ptr)[4] = (uint8_t)(((uint64_t)(n)) >> 24u); \
+		(ptr)[5] = (uint8_t)(((uint64_t)(n)) >> 16u); \
+		(ptr)[6] = (uint8_t)(((uint64_t)(n)) >> 8u);  \
 		(ptr)[7] = (uint8_t)((uint64_t)(n));          \
 	} while (0)
 


### PR DESCRIPTION
MSVC1800 does not like mixing lowercase macro variable named `u` together with the integral suffix lower case `u`. 
To fix this, lets use lower case for macro var and uppercase suffix instead.

Error: C:\github\nng\src\transport\tls\tls.c(584): error C2059: syntax error : 'bad suffix on number' [C:\github\nng\build\src\nng.vcxproj]
