### PR TITLE
Fix valgrind error epoll_ctl points to uninitialised bytes

### DIFF
--- a/src/platform/posix/posix_pollq_epoll.c
+++ b/src/platform/posix/posix_pollq_epoll.c
@@ -107,6 +107,7 @@ nni_posix_pfd_init(nni_posix_pfd **pfdp, int fd)
 	NNI_LIST_NODE_INIT(&pfd->node);
 
 	// notifications disabled to begin with
+	memset(&ev, 0, sizeof(ev));
 	ev.events   = 0;
 	ev.data.ptr = pfd;
 
@@ -138,6 +139,7 @@ nni_posix_pfd_arm(nni_posix_pfd *pfd, unsigned events)
 		pfd->events |= events;
 		events = pfd->events;
 
+		memset(&ev, 0, sizeof(ev));
 		ev.events   = events | NNI_EPOLL_FLAGS;
 		ev.data.ptr = pfd;
 


### PR DESCRIPTION
I am trying to replace ZeroMQ with NNG in some company libraries. In our UTs I have added `nng_fini()` to our `atexit()` to avoid false positives reported by valgrind regarding possible lost bytes. One thing I cannot get rid of however is this error

```
==1664== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==1664==    at 0x4D527BE: epoll_ctl (syscall-template.S:78)
==1664==    by 0x49660D8: nni_posix_pfd_arm (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x495FACF: ipc_listener_doaccept (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x4960799: ipc_listener_accept (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x49584EA: nng_stream_listener_accept (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x497B3FF: ipc_ep_accept (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x494F16E: listener_accept_start (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x494F1F4: nni_listener_start (in /usr/lib/i386-linux-gnu/libnng.so.1)
==1664==    by 0x494656D: nng_listen (in /usr/lib/i386-linux-gnu/libnng.so.1)
```

and another, similar one (this PR targets both). I realize that this is a good candidate for a valgrind suppression but I wanted to see where NNG stands on this issue. For me, using suppressions would mean having a suppression file in _many_ unittests as the libraries are used in many places.

Alternatively, I have on some occasions simply changed my code to work better with the tool in question. My intention with this PR is to discuss whether this could be considered for NNG ? Note the changes proposed here are merely to illustrate what I am talking about in the codebase.
