### PR TITLE
fixes #1409 reader/writer lock desired

### DIFF
--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -88,9 +88,11 @@ extern void *nni_zalloc(size_t);
 // Most implementations can just call free() here.
 extern void nni_free(void *, size_t);
 
-typedef struct nni_plat_mtx nni_plat_mtx;
-typedef struct nni_plat_cv  nni_plat_cv;
-typedef struct nni_plat_thr nni_plat_thr;
+typedef struct nni_plat_mtx    nni_plat_mtx;
+typedef struct nni_plat_rwlock nni_plat_rwlock;
+typedef struct nni_plat_cv     nni_plat_cv;
+typedef struct nni_plat_thr    nni_plat_thr;
+typedef struct nni_rwlock      nni_rwlock;
 
 //
 // Threading & Synchronization Support
@@ -111,6 +113,15 @@ extern void nni_plat_mtx_lock(nni_plat_mtx *);
 // nni_plat_mtx_unlock unlocks the mutex.  This can only be performed by the
 // thread that owned the mutex.
 extern void nni_plat_mtx_unlock(nni_plat_mtx *);
+
+// read/write locks - these work like mutexes except that multiple readers
+// can acquire the lock.  These are not safe for recursive use, and it is
+// unspecified whether any measures are provided to prevent starvation.
+extern void nni_rwlock_init(nni_rwlock *);
+extern void nni_rwlock_fini(nni_rwlock *);
+extern void nni_rwlock_rdlock(nni_rwlock *);
+extern void nni_rwlock_wrlock(nni_rwlock *);
+extern void nni_rwlock_unlock(nni_rwlock *);
 
 // nni_plat_cv_init initializes a condition variable.  We require a mutex be
 // supplied with it, and that mutex must always be held when performing any
@@ -161,6 +172,7 @@ extern bool nni_plat_thr_is_self(nni_plat_thr *);
 // should be a short ASCII string.  It may or may not be supported --
 // this is intended to facilitate debugging.
 extern void nni_plat_thr_set_name(nni_plat_thr *, const char *);
+
 //
 // Atomics support.  This will evolve over time.
 //

--- a/src/platform/posix/posix_impl.h
+++ b/src/platform/posix/posix_impl.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -56,6 +56,10 @@ extern int nni_plat_errno(int);
 
 struct nni_plat_mtx {
 	pthread_mutex_t mtx;
+};
+
+struct nni_rwlock {
+	pthread_rwlock_t rwl;
 };
 
 struct nni_plat_cv {

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -41,6 +41,11 @@ struct nni_plat_mtx {
 	int     init;
 };
 
+struct nni_rwlock {
+	SRWLOCK rwl;
+	BOOLEAN exclusive;
+};
+
 struct nni_plat_cv {
 	CONDITION_VARIABLE cv;
 	PSRWLOCK           srl;


### PR DESCRIPTION
This provides the initial implementation, and converts the
transport lookup routines to use it.  This is probably of limited
performance benefit, but rwlock's may be useful in further future work.
