### PR TITLE
Fix typo in tls_common.c

### DIFF
--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -1473,7 +1473,7 @@ nng_tls_engine_register(const nng_tls_engine *engine)
 extern int NNG_TLS_ENGINE_INIT(void);
 #else
 static int
-NNI_TLS_ENGINE_INIT(void)
+NNG_TLS_ENGINE_INIT(void)
 {
 	return (0);
 }


### PR DESCRIPTION
fixes #<issue number> <issue synopsis>

This fixes a build error when `NNG_TLS_ENGINE_INIT` is not defined.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
