### PR TITLE
Fix premature transport registration. Mark it deprecated.

### DIFF
--- a/docs/man/nng_inproc_register.3.adoc
+++ b/docs/man/nng_inproc_register.3.adoc
@@ -1,6 +1,6 @@
 = nng_inproc_register(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -26,6 +26,9 @@ int nng_inproc_register(void);
 
 The `nng_inproc_register()` function registers the
 ((_inproc_ transport))(((transport, _inproc_))) for use.
+
+NOTE: This function is deprecated, and may be removed from a future release.
+It is no longer necessary to explicitly register transports.
 
 == RETURN VALUES
 

--- a/docs/man/nng_ipc_register.3.adoc
+++ b/docs/man/nng_ipc_register.3.adoc
@@ -1,6 +1,6 @@
 = nng_ipc_register(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -26,6 +26,9 @@ int nng_ipc_register(void);
 
 The `nng_ipc_register()` function registers the
 ((_ipc_ transport))(((transport, _ipc_))) for use.
+
+NOTE: This function is deprecated, and may be removed from a future release.
+It is no longer necessary to explicitly register transports.
 
 == RETURN VALUES
 

--- a/docs/man/nng_tcp_register.3.adoc
+++ b/docs/man/nng_tcp_register.3.adoc
@@ -1,6 +1,6 @@
 = nng_tcp_register(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -26,6 +26,9 @@ int nng_tcp_register(void);
 
 The `nng_tcp_register()` function registers the
 ((_tcp_ transport))(((transport, _tcp_))) for use.
+
+NOTE: This function is deprecated, and may be removed from a future release.
+It is no longer necessary to explicitly register transports.
 
 == RETURN VALUES
 

--- a/docs/man/nng_ws_register.3.adoc
+++ b/docs/man/nng_ws_register.3.adoc
@@ -1,6 +1,6 @@
 = nng_ws_register(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -26,6 +26,9 @@ int nng_ws_register(void);
 
 The `nng_ws_register()` function registers the
 ((_ws_ transport))(((transport, _ws_))) for use.
+
+NOTE: This function is deprecated, and may be removed from a future release.
+It is no longer necessary to explicitly register transports.
 
 == RETURN VALUES
 

--- a/docs/man/nng_wss_register.3.adoc
+++ b/docs/man/nng_wss_register.3.adoc
@@ -1,6 +1,6 @@
 = nng_wss_register(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -26,6 +26,9 @@ int nng_wss_register(void);
 
 The `nng_wss_register()` function registers the
 ((_wss_ transport))(((transport, _wss_))) for use.
+
+NOTE: This function is deprecated, and may be removed from a future release.
+It is no longer necessary to explicitly register transports.
 
 == RETURN VALUES
 

--- a/docs/man/nng_zt_register.3.adoc
+++ b/docs/man/nng_zt_register.3.adoc
@@ -1,6 +1,6 @@
 = nng_zt_register(3)
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This document is supplied under the terms of the MIT License, a
@@ -26,6 +26,9 @@ int nng_zt_register(void);
 
 The `nng_zt_register()` function registers the
 ((_zt_ transport))(((transport, _zt_))) for use.
+
+NOTE: This function is deprecated, and may be removed from a future release.
+It is no longer necessary to explicitly register transports.
 
 == RETURN VALUES
 

--- a/include/nng/transport/inproc/inproc.h
+++ b/include/nng/transport/inproc/inproc.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -18,8 +18,9 @@ extern "C" {
 #endif
 
 // inproc transport.  This is used for intra-process communication.
-
+#ifndef NNG_ELIDE_DEPRECATED
 NNG_DECL int nng_inproc_register(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nng/transport/ipc/ipc.h
+++ b/include/nng/transport/ipc/ipc.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -20,7 +20,9 @@ extern "C" {
 // ipc transport.  This is used for inter-process communication on
 // the same host computer.
 
+#ifndef NNG_ELIDE_DEPRECATED
 NNG_DECL int nng_ipc_register(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nng/transport/tcp/tcp.h
+++ b/include/nng/transport/tcp/tcp.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -19,7 +19,9 @@ extern "C" {
 
 // TCP transport.  This is used for communication over TCP/IP.
 
+#ifndef NNG_ELIDE_DEPRECATED
 NNG_DECL int nng_tcp_register(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nng/transport/tls/tls.h
+++ b/include/nng/transport/tls/tls.h
@@ -19,7 +19,9 @@ extern "C" {
 
 // TLS transport.  This is used for communication via TLS v1.2 over TCP/IP.
 
+#ifndef NNG_ELIDE_DEPRECATED
 NNG_DECL int nng_tls_register(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nng/transport/ws/websocket.h
+++ b/include/nng/transport/ws/websocket.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2019 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -19,13 +19,14 @@ extern "C" {
 
 // WebSocket transport.  This is used for communication via WebSocket.
 
-NNG_DECL int nng_ws_register(void);
-
 // These aliases are for WSS naming consistency.
 #define NNG_OPT_WSS_REQUEST_HEADERS NNG_OPT_WS_REQUEST_HEADERS
 #define NNG_OPT_WSS_RESPONSE_HEADERS NNG_OPT_WS_RESPONSE_HEADERS
 
+#ifndef NNG_ELIDE_DEPRECATED
+NNG_DECL int nng_ws_register(void);
 NNG_DECL int nng_wss_register(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/nng/transport/zerotier/zerotier.h
+++ b/include/nng/transport/zerotier/zerotier.h
@@ -150,7 +150,9 @@ enum nng_zt_status {
 	NNG_ZT_STATUS_UNKNOWN,
 };
 
+#ifndef NNG_ELIDE_DEPRECATED
 NNG_DECL int nng_zt_register(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/sp/transport.c
+++ b/src/sp/transport.c
@@ -11,25 +11,6 @@
 
 #include "core/nng_impl.h"
 
-#ifdef NNG_TRANSPORT_INPROC
-#include "nng/transport/inproc/inproc.h"
-#endif
-#ifdef NNG_TRANSPORT_IPC
-#include "nng/transport/ipc/ipc.h"
-#endif
-#ifdef NNG_TRANSPORT_TCP
-#include "nng/transport/tcp/tcp.h"
-#endif
-#ifdef NNG_TRANSPORT_TLS
-#include "nng/transport/tls/tls.h"
-#endif
-#ifdef NNG_TRANSPORT_WS
-#include "nng/transport/ws/websocket.h"
-#endif
-#ifdef NNG_TRANSPORT_ZEROTIER
-#include "nng/transport/zerotier/zerotier.h"
-#endif
-
 #include <stdio.h>
 #include <string.h>
 
@@ -67,6 +48,28 @@ nni_sp_tran_find(nni_url *url)
 // nni_sp_tran_sys_init initializes the entire transport subsystem, including
 // each individual transport.
 
+#ifdef NNG_TRANSPORT_INPROC
+extern void nni_sp_inproc_register(void);
+#endif
+#ifdef NNG_TRANSPORT_IPC
+extern void nni_sp_ipc_register(void);
+#endif
+#ifdef NNG_TRANSPORT_TCP
+extern void nni_sp_tcp_register(void);
+#endif
+#ifdef NNG_TRANSPORT_TLS
+extern void nni_sp_tls_register(void);
+#endif
+#ifdef NNG_TRANSPORT_WS
+extern void nni_sp_ws_register(void);
+#endif
+#ifdef NNG_TRANSPORT_WSS
+extern void nni_sp_wss_register(void);
+#endif
+#ifdef NNG_TRANSPORT_ZEROTIER
+extern void nni_sp_zt_register(void);
+#endif
+
 int
 nni_sp_tran_sys_init(void)
 {
@@ -74,25 +77,25 @@ nni_sp_tran_sys_init(void)
 	nni_rwlock_init(&sp_tran_lk);
 
 #ifdef NNG_TRANSPORT_INPROC
-	nng_inproc_register();
+	nni_sp_inproc_register();
 #endif
 #ifdef NNG_TRANSPORT_IPC
-	nng_ipc_register();
+	nni_sp_ipc_register();
 #endif
 #ifdef NNG_TRANSPORT_TCP
-	nng_tcp_register();
+	nni_sp_tcp_register();
 #endif
 #ifdef NNG_TRANSPORT_TLS
-	nng_tls_register();
+	nni_sp_tls_register();
 #endif
 #ifdef NNG_TRANSPORT_WS
-	nng_ws_register();
+	nni_sp_ws_register();
 #endif
 #ifdef NNG_TRANSPORT_WSS
-	nng_wss_register();
+	nni_sp_wss_register();
 #endif
 #ifdef NNG_TRANSPORT_ZEROTIER
-	nng_zt_register();
+	nni_sp_zt_register();
 #endif
 	return (0);
 }

--- a/src/sp/transport/inproc/inproc.c
+++ b/src/sp/transport/inproc/inproc.c
@@ -313,9 +313,9 @@ inproc_listener_init(void **epp, nni_url *url, nni_listener *nlistener)
 	}
 	nni_mtx_init(&ep->mtx);
 
-	ep->listener  = true;
-	ep->proto     = nni_sock_proto_id(sock);
-	ep->rcvmax    = 0;
+	ep->listener = true;
+	ep->proto    = nni_sock_proto_id(sock);
+	ep->rcvmax   = 0;
 	NNI_LIST_INIT(&ep->clients, inproc_ep, node);
 	nni_aio_list_init(&ep->aios);
 
@@ -683,9 +683,16 @@ struct nni_sp_tran nni_inproc_tran = {
 	.tran_fini     = inproc_fini,
 };
 
+#ifndef NNG_ELIDE_DEPRECATED
 int
 nng_inproc_register(void)
 {
+	return (nni_init());
+}
+#endif
+
+void
+nni_sp_inproc_register(void)
+{
 	nni_sp_tran_register(&nni_inproc_tran);
-	return (0);
 }

--- a/src/sp/transport/ipc/ipc.c
+++ b/src/sp/transport/ipc/ipc.c
@@ -1148,8 +1148,17 @@ static nni_sp_tran ipc_tran_abstract = {
 };
 #endif
 
+
+#ifndef NNG_ELIDE_DEPRECATED
 int
 nng_ipc_register(void)
+{
+	return (nni_init());
+}
+#endif
+
+void
+nni_sp_ipc_register(void)
 {
 	nni_sp_tran_register(&ipc_tran);
 #ifdef NNG_PLATFORM_POSIX
@@ -1158,6 +1167,4 @@ nng_ipc_register(void)
 #ifdef NNG_HAVE_ABSTRACT_SOCKETS
 	nni_sp_tran_register(&ipc_tran_abstract);
 #endif
-
-	return (0);
 }

--- a/src/sp/transport/tcp/tcp.c
+++ b/src/sp/transport/tcp/tcp.c
@@ -1247,11 +1247,18 @@ static nni_sp_tran tcp6_tran = {
 	.tran_fini     = tcptran_fini,
 };
 
+#ifndef NNG_ELIDE_DEPRECATED
 int
 nng_tcp_register(void)
+{
+	return (nni_init());
+}
+#endif
+
+void
+nni_sp_tcp_register(void)
 {
 	nni_sp_tran_register(&tcp_tran);
 	nni_sp_tran_register(&tcp4_tran);
 	nni_sp_tran_register(&tcp6_tran);
-	return (0);
 }

--- a/src/sp/transport/tls/tls.c
+++ b/src/sp/transport/tls/tls.c
@@ -1279,8 +1279,13 @@ static nni_sp_tran tls6_tran = {
 int
 nng_tls_register(void)
 {
+	return (nni_init());
+}
+
+void
+nni_sp_tls_register(void)
+{
 	nni_sp_tran_register(&tls_tran);
 	nni_sp_tran_register(&tls4_tran);
 	nni_sp_tran_register(&tls6_tran);
-	return (0);
 }

--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -667,14 +667,26 @@ static nni_sp_tran ws6_tran = {
 	.tran_fini     = wstran_fini,
 };
 
+#ifndef NNG_ELIDE_DEPRECATED
 int
 nng_ws_register(void)
+{
+	return (nni_init());
+}
+
+int
+nng_wss_register(void)
+{
+	return (nni_init());
+}
+#endif
+
+void
+nni_sp_ws_register(void)
 {
 	nni_sp_tran_register(&ws_tran);
 	nni_sp_tran_register(&ws4_tran);
 	nni_sp_tran_register(&ws6_tran);
-
-	return (0);
 }
 
 #ifdef NNG_TRANSPORT_WSS
@@ -706,22 +718,12 @@ static nni_sp_tran wss6_tran = {
 	.tran_fini     = wstran_fini,
 };
 
-int
-nng_wss_register(void)
+void
+nni_sp_wss_register(void)
 {
 	nni_sp_tran_register(&wss_tran);
 	nni_sp_tran_register(&wss4_tran);
 	nni_sp_tran_register(&wss6_tran);
-
-	return (0);
-}
-
-#else
-
-int
-nng_wss_register(void)
-{
-	return (0);
 }
 
 #endif // NNG_TRANSPORT_WSS

--- a/src/sp/transport/zerotier/zerotier.c
+++ b/src/sp/transport/zerotier/zerotier.c
@@ -58,18 +58,17 @@ typedef struct zt_node     zt_node;
 typedef struct zt_frag     zt_frag;
 typedef struct zt_fraglist zt_fraglist;
 
-
 // Port numbers are stored as 24-bit values in network byte order.
-#define ZT_GET24(ptr, v)                              \
-	v = (((uint32_t)((uint8_t)(ptr)[0])) << 16) + \
-	    (((uint32_t)((uint8_t)(ptr)[1])) << 8) +  \
-	    (((uint32_t)(uint8_t)(ptr)[2]))
+#define ZT_GET24(ptr, v)                                \
+	v = (((uint32_t) ((uint8_t) (ptr)[0])) << 16) + \
+	    (((uint32_t) ((uint8_t) (ptr)[1])) << 8) +  \
+	    (((uint32_t) (uint8_t) (ptr)[2]))
 
-#define ZT_PUT24(ptr, u)                                     \
-	do {                                                 \
-		(ptr)[0] = (uint8_t)(((uint32_t)(u)) >> 16); \
-		(ptr)[1] = (uint8_t)(((uint32_t)(u)) >> 8);  \
-		(ptr)[2] = (uint8_t)((uint32_t)(u));         \
+#define ZT_PUT24(ptr, u)                                       \
+	do {                                                   \
+		(ptr)[0] = (uint8_t) (((uint32_t) (u)) >> 16); \
+		(ptr)[1] = (uint8_t) (((uint32_t) (u)) >> 8);  \
+		(ptr)[2] = (uint8_t) ((uint32_t) (u));         \
 	} while (0)
 
 static const uint16_t     zt_ethertype = 0x901;
@@ -455,7 +454,7 @@ zt_node_to_mac(uint64_t node, uint64_t nwid)
 	// multicast and set local administration -- this is the first
 	// octet of the 48 bit mac address.  We also avoid 0x52, which
 	// is known to be used in KVM, libvirt, etc.
-	mac = ((uint8_t)(nwid & 0xfe) | 0x02);
+	mac = ((uint8_t) (nwid & 0xfe) | 0x02);
 	if (mac == 0x52) {
 		mac = 0x32;
 	}
@@ -907,7 +906,7 @@ zt_pipe_recv_data(zt_pipe *p, const uint8_t *data, size_t len)
 		return;
 	}
 
-	bit = (uint8_t)(1 << (fragno % 8));
+	bit = (uint8_t) (1 << (fragno % 8));
 	if ((fl->fl_missing[fragno / 8] & bit) == 0) {
 		// We've already got this fragment, ignore it.  We don't
 		// bother to check for changed data.
@@ -1714,8 +1713,8 @@ zt_pipe_fini(void *arg)
 }
 
 static nni_reap_list zt_reap_list = {
-       .rl_offset = offsetof(zt_pipe, zp_reap),
-       .rl_func   = zt_pipe_fini,
+	.rl_offset = offsetof(zt_pipe, zp_reap),
+	.rl_func   = zt_pipe_fini,
 };
 
 static void
@@ -1841,15 +1840,15 @@ zt_pipe_send(void *arg, nni_aio *aio)
 	NNI_ASSERT(fragsz < 0x10000); // Because zp_mtu is 16 bits
 
 	msg_header_len = nni_msg_header_len(m);
-	msg_len = nni_msg_len(m);
-	bytes = msg_header_len + msg_len;
+	msg_len        = nni_msg_len(m);
+	bytes          = msg_header_len + msg_len;
 	if (bytes >= (0xfffe * fragsz)) {
 		nni_aio_finish_error(aio, NNG_EMSGSIZE);
 		nni_mtx_unlock(&zt_lk);
 		return;
 	}
 	// above check means nfrags will fit in 16-bits.
-	nfrags = (uint16_t)((bytes + (fragsz - 1)) / fragsz);
+	nfrags = (uint16_t) ((bytes + (fragsz - 1)) / fragsz);
 
 	// get the next message ID, but skip 0
 	if ((id = p->zp_next_msgid++) == 0) {
@@ -1865,7 +1864,7 @@ zt_pipe_send(void *arg, nni_aio *aio)
 		size_t   len;
 
 		// Prepend the header first.
-		if ( (!offset)  && (msg_header_len > 0)) {
+		if ((!offset) && (msg_header_len > 0)) {
 			if (msg_header_len > fragsz) {
 				// This shouldn't happen!  SP headers are
 				// supposed to be quite small.
@@ -1895,7 +1894,7 @@ zt_pipe_send(void *arg, nni_aio *aio)
 		fragno++;
 		zt_send(p->zp_ztn, p->zp_nwid, zt_op_data, p->zp_raddr,
 		    p->zp_laddr, data, fraglen + zt_offset_data_data);
-	} while (msg_header_len  + msg_len -offset != 0);
+	} while (msg_header_len + msg_len - offset != 0);
 	nni_mtx_unlock(&zt_lk);
 
 	// NB, We never bothered to call nn_aio_sched, because we run this
@@ -3240,9 +3239,16 @@ static struct nni_tran zt_tran = {
 	.tran_fini     = zt_tran_fini,
 };
 
+#ifndef NNG_ELIDE_DEPRECATED
 int
 nng_zt_register(void)
 {
+	return (nni_init());
+}
+#endif
+
+void
+nni_sp_zt_register(void)
+{
 	nni_tran_register(&zt_tran);
-	return (0);
 }


### PR DESCRIPTION
Originally the idea was to better support having the transports
be separate loadable modules.  This isn't needed for the builtin
transports, so we make the explicit initialization of them
deprecated, and document it as such.
