### PR TITLE
Fix implicit declaration warnings for pthread_set_name_np on OpenBSD

### DIFF
--- a/src/platform/posix/posix_thread.c
+++ b/src/platform/posix/posix_thread.c
@@ -24,6 +24,10 @@
 #include <time.h>
 #include <unistd.h>
 
+#ifdef NNG_PLATFORM_OPENBSD
+#include <pthread_np.h>
+#endif
+
 #ifdef NNG_SETSTACKSIZE
 #include <limits.h>
 #include <sys/resource.h>


### PR DESCRIPTION
OpenBSD requires an additional header for both `pthread_set_name_np` and `pthread_get_name_np`. Otherwise, you get compiler warnings like:

```
[43/399] Building C object CMakeFiles/nng.dir/src/platform/posix/posix_thread.c.o     
../src/platform/posix/posix_thread.c:274:3: warning: implicit declaration of function 'pthread_set_name_np' is invalid in C99 [-Wimplicit-function-declaration]
                pthread_set_name_np(pthread_self(), name);                                                                                                                   
                ^                                                                     
../src/platform/posix/posix_thread.c:276:10: warning: implicit declaration of function 'pthread_set_name_np' is invalid in C99 [-Wimplicit-function-declaration]
                pthread_set_name_np(thr->tid, name);                                  
                ^
```

See http://man.openbsd.org/pthread_set_name_np for details.

Tested on both OpenBSD 6.8 and OpenBSD-current snapshot from 13 Feb 2021.