### PR TITLE
fixes #1323 stats framework is *way* to heavy

### DIFF
--- a/docs/man/CMakeLists.txt
+++ b/docs/man/CMakeLists.txt
@@ -163,6 +163,7 @@ if (NNG_ENABLE_DOC)
             nng_socket_set
             nng_stats_free
             nng_stats_get
+            nng_stat_bool
             nng_stat_child
             nng_stat_desc
             nng_stat_find
@@ -354,6 +355,7 @@ if (NNG_ENABLE_DOC)
             nng_options
             nng_pipe
             nng_sockaddr
+            nng_sockaddr_abstract
             nng_sockaddr_in
             nng_sockaddr_in6
             nng_sockaddr_inproc

--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -239,6 +239,7 @@ The following functions provide access to statistics which can be used
 to observe program behaviors and as an aid in troubleshooting.
 
 |===
+|xref:nng_stat_bool.3.adoc[nng_stat_bool()]|get statistic Boolean value
 |xref:nng_stat_child.3.adoc[nng_stat_child()]|get child statistic
 |xref:nng_stat_desc.3.adoc[nng_stat_name()]|get statistic description
 |xref:nng_stat_find.3.adoc[nng_stat_find()]|find statistic by name
@@ -251,7 +252,7 @@ to observe program behaviors and as an aid in troubleshooting.
 |xref:nng_stat_timestamp.3.adoc[nng_stat_timestamp()]|get statistic timestamp
 |xref:nng_stat_type.3.adoc[nng_stat_type()]|get statistic type
 |xref:nng_stat_unit.3.adoc[nng_stat_unit()]|get statistic unit
-|xref:nng_stat_value.3.adoc[nng_stat_value()]|get statistic value
+|xref:nng_stat_value.3.adoc[nng_stat_value()]|get statistic numeric value
 |xref:nng_stats_free.3.adoc[nng_stats_free()]|free statistics
 |xref:nng_stats_get.3.adoc[nng_stats_get()]|get statistics
 |===

--- a/docs/man/nng_stat_bool.3.adoc
+++ b/docs/man/nng_stat_bool.3.adoc
@@ -1,6 +1,6 @@
 = nng_stat_value(3)
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -21,18 +21,18 @@ nng_stat_value - get statistic value
 
 typedef struct nng_stat nng_stat;
 
-uint64_t nng_stat_value(nng_stat *stat);
+bool nng_stat_bool(nng_stat *stat);
 ----
 
 == DESCRIPTION
 
-The `nng_stat_value()` function returns a numeric value for the statistic _stat_.
-If the statistic is not of numeric type, then zero is returned.
+The `nng_stat_bool()` function returns the Boolean value for the statistic _stat_.
+Otherwise, if the statistic is not of Boolean type, the result is indeterminate.
 See xref:nng_stat_type.3.adoc[`nng_stat_type()`] for a description of statistic types.
 
 == RETURN VALUES
 
-The numeric value associated with _stat_.
+The boolean value associated with _stat_.
 
 == ERRORS
 
@@ -43,8 +43,8 @@ None.
 [.text-left]
 xref:libnng.3.adoc[libnng(3)],
 xref:nng_stats_get.3.adoc[nng_stats_get(3)],
-xref:nng_stat_bool.3.adoc[nng_stat_bool(3)],
 xref:nng_stat_type.3.adoc[nng_stat_type(3)],
 xref:nng_stat_unit.3.adoc[nng_stat_unit(3)],
+xref:nng_stat_value.3.adoc[nng_stat_value(3)],
 xref:nng_stat.5.adoc[nng_stat(5)],
 xref:nng.7.adoc[nng(7)]

--- a/docs/man/nng_stat_string.3.adoc
+++ b/docs/man/nng_stat_string.3.adoc
@@ -1,6 +1,6 @@
 = nng_stat_string(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -30,6 +30,9 @@ The `nng_stat_string()` function returns a string value for the statistic _stat_
 which must be of type `NNG_STAT_STRING` (see xref:nng_stat_type.3.adoc[`nng_stat_type(3)`]).
 
 If the statistic is not of type `NNG_STAT_STRING`, then `NULL` will be returned.
+
+NOTE: The returned string is valid until xref:nng_stats_free.3.adoc[`nng_stats_free()`] is called to
+free the memory for the snapshot.
 
 == RETURN VALUES
 

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1059,6 +1059,11 @@ enum nng_unit_enum {
 // snapshot was updated, and are undefined until an update is performed.
 NNG_DECL uint64_t nng_stat_value(nng_stat *);
 
+// nng_stat_value returns returns the actual value of the statistic.
+// Statistic values reflect their value at the time that the corresponding
+// snapshot was updated, and are undefined until an update is performed.
+NNG_DECL bool nng_stat_bool(nng_stat *);
+
 // nng_stat_string returns the string associated with a string statistic,
 // or NULL if the statistic is not part of the string.  The value returned
 // is valid until the associated statistic is freed.

--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -23,8 +23,6 @@ static void dialer_timer_cb(void *);
 static nni_id_map dialers;
 static nni_mtx    dialers_lk;
 
-#define BUMP_STAT(x) nni_stat_inc_atomic(x, 1)
-
 int
 nni_dialer_sys_init(void)
 {
@@ -65,59 +63,129 @@ nni_dialer_destroy(nni_dialer *d)
 	NNI_FREE_STRUCT(d);
 }
 
+#if NNG_ENABLE_STATS
+static void
+dialer_stat_init(nni_dialer *d, nni_stat_item *item, const nni_stat_info *info)
+{
+	nni_stat_init(item, info);
+	nni_stat_add(&d->st_root, item);
+}
+
 static void
 dialer_stats_init(nni_dialer *d)
 {
-	nni_dialer_stats *st   = &d->d_stats;
-	nni_stat_item *   root = &st->s_root;
+	static const nni_stat_info root_info = {
+		.si_name = "dialer",
+		.si_desc = "dialer statistics",
+		.si_type = NNG_STAT_SCOPE,
+	};
+	static const nni_stat_info id_info = {
+		.si_name = "id",
+		.si_desc = "dialer id",
+		.si_type = NNG_STAT_ID,
+	};
+	static const nni_stat_info socket_info = {
+		.si_name = "socket",
+		.si_desc = "socket for dialer",
+		.si_type = NNG_STAT_ID,
+	};
+	static const nni_stat_info url_info = {
+		.si_name  = "url",
+		.si_desc  = "dialer url",
+		.si_type  = NNG_STAT_STRING,
+		.si_alloc = true,
+	};
+	static const nni_stat_info pipes_info = {
+		.si_name   = "pipes",
+		.si_desc   = "open pipes",
+		.si_type   = NNG_STAT_LEVEL,
+		.si_atomic = true,
+	};
+	static const nni_stat_info connect_info = {
+		.si_name   = "connect",
+		.si_desc   = "connections established",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info refused_info = {
+		.si_name   = "refused",
+		.si_desc   = "connections refused",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info disconnect_info = {
+		.si_name   = "disconnect",
+		.si_desc   = "remote disconnects",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info canceled_info = {
+		.si_name   = "canceled",
+		.si_desc   = "canceled connections",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info other_info = {
+		.si_name   = "other",
+		.si_desc   = "other errors",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info timeout_info = {
+		.si_name   = "timeout",
+		.si_desc   = "timeout errors",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info proto_info = {
+		.si_name   = "proto",
+		.si_desc   = "protocol errors",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info auth_info = {
+		.si_name   = "auth",
+		.si_desc   = "auth errors",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info oom_info = {
+		.si_name   = "oom",
+		.si_desc   = "allocation failures",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info reject_info = {
+		.si_name   = "reject",
+		.si_desc   = "rejected pipes",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
 
-	nni_stat_init_scope(root, st->s_scope, "dialer statistics");
+	nni_stat_init(&d->st_root, &root_info);
 
-	nni_stat_init_id(&st->s_id, "id", "dialer id", d->d_id);
-	nni_stat_add(root, &st->s_id);
+	dialer_stat_init(d, &d->st_id, &id_info);
+	dialer_stat_init(d, &d->st_sock, &socket_info);
+	dialer_stat_init(d, &d->st_url, &url_info);
+	dialer_stat_init(d, &d->st_pipes, &pipes_info);
+	dialer_stat_init(d, &d->st_connect, &connect_info);
+	dialer_stat_init(d, &d->st_refused, &refused_info);
+	dialer_stat_init(d, &d->st_disconnect, &disconnect_info);
+	dialer_stat_init(d, &d->st_canceled, &canceled_info);
+	dialer_stat_init(d, &d->st_other, &other_info);
+	dialer_stat_init(d, &d->st_timeout, &timeout_info);
+	dialer_stat_init(d, &d->st_proto, &proto_info);
+	dialer_stat_init(d, &d->st_auth, &auth_info);
+	dialer_stat_init(d, &d->st_oom, &oom_info);
+	dialer_stat_init(d, &d->st_reject, &reject_info);
 
-	nni_stat_init_id(&st->s_sock, "socket", "socket for dialer",
-	    nni_sock_id(d->d_sock));
-	nni_stat_add(root, &st->s_sock);
-
-	nni_stat_init_string(
-	    &st->s_url, "url", "dialer url", d->d_url->u_rawurl);
-	nni_stat_add(root, &st->s_url);
-
-	nni_stat_init_atomic(&st->s_npipes, "npipes", "open pipes");
-	nni_stat_add(root, &st->s_npipes);
-
-	nni_stat_init_atomic(
-	    &st->s_connok, "connect", "connections established");
-	nni_stat_add(root, &st->s_connok);
-
-	nni_stat_init_atomic(&st->s_refused, "refused", "connections refused");
-	nni_stat_add(root, &st->s_refused);
-
-	nni_stat_init_atomic(&st->s_discon, "discon", "remote disconnects");
-	nni_stat_add(root, &st->s_discon);
-
-	nni_stat_init_atomic(&st->s_canceled, "canceled", "canceled");
-	nni_stat_add(root, &st->s_canceled);
-
-	nni_stat_init_atomic(&st->s_othererr, "othererr", "other errors");
-	nni_stat_add(root, &st->s_othererr);
-
-	nni_stat_init_atomic(&st->s_etimedout, "timedout", "timed out");
-	nni_stat_add(root, &st->s_etimedout);
-
-	nni_stat_init_atomic(&st->s_eproto, "protoerr", "protocol errors");
-	nni_stat_add(root, &st->s_eproto);
-
-	nni_stat_init_atomic(&st->s_eauth, "autherr", "auth errors");
-	nni_stat_add(root, &st->s_eauth);
-
-	nni_stat_init_atomic(&st->s_enomem, "nomem", "out of memory");
-	nni_stat_add(root, &st->s_enomem);
-
-	nni_stat_init_atomic(&st->s_reject, "reject", "pipes rejected");
-	nni_stat_add(root, &st->s_reject);
+	nni_stat_set_id(&d->st_root, d->d_id);
+	nni_stat_set_id(&d->st_id, d->d_id);
+	nni_stat_set_id(&d->st_sock, nni_sock_id(d->d_sock));
+	nni_stat_set_string(&d->st_url, d->d_url->u_rawurl);
+	nni_stat_register(&d->st_root);
 }
+#endif // NNG_ENABLE_STATS
 
 void
 nni_dialer_bump_error(nni_dialer *d, int err)
@@ -126,34 +194,31 @@ nni_dialer_bump_error(nni_dialer *d, int err)
 	switch (err) {
 	case NNG_ECONNABORTED:
 	case NNG_ECONNRESET:
-		BUMP_STAT(&d->d_stats.s_discon);
+		nni_stat_inc(&d->st_disconnect, 1);
 		break;
 	case NNG_ECONNREFUSED:
-		BUMP_STAT(&d->d_stats.s_refused);
+		nni_stat_inc(&d->st_refused, 1);
 		break;
 	case NNG_ECANCELED:
-		BUMP_STAT(&d->d_stats.s_canceled);
+		nni_stat_inc(&d->st_canceled, 1);
 		break;
 	case NNG_ETIMEDOUT:
-		BUMP_STAT(&d->d_stats.s_etimedout);
+		nni_stat_inc(&d->st_timeout, 1);
 		break;
 	case NNG_EPROTO:
-		BUMP_STAT(&d->d_stats.s_eproto);
+		nni_stat_inc(&d->st_proto, 1);
 		break;
 	case NNG_EPEERAUTH:
 	case NNG_ECRYPTO:
-		BUMP_STAT(&d->d_stats.s_eauth);
+		nni_stat_inc(&d->st_auth, 1);
 		break;
 	case NNG_ENOMEM:
-		BUMP_STAT(&d->d_stats.s_enomem);
+		nni_stat_inc(&d->st_oom, 1);
 		break;
 	default:
-		BUMP_STAT(&d->d_stats.s_othererr);
+		nni_stat_inc(&d->st_other, 1);
 		break;
 	}
-#else
-	NNI_ARG_UNUSED(d);
-	NNI_ARG_UNUSED(err);
 #endif
 }
 
@@ -182,7 +247,7 @@ nni_dialer_create(nni_dialer **dp, nni_sock *s, const char *urlstr)
 	d->d_closed  = false;
 	d->d_closing = false;
 	d->d_data    = NULL;
-	d->d_refcnt  = 1;
+	d->d_ref     = 1;
 	d->d_sock    = s;
 	d->d_tran    = tran;
 	nni_atomic_flag_reset(&d->d_started);
@@ -197,7 +262,6 @@ nni_dialer_create(nni_dialer **dp, nni_sock *s, const char *urlstr)
 
 	nni_mtx_init(&d->d_mtx);
 
-	dialer_stats_init(d);
 	nni_aio_init(&d->d_con_aio, dialer_connect_cb, d);
 	nni_aio_init(&d->d_tmo_aio, dialer_timer_cb, d);
 
@@ -205,19 +269,22 @@ nni_dialer_create(nni_dialer **dp, nni_sock *s, const char *urlstr)
 	rv = nni_id_alloc(&dialers, &d->d_id, d);
 	nni_mtx_unlock(&dialers_lk);
 
+#ifdef NNG_ENABLE_STATS
+	dialer_stats_init(d);
+#endif
+
 	if ((rv != 0) || ((rv = d->d_ops.d_init(&d->d_data, url, d)) != 0) ||
 	    ((rv = nni_sock_add_dialer(s, d)) != 0)) {
 		nni_mtx_lock(&dialers_lk);
 		nni_id_remove(&dialers, d->d_id);
 		nni_mtx_unlock(&dialers_lk);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_unregister(&d->st_root);
+#endif
 		nni_dialer_destroy(d);
 		return (rv);
 	}
 
-	snprintf(d->d_stats.s_scope, sizeof(d->d_stats.s_scope), "dialer%u",
-	    d->d_id);
-	nni_stat_set_value(&d->d_stats.s_id, d->d_id);
-	nni_stat_register(&d->d_stats.s_root);
 	*dp = d;
 	return (0);
 }
@@ -234,7 +301,7 @@ nni_dialer_find(nni_dialer **dp, uint32_t id)
 
 	nni_mtx_lock(&dialers_lk);
 	if ((d = nni_id_get(&dialers, id)) != NULL) {
-		d->d_refcnt++;
+		d->d_ref++;
 		*dp = d;
 	}
 	nni_mtx_unlock(&dialers_lk);
@@ -249,7 +316,7 @@ nni_dialer_hold(nni_dialer *d)
 	if (d->d_closed) {
 		rv = NNG_ECLOSED;
 	} else {
-		d->d_refcnt++;
+		d->d_ref++;
 		rv = 0;
 	}
 	nni_mtx_unlock(&dialers_lk);
@@ -260,8 +327,8 @@ void
 nni_dialer_rele(nni_dialer *d)
 {
 	nni_mtx_lock(&dialers_lk);
-	d->d_refcnt--;
-	if ((d->d_refcnt == 0) && (d->d_closed)) {
+	d->d_ref--;
+	if ((d->d_ref == 0) && (d->d_closed)) {
 		nni_reap(&d->d_reap, (nni_cb) nni_dialer_reap, d);
 	}
 	nni_mtx_unlock(&dialers_lk);
@@ -326,7 +393,9 @@ dialer_connect_cb(void *arg)
 
 	switch ((rv = nni_aio_result(aio))) {
 	case 0:
-		BUMP_STAT(&d->d_stats.s_connok);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_inc(&d->st_connect, 1);
+#endif
 		nni_dialer_add_pipe(d, nni_aio_get_output(aio, 0));
 		break;
 	case NNG_ECLOSED:   // No further action.
@@ -491,7 +560,12 @@ nni_dialer_getopt(
 }
 
 void
-nni_dialer_add_stat(nni_dialer *d, nni_stat_item *stat)
+nni_dialer_add_stat(nni_dialer *d, nni_stat_item *item)
 {
-	nni_stat_add(&d->d_stats.s_root, stat);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_add(&d->st_root, item);
+#else
+	NNI_ARG_UNUSED(d);
+	NNI_ARG_UNUSED(item);
+#endif
 }

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -29,7 +29,7 @@ struct nni_ctx {
 	void *            c_data;
 	size_t            c_size;
 	bool              c_closed;
-	unsigned          c_refcnt; // protected by global lock
+	unsigned          c_ref; // protected by global lock
 	uint32_t          c_id;
 	nng_duration      c_sndtimeo;
 	nng_duration      c_rcvtimeo;
@@ -48,21 +48,6 @@ typedef struct nni_sock_pipe_cb {
 	void *      cb_arg;
 } nni_sock_pipe_cb;
 
-typedef struct sock_stats {
-	nni_stat_item s_root;       // socket scope
-	nni_stat_item s_id;         // socket id
-	nni_stat_item s_name;       // socket name
-	nni_stat_item s_protocol;   // socket protocol
-	nni_stat_item s_ndialers;   // number of dialers
-	nni_stat_item s_nlisteners; // number of listeners
-	nni_stat_item s_npipes;     // number of pipes
-	nni_stat_item s_rxbytes;    // number of bytes received
-	nni_stat_item s_txbytes;    // number of bytes received
-	nni_stat_item s_rxmsgs;     // number of msgs received
-	nni_stat_item s_txmsgs;     // number of msgs sent
-	nni_stat_item s_reject;     // pipes rejected
-} sock_stats;
-
 struct nni_socket {
 	nni_list_node s_node;
 	nni_mtx       s_mx;
@@ -71,8 +56,8 @@ struct nni_socket {
 
 	uint32_t s_id;
 	uint32_t s_flags;
-	unsigned s_refcnt; // protected by global lock
-	void *   s_data;   // Protocol private
+	unsigned s_ref;  // protected by global lock
+	void *   s_data; // Protocol private
 	size_t   s_size;
 
 	nni_msgq *s_uwq; // Upper write queue
@@ -93,7 +78,6 @@ struct nni_socket {
 	size_t       s_rcvmaxsz;  // max receive size
 	nni_list     s_options;   // opts not handled by sock/proto
 	char         s_name[64];  // socket name (legacy compat)
-	char         s_scope[24]; // socket scope ("socket%u", 32 bits max)
 
 	nni_list s_listeners; // active listeners
 	nni_list s_dialers;   // active dialers
@@ -107,7 +91,20 @@ struct nni_socket {
 	nni_mtx          s_pipe_cbs_mtx;
 	nni_sock_pipe_cb s_pipe_cbs[NNG_PIPE_EV_NUM];
 
-	sock_stats s_stats;
+#ifdef NNG_ENABLE_STATS
+	nni_stat_item st_root;      // socket scope
+	nni_stat_item st_id;        // socket id
+	nni_stat_item st_name;      // socket name
+	nni_stat_item st_protocol;  // socket protocol
+	nni_stat_item st_dialers;   // number of dialers
+	nni_stat_item st_listeners; // number of listeners
+	nni_stat_item st_pipes;     // number of pipes
+	nni_stat_item st_rx_bytes;  // number of bytes received
+	nni_stat_item st_tx_bytes;  // number of bytes received
+	nni_stat_item st_rx_msgs;   // number of msgs received
+	nni_stat_item st_tx_msgs;   // number of msgs sent
+	nni_stat_item st_rejects;   // pipes rejected
+#endif
 };
 
 static void nni_ctx_destroy(nni_ctx *);
@@ -379,7 +376,7 @@ nni_sock_find(nni_sock **sockp, uint32_t id)
 		if (s->s_closed) {
 			rv = NNG_ECLOSED;
 		} else {
-			s->s_refcnt++;
+			s->s_ref++;
 			*sockp = s;
 		}
 	} else {
@@ -394,87 +391,128 @@ void
 nni_sock_rele(nni_sock *s)
 {
 	nni_mtx_lock(&sock_lk);
-	s->s_refcnt--;
-	if (s->s_closed && (s->s_refcnt < 2)) {
+	s->s_ref--;
+	if (s->s_closed && (s->s_ref < 2)) {
 		nni_cv_wake(&s->s_close_cv);
 	}
 	nni_mtx_unlock(&sock_lk);
 }
 
-static void
-sock_stats_fini(nni_sock *s)
-{
 #ifdef NNG_ENABLE_STATS
-	sock_stats *st = &s->s_stats;
-	nni_stat_unregister(&st->s_root);
-#else
-	NNI_ARG_UNUSED(s);
-#endif
+static void
+sock_stat_init(nni_sock *s, nni_stat_item *item, const nni_stat_info *info)
+{
+	nni_stat_init(item, info);
+	nni_stat_add(&s->st_root, item);
 }
 
 static void
 sock_stats_init(nni_sock *s)
 {
-#ifdef NNG_ENABLE_STATS
-	sock_stats *   st   = &s->s_stats;
-	nni_stat_item *root = &s->s_stats.s_root;
+	static const nni_stat_info root_info = {
+		.si_name = "socket",
+		.si_desc = "socket statistics",
+		.si_type = NNG_STAT_SCOPE,
+	};
+	static const nni_stat_info id_info = {
+		.si_name = "id",
+		.si_desc = "socket identifier",
+		.si_type = NNG_STAT_ID,
+	};
+	static const nni_stat_info name_info = {
+		.si_name  = "name",
+		.si_desc  = "socket name",
+		.si_type  = NNG_STAT_STRING,
+		.si_alloc = true,
+	};
+	static const nni_stat_info protocol_info = {
+		.si_name = "protocol",
+		.si_desc = "socket protocol",
+		.si_type = NNG_STAT_STRING,
+	};
+	static const nni_stat_info dialers_info = {
+		.si_name   = "dialers",
+		.si_desc   = "open dialers",
+		.si_type   = NNG_STAT_LEVEL,
+		.si_atomic = true,
+	};
+	static const nni_stat_info listeners_info = {
+		.si_name   = "listeners",
+		.si_desc   = "open listeners",
+		.si_type   = NNG_STAT_LEVEL,
+		.si_atomic = true,
+	};
+	static const nni_stat_info pipes_info = {
+		.si_name   = "pipes",
+		.si_desc   = "open pipes",
+		.si_type   = NNG_STAT_LEVEL,
+		.si_atomic = true,
+	};
+	static const nni_stat_info reject_info = {
+		.si_name   = "reject",
+		.si_desc   = "rejected pipes",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info tx_msgs_info = {
+		.si_name   = "tx_msgs",
+		.si_desc   = "sent messages",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_MESSAGES,
+		.si_atomic = true,
+	};
+	static const nni_stat_info rx_msgs_info = {
+		.si_name   = "rx_msgs",
+		.si_desc   = "received messages",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_MESSAGES,
+		.si_atomic = true,
+	};
+	static const nni_stat_info tx_bytes_info = {
+		.si_name   = "tx_bytes",
+		.si_desc   = "sent bytes",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_BYTES,
+		.si_atomic = true,
+	};
+	static const nni_stat_info rx_bytes_info = {
+		.si_name   = "rx_bytes",
+		.si_desc   = "received messages",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_BYTES,
+		.si_atomic = true,
+	};
 
 	// To make collection cheap and atomic for the socket,
 	// we just use a single lock for the entire chain.
 
-	nni_stat_init_scope(root, s->s_scope, "socket statistics");
+	nni_stat_init(&s->st_root, &root_info);
+	sock_stat_init(s, &s->st_id, &id_info);
+	sock_stat_init(s, &s->st_name, &name_info);
+	sock_stat_init(s, &s->st_protocol, &protocol_info);
+	sock_stat_init(s, &s->st_dialers, &dialers_info);
+	sock_stat_init(s, &s->st_listeners, &listeners_info);
+	sock_stat_init(s, &s->st_pipes, &pipes_info);
+	sock_stat_init(s, &s->st_rejects, &reject_info);
+	sock_stat_init(s, &s->st_tx_msgs, &tx_msgs_info);
+	sock_stat_init(s, &s->st_rx_msgs, &rx_msgs_info);
+	sock_stat_init(s, &s->st_tx_bytes, &tx_bytes_info);
+	sock_stat_init(s, &s->st_rx_bytes, &rx_bytes_info);
 
-	nni_stat_init_id(&st->s_id, "id", "socket id", s->s_id);
-	nni_stat_add(root, &st->s_id);
-
-	nni_stat_init_string(&st->s_name, "name", "socket name", s->s_name);
-	nni_stat_set_lock(&st->s_name, &s->s_mx);
-	nni_stat_add(root, &st->s_name);
-
-	nni_stat_init_string(&st->s_protocol, "protocol", "socket protocol",
-	    nni_sock_proto_name(s));
-	nni_stat_add(root, &st->s_protocol);
-
-	nni_stat_init_atomic(&st->s_ndialers, "ndialers", "open dialers");
-	nni_stat_set_type(&st->s_ndialers, NNG_STAT_LEVEL);
-	nni_stat_add(root, &st->s_ndialers);
-
-	nni_stat_init_atomic(
-	    &st->s_nlisteners, "nlisteners", "open listeners");
-	nni_stat_set_type(&st->s_nlisteners, NNG_STAT_LEVEL);
-	nni_stat_add(root, &st->s_nlisteners);
-
-	nni_stat_init_atomic(&st->s_npipes, "npipes", "open pipes");
-	nni_stat_set_type(&st->s_npipes, NNG_STAT_LEVEL);
-	nni_stat_add(root, &st->s_npipes);
-
-	nni_stat_init_atomic(&st->s_rxbytes, "rxbytes", "bytes received");
-	nni_stat_set_unit(&st->s_rxbytes, NNG_UNIT_BYTES);
-	nni_stat_add(root, &st->s_rxbytes);
-
-	nni_stat_init_atomic(&st->s_txbytes, "txbytes", "bytes sent");
-	nni_stat_set_unit(&st->s_txbytes, NNG_UNIT_BYTES);
-	nni_stat_add(root, &st->s_txbytes);
-
-	nni_stat_init_atomic(&st->s_rxmsgs, "rxmsgs", "messages received");
-	nni_stat_set_unit(&st->s_rxmsgs, NNG_UNIT_MESSAGES);
-	nni_stat_add(root, &st->s_rxmsgs);
-
-	nni_stat_init_atomic(&st->s_txmsgs, "txmsgs", "messages sent");
-	nni_stat_set_unit(&st->s_txmsgs, NNG_UNIT_MESSAGES);
-	nni_stat_add(root, &st->s_txmsgs);
-
-	nni_stat_init_atomic(&st->s_reject, "reject", "pipes rejected");
-	nni_stat_add(root, &st->s_reject);
-#else
-	NNI_ARG_UNUSED(s);
-#endif
+	nni_stat_set_id(&s->st_id, s->s_id);
+	nni_stat_set_string(&s->st_name, s->s_name);
+	nni_stat_set_string(&s->st_protocol, nni_sock_proto_name(s));
 }
+#endif
 
 static void
 sock_destroy(nni_sock *s)
 {
 	nni_sockopt *sopt;
+
+#ifdef NNG_ENABLE_STATS
+	nni_stat_unregister(&s->st_root);
+#endif
 
 	// The protocol needs to clean up its state.
 	if (s->s_data != NULL) {
@@ -490,7 +528,6 @@ sock_destroy(nni_sock *s)
 	nni_mtx_lock(&s->s_mx);
 	nni_mtx_unlock(&s->s_mx);
 
-	sock_stats_fini(s);
 	nni_msgq_fini(s->s_urq);
 	nni_msgq_fini(s->s_uwq);
 	nni_cv_fini(&s->s_close_cv);
@@ -519,7 +556,7 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 	s->s_reconnmax = 0;
 	s->s_rcvmaxsz  = 0; // unlimited by default
 	s->s_id        = 0;
-	s->s_refcnt    = 0;
+	s->s_ref       = 0;
 	s->s_self_id   = proto->proto_self;
 	s->s_peer_id   = proto->proto_peer;
 	s->s_flags     = proto->proto_flags;
@@ -545,7 +582,10 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 	nni_mtx_init(&s->s_pipe_cbs_mtx);
 	nni_cv_init(&s->s_cv, &s->s_mx);
 	nni_cv_init(&s->s_close_cv, &sock_lk);
+
+#ifdef NNG_ENABLE_STATS
 	sock_stats_init(s);
+#endif
 
 	if (((rv = nni_msgq_init(&s->s_uwq, 0)) != 0) ||
 	    ((rv = nni_msgq_init(&s->s_urq, 1)) != 0) ||
@@ -629,11 +669,10 @@ nni_sock_open(nni_sock **sockp, const nni_proto *proto)
 	(void) snprintf(s->s_name, sizeof(s->s_name), "%u", s->s_id);
 
 	// Set up basic stat values.
-	(void) snprintf(s->s_scope, sizeof(s->s_scope), "socket%u", s->s_id);
-	nni_stat_set_value(&s->s_stats.s_id, s->s_id);
+	nni_stat_set_id(&s->st_id, s->s_id);
 
 	// Add our stats chain.
-	nni_stat_register(&s->s_stats.s_root);
+	nni_stat_register(&s->st_root);
 
 	return (0);
 }
@@ -677,7 +716,7 @@ nni_sock_shutdown(nni_sock *sock)
 	while ((ctx = nctx) != NULL) {
 		nctx          = nni_list_next(&sock->s_ctxs, ctx);
 		ctx->c_closed = true;
-		if (ctx->c_refcnt == 0) {
+		if (ctx->c_ref == 0) {
 			// No open operations.  So close it.
 			nni_id_remove(&ctx_ids, ctx->c_id);
 			nni_list_remove(&sock->s_ctxs, ctx);
@@ -767,8 +806,6 @@ nni_sock_close(nni_sock *s)
 	// is idempotent.
 	nni_sock_shutdown(s);
 
-	nni_stat_unregister(&s->s_stats.s_root);
-
 	nni_mtx_lock(&sock_lk);
 	if (s->s_closed) {
 		// Some other thread called close.  All we need to do
@@ -787,7 +824,7 @@ nni_sock_close(nni_sock *s)
 	// Wait for all other references to drop.  Note that we
 	// have a reference already (from our caller).
 	s->s_ctxwait = true;
-	while ((s->s_refcnt > 1) || (!nni_list_empty(&s->s_ctxs))) {
+	while ((s->s_ref > 1) || (!nni_list_empty(&s->s_ctxs))) {
 		nni_cv_wait(&s->s_close_cv);
 	}
 	nni_mtx_unlock(&sock_lk);
@@ -819,7 +856,7 @@ nni_sock_closeall(void)
 		}
 		// Bump the reference count.  The close call below
 		// will drop it.
-		s->s_refcnt++;
+		s->s_ref++;
 		nni_list_node_remove(&s->s_node);
 		nni_mtx_unlock(&sock_lk);
 		nni_sock_close(s);
@@ -901,7 +938,9 @@ nni_sock_add_listener(nni_sock *s, nni_listener *l)
 
 	nni_list_append(&s->s_listeners, l);
 
-	nni_stat_inc_atomic(&s->s_stats.s_nlisteners, 1);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_inc(&s->st_listeners, 1);
+#endif
 
 	nni_mtx_unlock(&s->s_mx);
 	return (0);
@@ -930,7 +969,9 @@ nni_sock_add_dialer(nni_sock *s, nni_dialer *d)
 
 	nni_list_append(&s->s_dialers, d);
 
-	nni_stat_inc_atomic(&s->s_stats.s_ndialers, 1);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_inc(&s->st_dialers, 1);
+#endif
 
 	nni_mtx_unlock(&s->s_mx);
 	return (0);
@@ -1159,7 +1200,7 @@ nni_ctx_find(nni_ctx **cp, uint32_t id, bool closing)
 		if (ctx->c_closed || ((!closing) && ctx->c_sock->s_closed)) {
 			rv = NNG_ECLOSED;
 		} else {
-			ctx->c_refcnt++;
+			ctx->c_ref++;
 			*cp = ctx;
 		}
 	} else {
@@ -1186,8 +1227,8 @@ nni_ctx_rele(nni_ctx *ctx)
 {
 	nni_sock *sock = ctx->c_sock;
 	nni_mtx_lock(&sock_lk);
-	ctx->c_refcnt--;
-	if ((ctx->c_refcnt > 0) || (!ctx->c_closed)) {
+	ctx->c_ref--;
+	if ((ctx->c_ref > 0) || (!ctx->c_closed)) {
 		// Either still have an active reference, or not
 		// actually closing yet.
 		nni_mtx_unlock(&sock_lk);
@@ -1225,7 +1266,7 @@ nni_ctx_open(nni_ctx **ctxp, nni_sock *sock)
 	ctx->c_size     = sz;
 	ctx->c_data     = ctx + 1;
 	ctx->c_closed   = false;
-	ctx->c_refcnt   = 1; // Caller implicitly gets a reference.
+	ctx->c_ref      = 1; // Caller implicitly gets a reference.
 	ctx->c_sock     = sock;
 	ctx->c_ops      = sock->s_ctx_ops;
 	ctx->c_rcvtimeo = sock->s_rcvtimeo;
@@ -1413,29 +1454,37 @@ nni_dialer_add_pipe(nni_dialer *d, void *tpipe)
 	d->d_pipe     = p;
 	d->d_currtime = d->d_inirtime;
 	nni_mtx_unlock(&s->s_mx);
-	nni_stat_inc_atomic(&s->s_stats.s_npipes, 1);
-	nni_stat_inc_atomic(&d->d_stats.s_npipes, 1);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_inc(&s->st_pipes, 1);
+	nni_stat_inc(&d->st_pipes, 1);
+#endif
 
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_PRE);
 
 	nni_mtx_lock(&s->s_mx);
 	if (p->p_closed) {
 		nni_mtx_unlock(&s->s_mx);
-		nni_stat_inc_atomic(&d->d_stats.s_reject, 1);
-		nni_stat_inc_atomic(&s->s_stats.s_reject, 1);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_inc(&d->st_reject, 1);
+		nni_stat_inc(&s->st_rejects, 1);
+#endif
 		nni_pipe_rele(p);
 		return;
 	}
 	if (p->p_proto_ops.pipe_start(p->p_proto_data) != 0) {
 		nni_mtx_unlock(&s->s_mx);
-		nni_stat_inc_atomic(&d->d_stats.s_reject, 1);
-		nni_stat_inc_atomic(&s->s_stats.s_reject, 1);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_inc(&d->st_reject, 1);
+		nni_stat_inc(&s->st_rejects, 1);
+#endif
 		nni_pipe_close(p);
 		nni_pipe_rele(p);
 		return;
 	}
 	nni_mtx_unlock(&s->s_mx);
-	nni_stat_register(&p->p_stats.s_root);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_register(&p->st_root);
+#endif
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_POST);
 	nni_pipe_rele(p);
 }
@@ -1483,7 +1532,9 @@ nni_dialer_reap(nni_dialer *d)
 	nni_aio_stop(&d->d_tmo_aio);
 	nni_aio_stop(&d->d_con_aio);
 
-	nni_stat_unregister(&d->d_stats.s_root);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_unregister(&d->st_root);
+#endif
 
 	nni_mtx_lock(&s->s_mx);
 	if (!nni_list_empty(&d->d_pipes)) {
@@ -1524,29 +1575,35 @@ nni_listener_add_pipe(nni_listener *l, void *tpipe)
 	nni_list_append(&l->l_pipes, p);
 	nni_list_append(&s->s_pipes, p);
 	nni_mtx_unlock(&s->s_mx);
-	nni_stat_inc_atomic(&l->l_stats.s_npipes, 1);
-	nni_stat_inc_atomic(&s->s_stats.s_npipes, 1);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_inc(&l->st_pipes, 1);
+	nni_stat_inc(&s->st_pipes, 1);
+#endif
 
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_PRE);
 
 	nni_mtx_lock(&s->s_mx);
 	if (p->p_closed) {
 		nni_mtx_unlock(&s->s_mx);
-		nni_stat_inc_atomic(&l->l_stats.s_reject, 1);
-		nni_stat_inc_atomic(&s->s_stats.s_reject, 1);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_inc(&l->st_reject, 1);
+		nni_stat_inc(&s->st_rejects, 1);
+#endif
 		nni_pipe_rele(p);
 		return;
 	}
 	if (p->p_proto_ops.pipe_start(p->p_proto_data) != 0) {
 		nni_mtx_unlock(&s->s_mx);
-		nni_stat_inc_atomic(&l->l_stats.s_reject, 1);
-		nni_stat_inc_atomic(&s->s_stats.s_reject, 1);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_inc(&l->st_reject, 1);
+		nni_stat_inc(&s->st_rejects, 1);
+#endif
 		nni_pipe_close(p);
 		nni_pipe_rele(p);
 		return;
 	}
 	nni_mtx_unlock(&s->s_mx);
-	nni_stat_register(&p->p_stats.s_root);
+	nni_stat_register(&p->st_root);
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_POST);
 	nni_pipe_rele(p);
 }
@@ -1595,7 +1652,9 @@ nni_listener_reap(nni_listener *l)
 	nni_aio_stop(&l->l_tmo_aio);
 	nni_aio_stop(&l->l_acc_aio);
 
-	nni_stat_unregister(&l->l_stats.s_root);
+#ifdef NNG_ENABLE_STATS
+	nni_stat_unregister(&l->st_root);
+#endif
 
 	nni_mtx_lock(&s->s_mx);
 	if (!nni_list_empty(&l->l_pipes)) {
@@ -1655,15 +1714,17 @@ nni_pipe_remove(nni_pipe *p)
 	nni_dialer *d = p->p_dialer;
 
 	nni_mtx_lock(&s->s_mx);
+#ifdef NNG_ENABLE_STATS
 	if (nni_list_node_active(&p->p_sock_node)) {
-		nni_stat_dec_atomic(&s->s_stats.s_npipes, 1);
+		nni_stat_dec(&s->st_pipes, 1);
 	}
 	if (p->p_listener != NULL) {
-		nni_stat_dec_atomic(&p->p_listener->l_stats.s_npipes, 1);
+		nni_stat_dec(&p->p_listener->st_pipes, 1);
 	}
 	if (p->p_dialer != NULL) {
-		nni_stat_dec_atomic(&p->p_dialer->d_stats.s_npipes, 1);
+		nni_stat_dec(&p->p_dialer->st_pipes, 1);
 	}
+#endif
 	nni_list_node_remove(&p->p_sock_node);
 	nni_list_node_remove(&p->p_ep_node);
 	p->p_listener = NULL;
@@ -1682,7 +1743,7 @@ void
 nni_sock_add_stat(nni_sock *s, nni_stat_item *stat)
 {
 #ifdef NNG_ENABLE_STATS
-	nni_stat_add(&s->s_stats.s_root, stat);
+	nni_stat_add(&s->st_root, stat);
 #else
 	NNI_ARG_UNUSED(s);
 	NNI_ARG_UNUSED(stat);
@@ -1693,8 +1754,8 @@ void
 nni_sock_bump_tx(nni_sock *s, uint64_t sz)
 {
 #ifdef NNG_ENABLE_STATS
-	nni_stat_inc_atomic(&s->s_stats.s_txmsgs, 1);
-	nni_stat_inc_atomic(&s->s_stats.s_txbytes, sz);
+	nni_stat_inc(&s->st_tx_msgs, 1);
+	nni_stat_inc(&s->st_tx_bytes, sz);
 #else
 	NNI_ARG_UNUSED(s);
 	NNI_ARG_UNUSED(sz);
@@ -1705,8 +1766,8 @@ void
 nni_sock_bump_rx(nni_sock *s, uint64_t sz)
 {
 #ifdef NNG_ENABLE_STATS
-	nni_stat_inc_atomic(&s->s_stats.s_rxmsgs, 1);
-	nni_stat_inc_atomic(&s->s_stats.s_rxbytes, sz);
+	nni_stat_inc(&s->st_rx_msgs, 1);
+	nni_stat_inc(&s->st_rx_bytes, sz);
 #else
 	NNI_ARG_UNUSED(s);
 	NNI_ARG_UNUSED(sz);

--- a/src/protocol/pair1/pair.c
+++ b/src/protocol/pair1/pair.c
@@ -15,7 +15,11 @@
 
 // Pair protocol.  The PAIRv1 protocol is a simple 1:1 messaging pattern.
 
-#define BUMP_STAT(x) nni_stat_inc_atomic(x, 1)
+#ifdef NNG_ENABLE_STATS
+#define BUMP_STAT(x) nni_stat_inc(x, 1)
+#else
+#define BUMP_STAT(x)
+#endif
 
 typedef struct pair1_pipe pair1_pipe;
 typedef struct pair1_sock pair1_sock;
@@ -37,14 +41,16 @@ struct pair1_sock {
 	nni_id_map     pipes;
 	nni_list       plist;
 	bool           started;
-	nni_stat_item  stat_poly;
-	nni_stat_item  stat_raw;
-	nni_stat_item  stat_reject_mismatch;
-	nni_stat_item  stat_reject_already;
-	nni_stat_item  stat_ttl_drop;
-	nni_stat_item  stat_rx_malformed;
-	nni_stat_item  stat_tx_malformed;
-	nni_stat_item  stat_tx_drop;
+#ifdef NNG_ENABLE_STATS
+	nni_stat_item stat_poly;
+	nni_stat_item stat_raw;
+	nni_stat_item stat_reject_mismatch;
+	nni_stat_item stat_reject_already;
+	nni_stat_item stat_ttl_drop;
+	nni_stat_item stat_rx_malformed;
+	nni_stat_item stat_tx_malformed;
+	nni_stat_item stat_tx_drop;
+#endif
 #ifdef NNG_TEST_LIB
 	bool inject_header;
 #endif
@@ -70,6 +76,16 @@ pair1_sock_fini(void *arg)
 	nni_mtx_fini(&s->mtx);
 }
 
+#ifdef NNG_ENABLE_STATS
+static void
+pair1_add_sock_stat(
+    pair1_sock *s, nni_stat_item *item, const nni_stat_info *info)
+{
+	nni_stat_init(item, info);
+	nni_sock_add_stat(s->sock, item);
+}
+#endif
+
 static int
 pair1_sock_init_impl(void *arg, nni_sock *sock, bool raw)
 {
@@ -80,50 +96,81 @@ pair1_sock_init_impl(void *arg, nni_sock *sock, bool raw)
 
 	// Raw mode uses this.
 	nni_mtx_init(&s->mtx);
+	s->sock = sock;
 
-	nni_stat_init_bool(
-	    &s->stat_poly, "polyamorous", "polyamorous mode?", false);
-	nni_sock_add_stat(sock, &s->stat_poly);
+#ifdef NNG_ENABLE_STATS
+	static const nni_stat_info poly_info = {
+		.si_name = "poly",
+		.si_desc = "polyamorous mode?",
+		.si_type = NNG_STAT_BOOLEAN,
+	};
+	static const nni_stat_info raw_info = {
+		.si_name = "raw",
+		.si_desc = "raw mode?",
+		.si_type = NNG_STAT_BOOLEAN,
+	};
+	static const nni_stat_info mismatch_info = {
+		.si_name   = "mismatch",
+		.si_desc   = "pipes rejected (protocol mismatch)",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info already_info = {
+		.si_name   = "already",
+		.si_desc   = "pipes rejected (already connected)",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_atomic = true,
+	};
+	static const nni_stat_info ttl_drop_info = {
+		.si_name   = "ttl_drop",
+		.si_desc   = "messages dropped due to too many hops",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_MESSAGES,
+		.si_atomic = true,
+	};
+	static const nni_stat_info tx_drop_info = {
+		.si_name   = "tx_drop",
+		.si_desc   = "messages dropped undeliverable",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_MESSAGES,
+		.si_atomic = true,
+	};
+	static const nni_stat_info rx_malformed_info = {
+		.si_name   = "rx_malformed",
+		.si_desc   = "malformed messages received",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_MESSAGES,
+		.si_atomic = true,
+	};
+	static const nni_stat_info tx_malformed_info = {
+		.si_name   = "tx_malformed",
+		.si_desc   = "malformed messages not sent",
+		.si_type   = NNG_STAT_COUNTER,
+		.si_unit   = NNG_UNIT_MESSAGES,
+		.si_atomic = true,
+	};
 
-	nni_stat_init_bool(&s->stat_raw, "raw", "raw mode?", raw);
-	nni_sock_add_stat(sock, &s->stat_raw);
+	pair1_add_sock_stat(s, &s->stat_poly, &poly_info);
+	pair1_add_sock_stat(s, &s->stat_raw, &raw_info);
+	pair1_add_sock_stat(s, &s->stat_reject_mismatch, &mismatch_info);
+	pair1_add_sock_stat(s, &s->stat_reject_already, &already_info);
+	pair1_add_sock_stat(s, &s->stat_ttl_drop, &ttl_drop_info);
+	pair1_add_sock_stat(s, &s->stat_tx_drop, &tx_drop_info);
+	pair1_add_sock_stat(s, &s->stat_rx_malformed, &rx_malformed_info);
 
-	nni_stat_init_atomic(&s->stat_reject_mismatch, "mismatch",
-	    "pipes rejected (protocol mismatch)");
-	nni_sock_add_stat(sock, &s->stat_reject_mismatch);
-
-	nni_stat_init_atomic(&s->stat_reject_already, "already",
-	    "pipes rejected (already connected)");
-	nni_sock_add_stat(sock, &s->stat_reject_already);
-
-	nni_stat_init_atomic(&s->stat_ttl_drop, "ttl_drop",
-	    "messages dropped due to too many hops");
-	nni_stat_set_unit(&s->stat_ttl_drop, NNG_UNIT_MESSAGES);
-	nni_sock_add_stat(sock, &s->stat_ttl_drop);
-
-	// This can only increment in polyamorous mode.
-	nni_stat_init_atomic(
-	    &s->stat_tx_drop, "tx_drop", "messages dropped undeliverable");
-	nni_stat_set_unit(&s->stat_tx_drop, NNG_UNIT_MESSAGES);
-	nni_sock_add_stat(sock, &s->stat_tx_drop);
-
-	nni_stat_init_atomic(&s->stat_rx_malformed, "rx_malformed",
-	    "malformed messages received");
-	nni_stat_set_unit(&s->stat_rx_malformed, NNG_UNIT_MESSAGES);
-	nni_sock_add_stat(sock, &s->stat_rx_malformed);
-
-	nni_stat_init_atomic(&s->stat_tx_malformed, "tx_malformed",
-	    "malformed messages not sent");
-	nni_stat_set_unit(&s->stat_tx_malformed, NNG_UNIT_MESSAGES);
 	if (raw) {
 		// This stat only makes sense in raw mode.
-		nni_sock_add_stat(sock, &s->stat_tx_malformed);
+		pair1_add_sock_stat(
+		    s, &s->stat_tx_malformed, &tx_malformed_info);
 	}
 
-	s->sock = sock;
-	s->raw  = raw;
-	s->uwq  = nni_sock_sendq(sock);
-	s->urq  = nni_sock_recvq(sock);
+	nni_stat_set_bool(&s->stat_raw, raw);
+	nni_stat_set_bool(&s->stat_poly, false);
+#endif
+
+	s->raw = raw;
+	s->uwq = nni_sock_sendq(sock);
+	s->urq = nni_sock_recvq(sock);
 	nni_atomic_init(&s->ttl);
 	nni_atomic_set(&s->ttl, 8);
 

--- a/src/transport/tcp/tcp.c
+++ b/src/transport/tcp/tcp.c
@@ -68,7 +68,10 @@ struct tcptran_ep {
 	nni_reap_item        reap;
 	nng_stream_dialer *  dialer;
 	nng_stream_listener *listener;
-	nni_stat_item        st_rcvmaxsz;
+
+#ifdef NNG_ENABLE_STATS
+	nni_stat_item st_rcv_max;
+#endif
 };
 
 static void tcptran_pipe_send_start(tcptran_pipe *);
@@ -173,7 +176,8 @@ tcptran_pipe_alloc(tcptran_pipe **pipep)
 	nni_mtx_init(&p->mtx);
 	if (((rv = nni_aio_alloc(&p->txaio, tcptran_pipe_send_cb, p)) != 0) ||
 	    ((rv = nni_aio_alloc(&p->rxaio, tcptran_pipe_recv_cb, p)) != 0) ||
-	    ((rv = nni_aio_alloc(&p->negoaio, tcptran_pipe_nego_cb, p)) != 0)) {
+	    ((rv = nni_aio_alloc(&p->negoaio, tcptran_pipe_nego_cb, p)) !=
+	        0)) {
 		tcptran_pipe_fini(p);
 		return (rv);
 	}
@@ -857,9 +861,16 @@ tcptran_ep_init(tcptran_ep **epp, nng_url *url, nni_sock *sock)
 	ep->proto = nni_sock_proto_id(sock);
 	ep->url   = url;
 
-	nni_stat_init(&ep->st_rcvmaxsz, "rcvmaxsz", "maximum receive size");
-	nni_stat_set_type(&ep->st_rcvmaxsz, NNG_STAT_LEVEL);
-	nni_stat_set_unit(&ep->st_rcvmaxsz, NNG_UNIT_BYTES);
+#ifdef NNG_ENABLE_STATS
+	static const nni_stat_info rcv_max_info = {
+	    .si_name   = "rcv_max",
+	    .si_desc   = "maximum receive size",
+	    .si_type   = NNG_STAT_LEVEL,
+	    .si_unit   = NNG_UNIT_BYTES,
+	    .si_atomic = true,
+	};
+	nni_stat_init(&ep->st_rcv_max, &rcv_max_info);
+#endif
 
 	*epp = ep;
 	return (0);
@@ -905,7 +916,9 @@ tcptran_dialer_init(void **dp, nng_url *url, nni_dialer *ndialer)
 		return (rv);
 	}
 
-	nni_dialer_add_stat(ndialer, &ep->st_rcvmaxsz);
+#ifdef NNG_ENABLE_STATS
+	nni_dialer_add_stat(ndialer, &ep->st_rcv_max);
+#endif
 	*dp = ep;
 	return (0);
 }
@@ -936,7 +949,9 @@ tcptran_listener_init(void **lp, nng_url *url, nni_listener *nlistener)
 		tcptran_ep_fini(ep);
 		return (rv);
 	}
-	nni_listener_add_stat(nlistener, &ep->st_rcvmaxsz);
+#ifdef NNG_ENABLE_STATS
+	nni_listener_add_stat(nlistener, &ep->st_rcv_max);
+#endif
 
 	*lp = ep;
 	return (0);
@@ -1036,8 +1051,10 @@ tcptran_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 		NNI_LIST_FOREACH (&ep->busypipes, p) {
 			p->rcvmax = val;
 		}
-		nni_stat_set_value(&ep->st_rcvmaxsz, val);
 		nni_mtx_unlock(&ep->mtx);
+#ifdef NNG_ENABLE_STATS
+		nni_stat_set_value(&ep->st_rcv_max, val);
+#endif
 	}
 	return (rv);
 }


### PR DESCRIPTION
This should reduce the amount of copying, and the overall size
used by pipes and other objects quite a bit.  (On my system, the
sizeof nni_pipe shrank by 400 bytes, for example.)

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
