### PR TITLE
Use env shebangs everywhere

### DIFF
--- a/demo/async/run.sh
+++ b/demo/async/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ADDR=ipc:///tmp/async_demo
 COUNT=10

--- a/etc/codecov.sh
+++ b/etc/codecov.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 Garrett D'Amore <garrett@damore.org>
 # Copyright 2017 Capitar IT Group BV <info@capitar.com>

--- a/etc/coverage.sh
+++ b/etc/coverage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2017 Garrett D'Amore <garrett@damore.org>
 # Copyright 2017 Capitar IT Group BV <info@capitar.com>

--- a/etc/format-check.sh
+++ b/etc/format-check.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 #
 # Copyright 2016 Garrett D'Amore <garrett@damore.org>
 #

--- a/src/tools/nngcat/nngcat_ambiguous_test.sh
+++ b/src/tools/nngcat/nngcat_ambiguous_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_async_test.sh
+++ b/src/tools/nngcat/nngcat_async_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_dup_proto_test.sh
+++ b/src/tools/nngcat/nngcat_dup_proto_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_help_test.sh
+++ b/src/tools/nngcat/nngcat_help_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_incompat_test.sh
+++ b/src/tools/nngcat/nngcat_incompat_test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_pubsub_test.sh
+++ b/src/tools/nngcat/nngcat_pubsub_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_recvmaxsz_test.sh
+++ b/src/tools/nngcat/nngcat_recvmaxsz_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_stdin_pipe_test.sh
+++ b/src/tools/nngcat/nngcat_stdin_pipe_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>

--- a/src/tools/nngcat/nngcat_unlimited_test.sh
+++ b/src/tools/nngcat/nngcat_unlimited_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>


### PR DESCRIPTION
Change all shebangs to use '#!/usr/bin/env bash'.
This increases portability to platforms which do not cohere to the FHS.

---
I am using NixOS as my development platform where "normal" shebangs do not work.
I don't know if using "env shebangs" lead to problems on other platforms, so feel free to close if this patch leads
to problems elsewhere.