### PR TITLE
getaddrinfo(3) on musl & BSDs fails with servname = ""

### DIFF
--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -253,7 +253,7 @@ nni_resolv_ip(const char *host, const char *serv, int af, bool passive,
 		return;
 	}
 
-	if (serv == NULL) {
+	if (serv == NULL || strcmp(serv, "") == 0) {
 		item->serv = NULL;
 	} else if ((item->serv = nni_strdup(serv)) == NULL) {
 		nni_aio_finish_error(aio, NNG_ENOMEM);


### PR DESCRIPTION
I noticed the `tcpsupp` test was failing on OpenBSD as well as on my Alpine Edge (musl v1.2.2-pre6) vm I use. (Tests at the v1.3.2 tag all pass, however.)

Looking into the problem, I traced it to the fact the url in the test (`tcp://127.0.0.1`) eventually ends up parsed and transformed into a `resolve_item` where `serv` is a non-`NULL` pointer. This results in the service name argument in the `getaddrinfo(3)` call to be non-`NULL` (like `""`). Apparently this is acceptable on some POSIX-like platforms (e.g. glibc-based Linux).

However, if one calls getaddrinfo(3) on OpenBSD like so, it returns -8 (`EAI_NONAME`):

```c
#include <sys/types.h>
#include <sys/socket.h>
#include <netdb.h>

#include <string.h>
#include <stdio.h>

int main() {
	struct addrinfo hints;
	struct addrinfo *results;
	int rv;

	results = NULL;

	memset(&hints, 0, sizeof(hints));
	hints.ai_flags = AI_ADDRCONFIG;
	hints.ai_flags |= AI_PASSIVE;
	hints.ai_family = AF_INET;
	hints.ai_socktype = SOCK_STREAM;

	rv = getaddrinfo("localhost", "", &hints, &results);
	printf("rv: %d\n", rv);

	return rv;
}
```

I tried to make the least invasive change possible that:

1. doesn't change the current url parsing logic that might impact other parts of nng
2. doesn't mutate state of any of the objects being used for resolution
3. only change posix parts of nng