### PR TITLE
Disable clock-dependent checks on macOS in CI/CD.

### DIFF
--- a/src/core/aio_test.c
+++ b/src/core/aio_test.c
@@ -302,7 +302,10 @@ test_sleep_loop(void)
 	nng_mtx_unlock(sl.mx);
 	dur = (nng_duration) (nng_clock() - start);
 	NUTS_ASSERT(dur >= 150);
-	NUTS_ASSERT(dur <= 500); // allow for sloppy clocks
+	if ((getenv("GITHUB_ACTIONS") == "") ||
+	    (getenv("RUNNER_OS") != "macOS")) {
+		NUTS_ASSERT(dur <= 500); // allow for sloppy clocks
+	}
 	NUTS_ASSERT(sl.done);
 	NUTS_PASS(sl.result);
 	NUTS_ASSERT(sl.count == 3);
@@ -339,7 +342,10 @@ test_sleep_cancel(void)
 	nng_mtx_unlock(sl.mx);
 	dur = (nng_duration) (nng_clock() - start);
 	NUTS_ASSERT(dur >= 100);
-	NUTS_ASSERT(dur <= 500); // allow for sloppy clocks
+	if ((getenv("GITHUB_ACTIONS") == "") ||
+	    (getenv("RUNNER_OS") != "macOS")) {
+		NUTS_ASSERT(dur <= 500); // allow for sloppy clocks
+	}
 	NUTS_ASSERT(sl.done);
 	NUTS_FAIL(sl.result, NNG_ECANCELED);
 	NUTS_ASSERT(sl.count == 1);


### PR DESCRIPTION
GitHub's darwin server farm appears possibly overloaded, and
the timing specific checks in that environment appear to be busted.
Local instances of macOS don't seem to have problems though.
