### PR TITLE
fixes #1436 Guard against UB in sub0_ctx_subscribe

### DIFF
--- a/src/sp/protocol/pubsub0/sub.c
+++ b/src/sp/protocol/pubsub0/sub.c
@@ -493,7 +493,9 @@ sub0_ctx_subscribe(void *arg, const void *buf, size_t sz, nni_type t)
 		NNI_FREE_STRUCT(new_topic);
 		return (NNG_ENOMEM);
 	}
-	memcpy(new_topic->buf, buf, sz);
+	if (buf && new_topic->buf) {
+		memcpy(new_topic->buf, buf, sz);
+	}
 	new_topic->len = sz;
 	nni_list_append(&ctx->topics, new_topic);
 	nni_mtx_unlock(&sock->lk);


### PR DESCRIPTION
In case `sub0_ctx_subscribe` is called to subscribe to _all_ topics.

fixes #1436 Guard against UB in sub0_ctx_subscribe
