### PR TITLE
Remove remaining references to nng_getopt_ptr

### DIFF
--- a/docs/man/nng_getopt.3.adoc
+++ b/docs/man/nng_getopt.3.adoc
@@ -27,8 +27,6 @@ int nng_getopt_int(nng_socket s, const char *opt, int *ivalp);
 
 int nng_getopt_ms(nng_socket s, const char *opt, nng_duration *durp);
 
-int nng_getopt_ptr(nng_socket s, const char *opt, void **ptr);
-
 int nng_getopt_size(nng_socket s, const char *opt, size_t *zp);
 
 int nng_getopt_string(nng_socket s, const char *opt, char **strp);
@@ -92,12 +90,6 @@ This function is used to retrieve time xref:nng_duration.5.adoc[durations]
 (such as timeouts), stored in _durp_ as a number of milliseconds.
 (The special value ((`NNG_DUR_INFINITE`)) means an infinite amount of time, and
 the special value ((`NNG_DUR_DEFAULT`)) means a context-specific default.)
-
-`nng_getopt_ptr()`::
-This function is used to retrieve a pointer, _ptr_, to structured data.
-The data referenced by _ptr_ is generally managed using other functions.
-Note that this form is somewhat special in that the object is generally
-not copied, but instead the *pointer* to the object is copied.
 
 `nng_getopt_size()`::
 This function is used to retrieve a size into the pointer _zp_,

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1205,7 +1205,6 @@ NNG_DECL int nng_getopt_int(nng_socket, const char *, int *);
 NNG_DECL int nng_getopt_ms(nng_socket, const char *, nng_duration *);
 NNG_DECL int nng_getopt_size(nng_socket, const char *, size_t *);
 NNG_DECL int nng_getopt_uint64(nng_socket, const char *, uint64_t *);
-NNG_DECL int nng_getopt_ptr(nng_socket, const char *, void **);
 NNG_DECL int nng_getopt_string(nng_socket, const char *, char **);
 NNG_DECL int nng_setopt(nng_socket, const char *, const void *, size_t);
 NNG_DECL int nng_setopt_bool(nng_socket, const char *, bool);


### PR DESCRIPTION
nng_getopt_ptr got removed/reworked in commit 249932f3a208260f6b9c99d778
[fixes #1071 tran_chkopt can be cleaned up] and since then, had a
declaration but no definition.