### PR TITLE
added missing backquote

### DIFF
--- a/docs/RATIONALE.adoc
+++ b/docs/RATIONALE.adoc
@@ -165,7 +165,7 @@ As a C programmer coming from UNIX systems, this really attracted me.
 
 The problem is that the POSIX APIs are actually really horrible.  In
 particular the semantics around `cmsg` are about as arcane and painful as
-one can imagine.  Largely, this has meant that extensions to the `cmsg
+one can imagine.  Largely, this has meant that extensions to the `cmsg`
 API simply have not occurred in _nanomsg_.
 
 The `cmsg` API specified by POSIX is as bad as it is because POSIX had


### PR DESCRIPTION
This is also missing in https://nng.nanomsg.org/RATIONALE.html, which seems to be a newer/extended version of this document

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
