### PR TITLE
fixes #1552 Several warnings compiling in Windows with Visual Studio …

### DIFF
--- a/src/core/idhash.c
+++ b/src/core/idhash.c
@@ -157,10 +157,10 @@ nni_id_map_sys_fini(void)
 static int
 id_resize(nni_id_map *m)
 {
-	size_t        new_cap;
-	size_t        old_cap;
 	nni_id_entry *new_entries;
 	nni_id_entry *old_entries;
+	uint32_t      new_cap;
+	uint32_t      old_cap;
 	uint32_t      i;
 	int           rv;
 

--- a/src/platform/windows/win_impl.h
+++ b/src/platform/windows/win_impl.h
@@ -30,7 +30,7 @@
 
 struct nni_plat_thr {
 	void (*func)(void *);
-	void * arg;
+	void  *arg;
 	HANDLE handle;
 	DWORD  id;
 };
@@ -39,21 +39,30 @@ struct nni_plat_mtx {
 	SRWLOCK srl;
 };
 
-#define NNI_MTX_INITIALIZER { SRWLOCK_INIT }
+#define NNI_MTX_INITIALIZER  \
+	{                    \
+		SRWLOCK_INIT \
+	}
 
 struct nni_rwlock {
 	SRWLOCK rwl;
 	BOOLEAN exclusive;
 };
 
-#define NNI_RWLOCK_INITIALIZER { SRWLOCK_INIT }
+#define NNI_RWLOCK_INITIALIZER \
+	{                      \
+		SRWLOCK_INIT   \
+	}
 
 struct nni_plat_cv {
 	CONDITION_VARIABLE cv;
 	PSRWLOCK           srl;
 };
 
-#define NNI_CV_INITIALIZER(mxp) { .srl = mxp, .cv = CONDITION_VARIABLE_INIT }
+#define NNI_CV_INITIALIZER(mxp)                                    \
+	{                                                          \
+		.srl = (void *) mxp, .cv = CONDITION_VARIABLE_INIT \
+	}
 
 struct nni_atomic_flag {
 	LONG f;
@@ -85,8 +94,8 @@ typedef void (*nni_win_io_cb)(nni_win_io *, int, size_t);
 struct nni_win_io {
 	OVERLAPPED    olpd;
 	HANDLE        f;
-	void *        ptr;
-	nni_aio *     aio;
+	void         *ptr;
+	nni_aio      *aio;
 	nni_win_io_cb cb;
 };
 

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -228,9 +228,9 @@ nni_atomic_get_ptr(nni_atomic_ptr *v)
 }
 
 void
-nni_atomic_set_ptr(nni_atomic_ptr *v)
+nni_atomic_set_ptr(nni_atomic_ptr *v, void *p)
 {
-	(void) InterlockedExchange64(&v->v, (LONGLONG) (uintptr_t) v);
+	(void) InterlockedExchange64(&v->v, (LONGLONG) (uintptr_t) p);
 }
 
 uint64_t


### PR DESCRIPTION
…2019

Note that one of these warning is a real bug that would prevent
TLS from functioning properly on Windows.
