### PR TITLE
Add snprintf wrapper if MSC_VER is less than 1900

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,7 +290,10 @@ if (WIN32)
     list(APPEND NNG_LIBS ws2_32 mswsock advapi32)
     nng_check_sym(InitializeConditionVariable windows.h NNG_HAVE_CONDVAR)
     nng_check_sym(snprintf stdio.h NNG_HAVE_SNPRINTF)
-    if (NOT NNG_HAVE_CONDVAR OR NOT NNG_HAVE_SNPRINTF)
+    if(NNG_HAVE_SNPRINTF)
+        add_definitions(-DNNG_HAVE_SNPRINTF=1)
+    endif()
+    if (NOT NNG_HAVE_CONDVAR)
         message(FATAL_ERROR
                 "Modern Windows API support is missing. "
                 "Versions of Windows prior to Vista are not supported.  "

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,7 +153,6 @@ if (NNG_PLATFORM_WINDOWS)
             platform/windows/win_impl.h
             platform/windows/win_ipc.h
             platform/windows/win_tcp.h
-
             platform/windows/win_clock.c
             platform/windows/win_debug.c
             platform/windows/win_file.c
@@ -171,6 +170,7 @@ if (NNG_PLATFORM_WINDOWS)
             platform/windows/win_tcplisten.c
             platform/windows/win_thread.c
             platform/windows/win_udp.c
+            platform/windows/win_snprintf.c
             )
 endif ()
 

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -25,6 +25,12 @@
 
 #include "core/list.h"
 
+#if !NNG_HAVE_SNPRINTF
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+extern int snprintf(char *buffer, size_t count, const char *format, ...);
+#endif
+#endif
+
 // These types are provided for here, to permit them to be directly inlined
 // elsewhere.
 

--- a/src/platform/windows/win_snprintf.c
+++ b/src/platform/windows/win_snprintf.c
@@ -1,0 +1,34 @@
+#ifndef NNG_WIN_SNPRINTF_H
+#define NNG_WIN_SNPRINTF_H
+
+#if !NNG_HAVE_SNPRINTF
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+
+#include <stdarg.h> // NOLINT
+#include <stdio.h>  // NOLINT
+
+#if !defined(_TRUNCATE)
+#define _TRUNCATE ((size_t) -1)
+#endif //_TRUNCATE
+
+// Each of these functions takes a pointer to an argument list, then formats
+// and writes up to count characters of the given data to the memory pointed to
+// by buffer and appends a terminating null. If count is _TRUNCATE, then these
+// functions write as much of the string as will fit in buffer while leaving
+// room for a terminating null. If the entire string (with terminating null)
+// fits in buffer, then these functions return the number of characters written
+// (not including the terminating null); otherwise, these functions return -1
+// to indicate that truncation occurred.
+int
+snprintf(char *buffer, size_t count, const char *format, ...)
+{
+	va_list args;
+	va_start(args, format);
+	int ret = vsnprintf_s(buffer, count, _TRUNCATE, format, args);
+	va_end(args);
+	return ret;
+}
+
+#endif // _MSC_VER < 1900
+#endif // !NNG_HAVE_SNPRINTF
+#endif NNG_WIN_SNPRINTF_H


### PR DESCRIPTION
`snprintf` does not exist in MSVC 1800 and below. This PR adds a wrapper around `vsnprintf_s` instead.

Unfortunately, this change also makes the `snprintf` function an internal implementation only available at linking, generating a compile warning:

`warning C4013: 'snprintf' undefined; assuming extern returning int`

To solve this, the files

```
src/supplemental/base64/base64_test.c
tests/convey.h
tests/testutil.h
tools/nngcat/nngcat.c
```

also needs to declare `snprintf` as extern, leading to code duplication throughout the test targets. 

One obvious way forward, to me, seems to be to add the declaration in

`nng/supplemental/util/platform.h`
 
instead. This would of course pollute the public header and may not be accepted.

 
