### PR TITLE
fixes #914 websocket stream mode should support TEXT

### DIFF
--- a/docs/man/nng_ws.7.adoc
+++ b/docs/man/nng_ws.7.adoc
@@ -128,7 +128,7 @@ only available for `wss://` endpoints.
 
 ((`NNG_OPT_WS_REQUEST_HEADERS`))::
 
-(string) Concentation of multiple lines terminated
+(string) Concatenation of multiple lines terminated
 by CRLF sequences, that can be used to add further headers to the
 HTTP request sent when connecting.
 This option can be set on dialers, and retrieved from pipes.
@@ -139,6 +139,30 @@ This option can be set on dialers, and retrieved from pipes.
 by CRLF sequences, that can be used to add further headers to the
 HTTP response sent when connecting.
 This option can be set on listeners, and retrieved from pipes.
+
+((`NNG_OPT_WS_RECV_TEXT`))::
+
+(bool) Enable receiving of TEXT frames at the WebSocket layer.
+This option should only be used with the low level
+xref:nng_stream.5.adoc[`nng_stream`] API.
+When set, the stream will accept in-bound TEXT frames as well as BINARY frames.
+
+NOTE: The SP protocols (such as xref:nng_req.7.adoc[REQ]) require BINARY frames as they pass binary protocol data.
+Hence this option should not be used with such protocols.
+
+NOTE: RFC 6455 requires that TEXT frames be discarded and the connection closed if the frame does not contain valid UTF-8 data.
+NNG does not perform any such validation.
+Applications that need to be strictly conformant should check for this themselves.
+
+((`NNG_OPT_WS_SEND_TEXT`))::
+
+(bool) Enable sending of TEXT frames at the WebSocket layer.
+This option should only be used with the low level
+xref:nng_stream.5.adoc[`nng_stream`] API.
+When set, the stream will send TEXT frames instead of BINARY frames.
+
+NOTE: NNG does not check the frame data, and will attempt to send whatever the client requests.
+Peers that are compliant with RFC 6455 will discard TEXT frames (and break the connection) if they do not contain valid UTF-8.
 
 ((`NNG_OPT_TLS_CONFIG`))::
 

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -932,10 +932,31 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 // to send more data than this in a single message, it will be dropped.
 #define NNG_OPT_WS_RECVMAXFRAME "ws:rxframe-max"
 
-// NNG_OPT_WS_PROTOCOL is the "websocket subprotocol" -- it's a string.
+// NNG_OPT_WS_PROTOCOL is the "websocket sub-protocol" -- it's a string.
 // This is also known as the Sec-WebSocket-Protocol header. It is treated
 // specially.  This is part of the websocket handshake.
 #define NNG_OPT_WS_PROTOCOL "ws:protocol"
+
+// NNG_OPT_WS_SEND_TEXT is a boolean used to tell the WS stream
+// transport to send text messages.  This is not supported for the
+// core WebSocket transport, but when using streams it might be useful
+// to speak with 3rd party WebSocket applications.  This mode should
+// not be used unless absolutely required. No validation of the message
+// contents is performed by NNG; applications are expected to honor
+// the requirement to send only valid UTF-8.  (Compliant applications
+// will close the socket if they see this message type with invalid UTF-8.)
+#define NNG_OPT_WS_SEND_TEXT "ws:send-text"
+
+// NNG_OPT_WS_RECV_TEXT is a boolean that enables NNG to receive
+// TEXT frames.  This is only useful for stream mode applications --
+// SP protocol requires the use of binary frames.  Note also that
+// NNG does not validate the message contents for valid UTF-8; this
+// means it will not be conformant with RFC-6455 on it's own. Applications
+// that need this should check the message contents themselves, and
+// close the connection if invalid UTF-8 is received.  This option
+// should not be used unless required to communication with 3rd party
+// peers that cannot be coerced into sending binary frames.
+#define NNG_OPT_WS_RECV_TEXT "ws:recv-text"
 
 // XXX: TBD: priorities, ipv4only
 

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -28,7 +28,7 @@ typedef int (*nni_ws_listen_hook)(void *, nng_http_req *, nng_http_res *);
 // We have chosen to be a bit more stringent in the size of the frames that
 // we send, while we more generously allow larger incoming frames.  These
 // may be tuned by options.
-#define WS_DEF_RECVMAX (1U << 20)    // 1MB Message limit (message mode only)
+#define WS_DEF_RECVMAX (1U << 20) // 1MB Message limit (message mode only)
 #define WS_DEF_MAXRXFRAME (1U << 20) // 1MB Frame size (recv)
 #define WS_DEF_MAXTXFRAME (1U << 16) // 64KB Frame size (send)
 
@@ -54,6 +54,8 @@ struct nni_ws {
 	bool             wclose;
 	bool             isstream;
 	bool             inmsg;
+	bool             send_text;
+	bool             recv_text;
 	nni_mtx          mtx;
 	nni_list         sendq;
 	nni_list         recvq;
@@ -92,6 +94,8 @@ struct nni_ws_listener {
 	bool                started;
 	bool                closed;
 	bool                isstream;
+	bool                send_text;
+	bool                recv_text;
 	nni_http_handler *  handler;
 	nni_ws_listen_hook  hookfn;
 	void *              hookarg;
@@ -119,6 +123,8 @@ struct nni_ws_dialer {
 	nni_list          wspend; // ws structures still negotiating
 	bool              closed;
 	bool              isstream;
+	bool              send_text;
+	bool              recv_text;
 	nni_list          headers; // request headers
 	size_t            maxframe;
 	size_t            fragsize;
@@ -455,7 +461,7 @@ ws_frame_prep_tx(nni_ws *ws, ws_frame *frame)
 			return (NNG_ENOMEM);
 		}
 		frame->asize = frame->len;
-		frame->buf = frame->adata;
+		frame->buf   = frame->adata;
 	}
 	buf = frame->buf;
 
@@ -474,7 +480,11 @@ ws_frame_prep_tx(nni_ws *ws, ws_frame *frame)
 
 	if (nni_aio_count(aio) == 0) {
 		// This is the first frame.
-		frame->op = WS_BINARY;
+		if (ws->send_text) {
+			frame->op = WS_TEXT;
+		} else {
+			frame->op = WS_BINARY;
+		}
 	} else {
 		frame->op = WS_CONT;
 	}
@@ -944,6 +954,12 @@ ws_read_frame_cb(nni_ws *ws, ws_frame *frame)
 		ws->rxframe = NULL;
 		nni_list_append(&ws->rxq, frame);
 		break;
+	case WS_TEXT:
+		if (!ws->recv_text) {
+			// No support for text mode at present.
+			ws_close(ws, WS_CLOSE_UNSUPP_FORMAT);
+		}
+		// FALLTHROUGH
 	case WS_BINARY:
 		if (ws->inmsg) {
 			ws_close(ws, WS_CLOSE_PROTOCOL_ERR);
@@ -955,10 +971,6 @@ ws_read_frame_cb(nni_ws *ws, ws_frame *frame)
 		ws->rxframe = NULL;
 		nni_list_append(&ws->rxq, frame);
 		break;
-	case WS_TEXT:
-		// No support for text mode at present.
-		ws_close(ws, WS_CLOSE_UNSUPP_FORMAT);
-		return;
 
 	case WS_PING:
 		if (frame->len > 125) {
@@ -1120,7 +1132,7 @@ ws_read_cb(void *arg)
 					return;
 				}
 				frame->asize = frame->len;
-				frame->buf = frame->adata;
+				frame->buf   = frame->adata;
 			}
 
 			iov.iov_buf = frame->buf;
@@ -1624,14 +1636,16 @@ ws_handler(nni_aio *aio)
 		status = NNG_HTTP_STATUS_INTERNAL_SERVER_ERROR;
 		goto err;
 	}
-	ws->http     = conn;
-	ws->req      = req;
-	ws->res      = res;
-	ws->server   = true;
-	ws->maxframe = l->maxframe;
-	ws->fragsize = l->fragsize;
-	ws->recvmax  = l->recvmax;
-	ws->isstream = l->isstream;
+	ws->http      = conn;
+	ws->req       = req;
+	ws->res       = res;
+	ws->server    = true;
+	ws->maxframe  = l->maxframe;
+	ws->fragsize  = l->fragsize;
+	ws->recvmax   = l->recvmax;
+	ws->isstream  = l->isstream;
+	ws->recv_text = l->recv_text;
+	ws->send_text = l->send_text;
 
 	nni_list_append(&l->reply, ws);
 	nni_aio_set_data(ws->httpaio, 0, l);
@@ -1907,6 +1921,58 @@ ws_listener_set_msgmode(void *arg, const void *buf, size_t sz, nni_type t)
 }
 
 static int
+ws_listener_set_recv_text(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_ws_listener *l = arg;
+	int              rv;
+	bool             b;
+
+	if ((rv = nni_copyin_bool(&b, buf, sz, t)) == 0) {
+		nni_mtx_lock(&l->mtx);
+		l->recv_text = b;
+		nni_mtx_unlock(&l->mtx);
+	}
+	return (rv);
+}
+
+static int
+ws_listener_set_send_text(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_ws_listener *l = arg;
+	int              rv;
+	bool             b;
+
+	if ((rv = nni_copyin_bool(&b, buf, sz, t)) == 0) {
+		nni_mtx_lock(&l->mtx);
+		l->send_text = b;
+		nni_mtx_unlock(&l->mtx);
+	}
+	return (rv);
+}
+
+static int
+ws_listener_get_recv_text(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_ws_listener *l = arg;
+	int              rv;
+	nni_mtx_lock(&l->mtx);
+	rv = nni_copyout_bool(l->recv_text, buf, szp, t);
+	nni_mtx_unlock(&l->mtx);
+	return (rv);
+}
+
+static int
+ws_listener_get_send_text(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_ws_listener *l = arg;
+	int              rv;
+	nni_mtx_lock(&l->mtx);
+	rv = nni_copyout_bool(l->send_text, buf, szp, t);
+	nni_mtx_unlock(&l->mtx);
+	return (rv);
+}
+
+static int
 ws_listener_get_url(void *arg, void *buf, size_t *szp, nni_type t)
 {
 	nni_ws_listener *l = arg;
@@ -1951,6 +2017,16 @@ static const nni_option ws_listener_options[] = {
 	{
 	    .o_name = NNG_OPT_URL,
 	    .o_get  = ws_listener_get_url,
+	},
+	{
+	    .o_name = NNG_OPT_WS_RECV_TEXT,
+	    .o_set  = ws_listener_set_recv_text,
+	    .o_get  = ws_listener_get_recv_text,
+	},
+	{
+	    .o_name = NNG_OPT_WS_SEND_TEXT,
+	    .o_set  = ws_listener_set_send_text,
+	    .o_get  = ws_listener_get_send_text,
 	},
 	{
 	    .o_name = NULL,
@@ -2245,11 +2321,13 @@ ws_dialer_dial(void *arg, nni_aio *aio)
 		ws_reap(ws);
 		return;
 	}
-	ws->dialer   = d;
-	ws->useraio  = aio;
-	ws->server   = false;
-	ws->maxframe = d->maxframe;
-	ws->isstream = d->isstream;
+	ws->dialer    = d;
+	ws->useraio   = aio;
+	ws->server    = false;
+	ws->maxframe  = d->maxframe;
+	ws->isstream  = d->isstream;
+	ws->recv_text = d->recv_text;
+	ws->send_text = d->send_text;
 	nni_list_append(&d->wspend, ws);
 	nni_http_client_connect(d->client, ws->connaio);
 	nni_mtx_unlock(&d->mtx);
@@ -2265,6 +2343,36 @@ ws_dialer_set_msgmode(void *arg, const void *buf, size_t sz, nni_type t)
 	if ((rv = nni_copyin_bool(&b, buf, sz, t)) == 0) {
 		nni_mtx_lock(&d->mtx);
 		d->isstream = !b;
+		nni_mtx_unlock(&d->mtx);
+	}
+	return (rv);
+}
+
+static int
+ws_dialer_set_recv_text(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_ws_dialer *d = arg;
+	int            rv;
+	bool           b;
+
+	if ((rv = nni_copyin_bool(&b, buf, sz, t)) == 0) {
+		nni_mtx_lock(&d->mtx);
+		d->recv_text = b;
+		nni_mtx_unlock(&d->mtx);
+	}
+	return (rv);
+}
+
+static int
+ws_dialer_set_send_text(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	nni_ws_dialer *d = arg;
+	int            rv;
+	bool           b;
+
+	if ((rv = nni_copyin_bool(&b, buf, sz, t)) == 0) {
+		nni_mtx_lock(&d->mtx);
+		d->send_text = b;
 		nni_mtx_unlock(&d->mtx);
 	}
 	return (rv);
@@ -2388,6 +2496,28 @@ ws_dialer_get_proto(void *arg, void *buf, size_t *szp, nni_type t)
 	return (rv);
 }
 
+static int
+ws_dialer_get_recv_text(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_ws_dialer *d = arg;
+	int            rv;
+	nni_mtx_lock(&d->mtx);
+	rv = nni_copyout_bool(d->recv_text, buf, szp, t);
+	nni_mtx_unlock(&d->mtx);
+	return (rv);
+}
+
+static int
+ws_dialer_get_send_text(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_ws_dialer *d = arg;
+	int            rv;
+	nni_mtx_lock(&d->mtx);
+	rv = nni_copyout_bool(d->send_text, buf, szp, t);
+	nni_mtx_unlock(&d->mtx);
+	return (rv);
+}
+
 static const nni_option ws_dialer_options[] = {
 	{
 	    .o_name = NNI_OPT_WS_MSGMODE,
@@ -2418,6 +2548,17 @@ static const nni_option ws_dialer_options[] = {
 	    .o_set  = ws_dialer_set_proto,
 	    .o_get  = ws_dialer_get_proto,
 	},
+	{
+	    .o_name = NNG_OPT_WS_RECV_TEXT,
+	    .o_set  = ws_dialer_set_recv_text,
+	    .o_get  = ws_dialer_get_recv_text,
+	},
+	{
+	    .o_name = NNG_OPT_WS_SEND_TEXT,
+	    .o_set  = ws_dialer_set_send_text,
+	    .o_get  = ws_dialer_get_send_text,
+	},
+
 	{
 	    .o_name = NULL,
 	},
@@ -2649,6 +2790,30 @@ ws_get_request_uri(void *arg, void *buf, size_t *szp, nni_type t)
 	return (nni_copyout_str(nni_http_req_get_uri(ws->req), buf, szp, t));
 }
 
+static int
+ws_get_recv_text(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_ws *ws = arg;
+	bool    b;
+	nni_mtx_lock(&ws->mtx);
+	b = ws->recv_text;
+	nni_mtx_unlock(&ws->mtx);
+
+	return (nni_copyout_bool(b, buf, szp, t));
+}
+
+static int
+ws_get_send_text(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_ws *ws = arg;
+	bool    b;
+	nni_mtx_lock(&ws->mtx);
+	b = ws->send_text;
+	nni_mtx_unlock(&ws->mtx);
+
+	return (nni_copyout_bool(b, buf, szp, t));
+}
+
 static const nni_option ws_options[] = {
 	{
 	    .o_name = NNG_OPT_WS_REQUEST_HEADERS,
@@ -2661,6 +2826,14 @@ static const nni_option ws_options[] = {
 	{
 	    .o_name = NNG_OPT_WS_REQUEST_URI,
 	    .o_get  = ws_get_request_uri,
+	},
+	{
+	    .o_name = NNG_OPT_WS_RECV_TEXT,
+	    .o_get  = ws_get_recv_text,
+	},
+	{
+	    .o_name = NNG_OPT_WS_SEND_TEXT,
+	    .o_get  = ws_get_send_text,
 	},
 	{
 	    .o_name = NULL,
@@ -2753,6 +2926,12 @@ ws_check_size(const void *buf, size_t sz, nni_type t)
 	return (nni_copyin_size(NULL, buf, sz, 0, NNI_MAXSZ, t));
 }
 
+static int
+ws_check_bool(const void *buf, size_t sz, nni_type t)
+{
+	return (nni_copyin_size(NULL, buf, sz, 0, NNI_MAXSZ, t));
+}
+
 static const nni_chkoption ws_chkopts[] = {
 	{
 	    .o_name  = NNG_OPT_WS_SENDMAXFRAME,
@@ -2777,6 +2956,14 @@ static const nni_chkoption ws_chkopts[] = {
 	{
 	    .o_name  = NNG_OPT_WS_RESPONSE_HEADERS,
 	    .o_check = ws_check_string,
+	},
+	{
+	    .o_name  = NNG_OPT_WS_RECV_TEXT,
+	    .o_check = ws_check_bool,
+	},
+	{
+	    .o_name  = NNG_OPT_WS_SEND_TEXT,
+	    .o_check = ws_check_bool,
 	},
 	{
 	    .o_name = NULL,


### PR DESCRIPTION
This adds new options, NNG_OPT_WS_SEND_TEXT and NNG_OPT_WS_RECV_TEXT
that permit communication with WebSocket peers that insist on using
TEXT frames (stream mode only).  The support is limited, as NNG does
no validation of the frame contents to check for UTF-8 compliance.
