### PR TITLE
Remove extraneous/out-dated comment, declare conn_init static

### DIFF
--- a/src/supplemental/tls/mbedtls/tls.c
+++ b/src/supplemental/tls/mbedtls/tls.c
@@ -167,9 +167,7 @@ conn_fini(nng_tls_engine_conn *ec)
 	mbedtls_ssl_free(&ec->ctx);
 }
 
-// The common code should call this only after it has released
-// it's upper layer stuff.
-int
+static int
 conn_init(nng_tls_engine_conn *ec, void *tls, nng_tls_engine_config *cfg)
 {
 	int rv;


### PR DESCRIPTION
Was looking into how to extend TLS support to a new engine when I found a small oddity.

The comment is an artifact from an old `tls_reap` function and no longer describes the following function (`conn_init`).

Function `conn_init` should be marked `static` as well to fit the design of the tls engine api and match the other mbed-related functions local to `src/supplemental/tls/mbedtls/tls.c`.