### PR TITLE
Fixes compiling on windows 32-bit

### DIFF
--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -52,7 +52,7 @@ struct nni_plat_cv {
 };
 
 struct nni_atomic_flag {
-	unsigned f;
+	LONG f;
 };
 
 struct nni_atomic_bool {

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -182,7 +182,7 @@ nni_atomic_set_bool(nni_atomic_bool *v, bool b)
 bool
 nni_atomic_get_bool(nni_atomic_bool *v)
 {
-	return ((bool) InterlockedAdd(&v->v, 0));
+	return ((bool) InterlockedExchangeAdd(&v->v, 0));
 }
 
 bool


### PR DESCRIPTION
- Use correct datatype for one nni_atomic_flag (that hadn't been changed to LONG)
   - resolves a compiler warning
- Use InterlockedExchangeAdd instead of InterlockedAdd (which isn't implemented on 32-bit windows)