### PR TITLE
CMake: fix cross-build to iOS/tvOS/watchOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,7 +190,7 @@ elseif (CMAKE_SYSTEM_NAME MATCHES "Android")
     add_definitions(-DNNG_USE_EVENTFD)
     set(NNG_PLATFORM_POSIX ON)
 
-elseif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+elseif (APPLE)
     add_definitions(-DNNG_PLATFORM_POSIX)
     add_definitions(-DNNG_PLATFORM_DARWIN)
     set(NNG_PLATFORM_POSIX ON)


### PR DESCRIPTION
Static libs generated on iOS, tvOS or watchOS are missing several symbols. The build succeeds, but static lib is illformed, and link of application to this lib will likely fail.

The reason is that proper definitions are injected only for macOS (if I look into source code, `NNG_PLATFORM_POSIX` is important, and `NNG_PLATFORM_DARWIN` useless). Indeed, `CMAKE_SYSTEM_NAME` is not `Darwin` if cross-building to iOS/tvOS/watchOS.

Instead of repeating `CMAKE_SYSTEM_NAME MATCHES "Darwin"`, `CMAKE_SYSTEM_NAME MATCHES "iOS"` etc, there is `APPLE` variable: https://cmake.org/cmake/help/latest/variable/APPLE.html