### PR TITLE
Provide atomic pointer support.

### DIFF
--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -232,6 +232,11 @@ extern void nni_atomic_inc(nni_atomic_int *);
 // true if the value was set.
 extern bool nni_atomic_cas(nni_atomic_int *, int, int);
 
+// atomic pointers.  We only support a few operations.
+typedef struct nni_atomic_ptr nni_atomic_ptr;
+extern void nni_atomic_set_ptr(nni_atomic_ptr *, void *);
+extern void *nni_atomic_get_ptr(nni_atomic_ptr *);
+
 //
 // Clock Support
 //

--- a/src/platform/posix/posix_atomic.c
+++ b/src/platform/posix/posix_atomic.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -81,7 +81,19 @@ nni_atomic_get(nni_atomic_int *v)
 void
 nni_atomic_set(nni_atomic_int *v, int i)
 {
-	return (atomic_store(&v->v, i));
+	 atomic_store(&v->v, i);
+}
+
+void *
+nni_atomic_get_ptr(nni_atomic_ptr *v)
+{
+	return ((void *) atomic_load(&v->v));
+}
+
+void
+nni_atomic_set_ptr(nni_atomic_ptr *v, void *p)
+{
+	atomic_store(&v->v, (uintptr_t) p);
 }
 
 int
@@ -360,6 +372,24 @@ nni_atomic_set(nni_atomic_int *v, int i)
 {
 	pthread_mutex_lock(&plat_atomic_lock);
 	v->v = i;
+	pthread_mutex_unlock(&plat_atomic_lock);
+}
+
+void *
+nni_atomic_get_ptr(nni_atomic_atomic *v)
+{
+	void *p;
+	pthread_mutex_lock(&plat_atomic_lock);
+	p = v->v;
+	pthread_mutex_unlock(&plat_atomic_lock);
+	return (p);
+}
+
+void
+nni_atomic_set_ptr(nni_atomic_atomic *v, void *p)
+{
+	pthread_mutex_lock(&plat_atomic_lock);
+	v->v = p;
 	pthread_mutex_unlock(&plat_atomic_lock);
 }
 

--- a/src/platform/posix/posix_impl.h
+++ b/src/platform/posix/posix_impl.h
@@ -64,7 +64,7 @@ struct nni_rwlock {
 
 struct nni_plat_cv {
 	pthread_cond_t cv;
-	nni_plat_mtx * mtx;
+	nni_plat_mtx  *mtx;
 };
 
 struct nni_plat_thr {
@@ -99,6 +99,10 @@ struct nni_atomic_bool {
 	atomic_bool v;
 };
 
+struct nni_atomic_ptr {
+	atomic_uintptr_t v;
+};
+
 #else // NNG_HAVE_C11_ATOMIC
 struct nni_atomic_flag {
 	bool f;
@@ -114,6 +118,10 @@ struct nni_atomic_int {
 
 struct nni_atomic_u64 {
 	uint64_t v;
+};
+
+struct nni_atomic_ptr {
+	void *v;
 };
 
 #endif

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2018 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -64,6 +64,10 @@ struct nni_atomic_int {
 };
 
 struct nni_atomic_u64 {
+	LONGLONG v;
+};
+
+struct nni_atomic_ptr {
 	LONGLONG v;
 };
 

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -223,6 +223,18 @@ nni_atomic_set64(nni_atomic_u64 *v, uint64_t u)
 	(void) InterlockedExchange64(&v->v, (LONGLONG) u);
 }
 
+void *
+nni_atomic_get_ptr(nni_atomic_ptr *v)
+{
+	return ((void *) (InterlockedExchangeAdd64(&v->v, 0)));
+}
+
+void
+nni_atomic_set_ptr(nni_atomic_ptr *v)
+{
+	(void) InterlockedExchange64(&v->v, (LONGLONG) (uintptr_t) v);
+}
+
 uint64_t
 nni_atomic_swap64(nni_atomic_u64 *v, uint64_t u)
 {


### PR DESCRIPTION
This is initially used for TLS to make loading the engine pointer
faster, eliminating a much more expensive lock operation.
