### PR TITLE
make getrandom a syscall, so it doesn't cause missing symbol errors

### DIFF
--- a/src/platform/posix/posix_rand_getrandom.c
+++ b/src/platform/posix/posix_rand_getrandom.c
@@ -15,7 +15,7 @@
 // normally be running.  This is the only time it can fail with correct
 // arguments, and then only if it is interrupted with a signal.
 
-#include <sys/random.h>
+#include <sys/syscall.h>
 
 #include "core/nng_impl.h"
 
@@ -31,10 +31,11 @@ nni_random(void)
 	// The exception here is that we could fail if for some
 	// reason we got a signal while blocked at very early boot
 	// (i.e. /dev/urandom was not yet seeded).
-	if (getrandom(&val, sizeof(val), 0) != sizeof(val)) {
+    int r = syscall(SYS_getrandom, &val, sizeof(val), 0);
+    if (r == -1) {
 		nni_panic("getrandom failed");
 	}
-	return (val);
+	return val;
 }
 
 #endif


### PR DESCRIPTION
This calls getrandom as a syscall.
'getrandom' seems to be a syscall, not just a function you can call. This causes troubles in certain settings (depends on your standard library i guess) during linking ('getrandom' will be a missing symbol).
