### PR TITLE
fixes #1313 support deferred nng_aio destruction

### DIFF
--- a/docs/man/libnng.3.adoc
+++ b/docs/man/libnng.3.adoc
@@ -170,6 +170,7 @@ The following functions are used in the asynchronous model:
 |xref:nng_aio_get_input.3.adoc[nng_aio_get_input()]|return input parameter
 |xref:nng_aio_get_msg.3.adoc[nng_aio_get_msg()]|get message from an asynchronous receive
 |xref:nng_aio_get_output.3.adoc[nng_aio_get_output()]|return output result
+|xref:nng_aio_free.3.adoc[nng_aio_reap()]|reap asynchronous I/O handle
 |xref:nng_aio_result.3.adoc[nng_aio_result()]|return result of asynchronous operation
 |xref:nng_aio_set_input.3.adoc[nng_aio_set_input()]|set input parameter
 |xref:nng_aio_set_iov.3.adoc[nng_aio_set_iov()]|set scatter/gather vector

--- a/docs/man/nng_aio_free.3.adoc
+++ b/docs/man/nng_aio_free.3.adoc
@@ -1,6 +1,6 @@
 = nng_aio_free(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -20,6 +20,7 @@ nng_aio_free - free asynchronous I/O handle
 #include <nng/nng.h>
 
 void nng_aio_free(nng_aio *aio);
+void nng_aio_reap(nng_aio *aio);
 ----
 
 == DESCRIPTION
@@ -29,6 +30,12 @@ If any operation is in progress, the operation is canceled, and the
 caller is blocked until the operation is completely canceled, to ensure
 that it is safe to deallocate the handle and any associated resources.
 (This is done by implicitly calling xref:nng_aio_stop.3.adoc[`nng_aio_stop()`].)
+
+The `nng_aio_reap()` function is the same as `nng_aio_free()`, but does
+it's work in a background thread.
+This can be useful to discard the _aio_ object from within the callback for the _aio_.
+
+IMPORTANT: Once either of these functions are called, the _aio_ object is invalid and must not be used again.
 
 == RETURN VALUES
 

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -488,6 +488,13 @@ NNG_DECL int nng_aio_alloc(nng_aio **, void (*)(void *), void *);
 // It *must not* be in use at the time it is freed.
 NNG_DECL void nng_aio_free(nng_aio *);
 
+// nng_aio_reap is like nng_aio_free, but calls it from a background
+// reaper thread.  This can be useful to free aio objects from aio
+// callbacks (e.g. when the result of the callback is to discard
+// the object in question.)  The aio object must be in further use
+// when this is called.
+NNG_DECL void nng_aio_reap(nng_aio *);
+
 // nng_aio_stop stops any outstanding operation, and waits for the
 // AIO to be free, including for the callback to have completed
 // execution.  Therefore the caller must NOT hold any locks that

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -28,6 +28,10 @@ extern void nni_aio_init(nni_aio *, nni_cb, void *arg);
 // It waits for the callback to complete.
 extern void nni_aio_fini(nni_aio *);
 
+// nni_aio_reap is used to asynchronously reap the aio.  It can
+// be called even from the callback of the aio itself.
+extern void nni_aio_reap(nni_aio *);
+
 // nni_aio_alloc allocates an aio object and initializes it.  The callback
 // is called with the supplied argument when the operation is complete.
 // If NULL is supplied for the callback, then nni_aio_wake is used in its
@@ -195,8 +199,8 @@ struct nng_aio {
 	nni_list_node     a_prov_node;     // Linkage on provider list.
 	void *            a_prov_extra[2]; // Extra data used by provider
 
-	// Expire node.
-	nni_list_node a_expire_node;
+	nni_list_node   a_expire_node; // Expiration node
+	struct nng_aio *a_reap_next;
 };
 
 #endif // CORE_AIO_H

--- a/src/core/aio_test.c
+++ b/src/core/aio_test.c
@@ -35,7 +35,7 @@ void
 test_sleep(void)
 {
 	nng_time start;
-	nng_time end   = 0;
+	nng_time end = 0;
 	nng_aio *aio;
 
 	NUTS_PASS(nng_aio_alloc(&aio, sleep_done, &end));
@@ -55,7 +55,7 @@ void
 test_sleep_timeout(void)
 {
 	nng_time start;
-	nng_time end   = 0;
+	nng_time end = 0;
 	nng_aio *aio;
 
 	NUTS_TRUE(nng_aio_alloc(&aio, sleep_done, &end) == 0);
@@ -226,6 +226,22 @@ test_zero_timeout(void)
 	NUTS_PASS(nng_close(s));
 }
 
+static void
+aio_sleep_cb(void *arg)
+{
+	nng_aio *aio = *(nng_aio **) arg;
+	nng_aio_reap(aio);
+}
+
+void
+test_aio_reap(void)
+{
+	nng_aio *a;
+	NUTS_PASS(nng_aio_alloc(&a, aio_sleep_cb, &a));
+	nng_sleep_aio(10, a);
+	nng_msleep(20);
+}
+
 NUTS_TESTS = {
 	{ "sleep", test_sleep },
 	{ "sleep timeout", test_sleep_timeout },
@@ -236,5 +252,6 @@ NUTS_TESTS = {
 	{ "explicit timeout", test_explicit_timeout },
 	{ "inherited timeout", test_inherited_timeout },
 	{ "zero timeout", test_zero_timeout },
+	{ "aio reap", test_aio_reap },
 	{ NULL, NULL },
 };

--- a/src/nng.c
+++ b/src/nng.c
@@ -1737,6 +1737,12 @@ nng_aio_free(nng_aio *aio)
 }
 
 void
+nng_aio_reap(nng_aio *aio)
+{
+	nni_aio_reap(aio);
+}
+
+void
 nng_sleep_aio(nng_duration ms, nng_aio *aio)
 {
 	nni_sleep_aio(ms, aio);


### PR DESCRIPTION
This also converts the HTTP client to make use of this.
