### PR TITLE
Remove separate protocol initialization step.

### DIFF
--- a/src/core/init.c
+++ b/src/core/init.c
@@ -47,7 +47,6 @@ nni_init_helper(void)
 	    ((rv = nni_dialer_sys_init()) != 0) ||
 	    ((rv = nni_pipe_sys_init()) != 0) ||
 	    ((rv = nni_tls_sys_init()) != 0) ||
-	    ((rv = nni_proto_sys_init()) != 0) ||
 	    ((rv = nni_sp_tran_sys_init()) != 0)) {
 		nni_fini();
 	}
@@ -81,7 +80,6 @@ nni_fini(void)
 		nni_mtx_unlock(&nni_init_mtx);
 	}
 	nni_sp_tran_sys_fini();
-	nni_proto_sys_fini();
 	nni_tls_sys_fini();
 	nni_pipe_sys_fini();
 	nni_dialer_sys_fini();

--- a/src/core/protocol.c
+++ b/src/core/protocol.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -12,87 +12,20 @@
 
 #include "core/nng_impl.h"
 
-// Protocol related stuff - generically.
-typedef struct nni_protocol nni_protocol;
-struct nni_protocol {
-	const nni_proto *p_proto;
-	nni_list_node    p_link;
-};
-
-static nni_mtx  nni_proto_lk;
-static nni_list nni_proto_list;
-static int      nni_proto_inited = 0;
-
-static int
-nni_proto_init(const nni_proto *proto)
-{
-	nni_protocol *p;
-	int           rv;
-
-	nni_mtx_lock(&nni_proto_lk);
-	NNI_LIST_FOREACH (&nni_proto_list, p) {
-		if (p->p_proto == proto) {
-			nni_mtx_unlock(&nni_proto_lk);
-			return (0);
-		}
-	}
-	if ((p = NNI_ALLOC_STRUCT(p)) == NULL) {
-		nni_mtx_unlock(&nni_proto_lk);
-		return (NNG_ENOMEM);
-	}
-	NNI_LIST_NODE_INIT(&p->p_link);
-	p->p_proto = proto;
-	if ((proto->proto_init != NULL) && ((rv = proto->proto_init()) != 0)) {
-		NNI_FREE_STRUCT(p);
-		nni_mtx_unlock(&nni_proto_lk);
-		return (rv);
-	}
-	nni_list_append(&nni_proto_list, p);
-	nni_mtx_unlock(&nni_proto_lk);
-	return (0);
-}
 
 int
-nni_proto_open(nng_socket *sockidp, const nni_proto *proto)
+nni_proto_open(nng_socket *sip, const nni_proto *proto)
 {
 	int       rv;
 	nni_sock *sock;
 
-	if (((rv = nni_init()) != 0) || ((rv = nni_proto_init(proto)) != 0)) {
+	if ((rv = nni_init()) != 0) {
 		return (rv);
 	}
 	if ((rv = nni_sock_open(&sock, proto)) == 0) {
 		nng_socket s;
 		s.id     = nni_sock_id(sock); // Keep socket held open.
-		*sockidp = s;
+		*sip     = s;
 	}
 	return (rv);
-}
-
-int
-nni_proto_sys_init(void)
-{
-	NNI_LIST_INIT(&nni_proto_list, nni_protocol, p_link);
-	nni_mtx_init(&nni_proto_lk);
-	nni_proto_inited = 1;
-	return (0);
-}
-
-void
-nni_proto_sys_fini(void)
-{
-	if (nni_proto_inited) {
-		nni_protocol *p;
-		nni_mtx_lock(&nni_proto_lk);
-		while ((p = nni_list_first(&nni_proto_list)) != NULL) {
-			nni_list_remove(&nni_proto_list, p);
-			if (p->p_proto->proto_fini != NULL) {
-				p->p_proto->proto_fini();
-			}
-			NNI_FREE_STRUCT(p);
-		}
-		nni_mtx_unlock(&nni_proto_lk);
-	}
-	nni_proto_inited = 0;
-	nni_mtx_fini(&nni_proto_lk);
 }

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -52,7 +52,7 @@ struct nni_proto_pipe_ops {
 	// pipe_stop is called during finalization, to ensure that
 	// the protocol is absolutely finished with the pipe.  It should
 	// wait if necessary to ensure that the pipe is not referenced
-	// anymore by the protocol.  It should not destroy resources.
+	// any more by the protocol.  It should not destroy resources.
 	void (*pipe_stop)(void *);
 };
 
@@ -125,15 +125,6 @@ struct nni_proto {
 	const nni_proto_sock_ops *proto_sock_ops; // Per-socket operations
 	const nni_proto_pipe_ops *proto_pipe_ops; // Per-pipe operations
 	const nni_proto_ctx_ops * proto_ctx_ops;  // Context operations
-
-	// proto_init, if not NULL, provides a function that initializes
-	// global values.  The main purpose of this may be to initialize
-	// protocol option values.
-	int (*proto_init)(void);
-
-	// proto_fini, if not NULL, is called at shutdown, to release
-	// any resources allocated at proto_init time.
-	void (*proto_fini)(void);
 };
 
 // We quite intentionally use a signature where the upper word is nonzero,
@@ -144,8 +135,8 @@ struct nni_proto {
 // during the life of the project.  If we add a new version, please keep
 // the old version around -- it may be possible to automatically convert
 // older versions in the future.
-#define NNI_PROTOCOL_V2 0x50520002u // "pr\0\2"
-#define NNI_PROTOCOL_VERSION NNI_PROTOCOL_V2
+#define NNI_PROTOCOL_V3 0x50520003u // "pr\0\3"
+#define NNI_PROTOCOL_VERSION NNI_PROTOCOL_V3
 
 // These flags determine which operations make sense.  We use them so that
 // we can reject attempts to create notification fds for operations that make
@@ -193,8 +184,5 @@ extern int nni_proto_open(nng_socket *, const nni_proto *);
 // BUSv0         7   0  bus
 // STARv0      100   0  star       mangos only, experimental
 //
-
-extern int  nni_proto_sys_init(void);
-extern void nni_proto_sys_fini(void);
 
 #endif // CORE_PROTOCOL_H


### PR DESCRIPTION
Nothing is using this, but it adds complexity and also requires
additional lock activity each time a socket is opened.
