### PR TITLE
 * FIX avoid infinity loop when pipe disconnects after calling nng_sl…

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -682,6 +682,9 @@ void
 nni_sleep_aio(nng_duration ms, nng_aio *aio)
 {
 	int rv;
+	if (aio->a_stop == true) {
+		return;
+	}
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}


### PR DESCRIPTION
…eep_aio in callback

fixes #1431  

<Comments describing your change. Not all changes need this.>

Avoiding infinity loop (dispatching task forever) by checking the status of AIO in the very beginning of nng_sleep_aio.