### PR TITLE
fixes #1393 Use after free in http

### DIFF
--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -751,14 +751,16 @@ finish:
 	nni_aio_set_input(sc->cbaio, 1, h);
 	nni_aio_set_input(sc->cbaio, 2, sc->conn);
 
+	// Set a reference -- this because the callback may be running
+	// asynchronously even after it gets removed from the server.
+	nni_atomic_inc64(&h->ref);
+
 	// Documented that we call this on behalf of the callback.
 	if (nni_aio_begin(sc->cbaio) != 0) {
 		nni_mtx_unlock(&s->mtx);
 		return;
 	}
-	// Set a reference -- this because the callback may be running
-	// asynchronously even after it gets removed from the server.
-	nni_atomic_inc64(&h->ref);
+
 	nni_mtx_unlock(&s->mtx);
 	h->cb(sc->cbaio);
 }


### PR DESCRIPTION
fixes #1393 Use after free in http

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
