### PR TITLE
fix building with PAIR and PUBSUB disabled

### DIFF
--- a/src/tools/perf/perf.c
+++ b/src/tools/perf/perf.c
@@ -45,6 +45,10 @@ static open_func open_client = no_open;
 #define nng_pair0_open no_open
 #endif
 
+#if !defined(NNG_HAVE_PAIR0) && !defined(NNG_HAVE_PAIR1)
+#define nng_pair_open no_open
+#endif
+
 #if defined(NNG_HAVE_REQ0)
 #include <nng/protocol/reqrep0/req.h>
 #else

--- a/src/tools/perf/pubdrop.c
+++ b/src/tools/perf/pubdrop.c
@@ -27,6 +27,8 @@
 
 #else
 
+#define NNG_OPT_SUB_SUBSCRIBE "sub:subscribe"
+
 static void die(const char *, ...);
 
 static int


### PR DESCRIPTION
When building with PAIR and PUBSUB protocols disabled, the perf tools fail to compile.

This makes some minor tweaks to correct that