### PR TITLE
Feat cleanup deprecated usage in tests

### DIFF
--- a/src/core/message_test.c
+++ b/src/core/message_test.c
@@ -19,7 +19,6 @@ test_msg_option(void)
 {
 	nng_msg *msg;
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
-	NUTS_FAIL(nng_msg_getopt(msg, 0, NULL, NULL), NNG_ENOTSUP);
 	nng_msg_free(msg);
 }
 

--- a/src/core/sock_test.c
+++ b/src/core/sock_test.c
@@ -161,7 +161,7 @@ test_socket_name_oversize(void)
 	NUTS_PASS(nng_socket_set(s1, NNG_OPT_SOCKNAME, name, sz));
 	sz = sizeof(name);
 	memset(name, 'B', sz);
-	NUTS_PASS(nng_getopt(s1, NNG_OPT_SOCKNAME, name, &sz));
+	NUTS_PASS(nng_socket_get(s1, NNG_OPT_SOCKNAME, name, &sz));
 	NUTS_TRUE(sz == 6);
 	NUTS_MATCH(name, "hello");
 	NUTS_CLOSE(s1);
@@ -222,7 +222,7 @@ test_send_recv_zero_length(void)
 	NUTS_OPEN(s2);
 
 	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_getopt_int(s1, NNG_OPT_RECVBUF, &len));
+	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_RECVBUF, &len));
 	NUTS_TRUE(len == 1);
 
 	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_SENDBUF, 1));

--- a/src/sp/protocol/bus0/bus_test.c
+++ b/src/sp/protocol/bus0/bus_test.c
@@ -43,9 +43,9 @@ test_bus_star(void)
 	NUTS_PASS(nng_bus0_open(&s2));
 	NUTS_PASS(nng_bus0_open(&s3));
 
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(s3, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s3, NNG_OPT_RECVTIMEO, SECOND));
 
 	NUTS_MARRY(s1, s2);
 	NUTS_MARRY(s1, s3);
@@ -77,9 +77,9 @@ test_bus_device(void)
 	NUTS_PASS(nng_bus0_open(&s3));
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
 
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(s3, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s3, NNG_OPT_RECVTIMEO, SECOND));
 
 	NUTS_MARRY(s1, s2);
 	NUTS_MARRY(s1, s3);

--- a/src/sp/protocol/pair0/pair0_test.c
+++ b/src/sp/protocol/pair0/pair0_test.c
@@ -81,10 +81,10 @@ test_faithful(void)
 	NUTS_PASS(nng_pair0_open(&s1));
 	NUTS_PASS(nng_pair0_open(&c1));
 	NUTS_PASS(nng_pair0_open(&c2));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 4));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_int(c2, NNG_OPT_SENDBUF, 2));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 4));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_int(c2, NNG_OPT_SENDBUF, 2));
 
 	NUTS_PASS(nng_listen(s1, addr, NULL, 0));
 	NUTS_MARRY(s1, c1);
@@ -121,10 +121,10 @@ test_back_pressure(void)
 
 	NUTS_PASS(nng_pair0_open(&s1));
 	NUTS_PASS(nng_pair0_open(&c1));
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(c1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, to));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(c1, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, to));
 
 	NUTS_MARRY(s1, c1);
 
@@ -151,7 +151,7 @@ test_send_no_peer(void)
 	nng_duration to = 100;
 
 	NUTS_PASS(nng_pair0_open(&s1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, to));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, to));
 
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_FAIL(nng_sendmsg(s1, msg, 0), NNG_ETIMEDOUT);
@@ -170,8 +170,8 @@ test_raw_exchange(void)
 	NUTS_PASS(nng_pair0_open_raw(&s1));
 	NUTS_PASS(nng_pair0_open_raw(&c1));
 
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_RECVTIMEO, SECOND));
 	NUTS_MARRY(s1, c1);
 
 	nng_pipe p = NNG_PIPE_INITIALIZER;
@@ -226,15 +226,15 @@ test_pair0_raw(void)
 	bool       raw;
 
 	NUTS_PASS(nng_pair0_open(&s1));
-	NUTS_PASS(nng_getopt_bool(s1, NNG_OPT_RAW, &raw));
+	NUTS_PASS(nng_socket_get_bool(s1, NNG_OPT_RAW, &raw));
 	NUTS_TRUE(raw == false);
-	NUTS_FAIL(nng_setopt_bool(s1, NNG_OPT_RAW, true), NNG_EREADONLY);
+	NUTS_FAIL(nng_socket_set_bool(s1, NNG_OPT_RAW, true), NNG_EREADONLY);
 	NUTS_PASS(nng_close(s1));
 
 	NUTS_PASS(nng_pair0_open_raw(&s1));
-	NUTS_PASS(nng_getopt_bool(s1, NNG_OPT_RAW, &raw));
+	NUTS_PASS(nng_socket_get_bool(s1, NNG_OPT_RAW, &raw));
 	NUTS_TRUE(raw == true);
-	NUTS_FAIL(nng_setopt_bool(s1, NNG_OPT_RAW, false), NNG_EREADONLY);
+	NUTS_FAIL(nng_socket_set_bool(s1, NNG_OPT_RAW, false), NNG_EREADONLY);
 	NUTS_PASS(nng_close(s1));
 }
 
@@ -288,17 +288,17 @@ test_pair0_send_buffer(void)
 	size_t     sz;
 
 	NUTS_PASS(nng_pair0_open(&s));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_SENDBUF, &v));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_SENDBUF, &v));
 	NUTS_TRUE(v == 0);
-	NUTS_FAIL(nng_getopt_bool(s, NNG_OPT_SENDBUF, &b), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_get_bool(s, NNG_OPT_SENDBUF, &b), NNG_EBADTYPE);
 	sz = 1;
-	NUTS_FAIL(nng_getopt(s, NNG_OPT_SENDBUF, &b, &sz), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_SENDBUF, -1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_SENDBUF, 100000), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s, NNG_OPT_SENDBUF, false), NNG_EBADTYPE);
-	NUTS_FAIL(nng_setopt(s, NNG_OPT_SENDBUF, &b, 1), NNG_EINVAL);
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_SENDBUF, 100));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_SENDBUF, &v));
+	NUTS_FAIL(nng_socket_get(s, NNG_OPT_SENDBUF, &b, &sz), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_SENDBUF, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_SENDBUF, 100000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s, NNG_OPT_SENDBUF, false), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s, NNG_OPT_SENDBUF, &b, 1), NNG_EINVAL);
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_SENDBUF, 100));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_SENDBUF, &v));
 	NUTS_TRUE(v == 100);
 	NUTS_CLOSE(s);
 }
@@ -312,17 +312,17 @@ test_pair0_recv_buffer(void)
 	size_t     sz;
 
 	NUTS_PASS(nng_pair0_open(&s));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_RECVBUF, &v));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_RECVBUF, &v));
 	NUTS_TRUE(v == 0);
-	NUTS_FAIL(nng_getopt_bool(s, NNG_OPT_RECVBUF, &b), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_get_bool(s, NNG_OPT_RECVBUF, &b), NNG_EBADTYPE);
 	sz = 1;
-	NUTS_FAIL(nng_getopt(s, NNG_OPT_RECVBUF, &b, &sz), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_RECVBUF, -1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_RECVBUF, 100000), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s, NNG_OPT_RECVBUF, false), NNG_EBADTYPE);
-	NUTS_FAIL(nng_setopt(s, NNG_OPT_RECVBUF, &b, 1), NNG_EINVAL);
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_RECVBUF, 100));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_RECVBUF, &v));
+	NUTS_FAIL(nng_socket_get(s, NNG_OPT_RECVBUF, &b, &sz), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_RECVBUF, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_RECVBUF, 100000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s, NNG_OPT_RECVBUF, false), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s, NNG_OPT_RECVBUF, &b, 1), NNG_EINVAL);
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_RECVBUF, 100));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_RECVBUF, &v));
 	NUTS_TRUE(v == 100);
 	NUTS_CLOSE(s);
 }

--- a/src/sp/protocol/pair1/pair1_poly_test.c
+++ b/src/sp/protocol/pair1/pair1_poly_test.c
@@ -48,10 +48,10 @@ test_poly_best_effort(void)
 	NUTS_PASS(nng_pair1_open_poly(&s1));
 	NUTS_PASS(nng_pair1_open(&c1));
 
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(c1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(c1, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, SECOND));
 
 	NUTS_MARRY(s1, c1);
 
@@ -78,14 +78,14 @@ test_poly_cooked(void)
 	NUTS_PASS(nng_pair1_open_poly(&s1));
 	NUTS_PASS(nng_pair1_open(&c1));
 	NUTS_PASS(nng_pair1_open(&c2));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 10));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 10));
-	NUTS_PASS(nng_setopt_ms(c2, NNG_OPT_RECVTIMEO, SECOND / 10));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 10));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 10));
+	NUTS_PASS(nng_socket_set_ms(c2, NNG_OPT_RECVTIMEO, SECOND / 10));
 
-	NUTS_PASS(nng_getopt_bool(s1, NNG_OPT_PAIR1_POLY, &v));
+	NUTS_PASS(nng_socket_get_bool(s1, NNG_OPT_PAIR1_POLY, &v));
 	NUTS_TRUE(v);
 
 	NUTS_MARRY(s1, c1);
@@ -151,9 +151,9 @@ test_poly_default(void)
 	NUTS_PASS(nng_pair1_open_poly(&s1));
 	NUTS_PASS(nng_pair1_open(&c1));
 	NUTS_PASS(nng_pair1_open(&c2));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
 
 	NUTS_MARRY(s1, c1);
 	NUTS_MARRY(s1, c2);
@@ -190,10 +190,10 @@ test_poly_close_abort(void)
 
 	NUTS_PASS(nng_pair1_open_poly(&s));
 	NUTS_PASS(nng_pair1_open(&c));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_SENDTIMEO, 200));
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_int(c, NNG_OPT_SENDBUF, 20));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_int(c, NNG_OPT_SENDBUF, 20));
 
 	NUTS_MARRY(c, s);
 
@@ -215,9 +215,9 @@ test_poly_recv_no_header(void)
 
 	NUTS_PASS(nng_pair1_open_poly(&s));
 	NUTS_PASS(nng_pair1_open(&c));
-	NUTS_PASS(nng_setopt_bool(c, "pair1_test_inject_header", true));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_bool(c, "pair1_test_inject_header", true));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_SENDTIMEO, 200));
 
 	NUTS_MARRY(c, s);
 
@@ -238,9 +238,9 @@ test_poly_recv_garbage(void)
 
 	NUTS_PASS(nng_pair1_open_poly(&s));
 	NUTS_PASS(nng_pair1_open(&c));
-	NUTS_PASS(nng_setopt_bool(c, "pair1_test_inject_header", true));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_bool(c, "pair1_test_inject_header", true));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_SENDTIMEO, 200));
 
 	NUTS_MARRY(c, s);
 
@@ -265,21 +265,21 @@ test_poly_ttl(void)
 
 	NUTS_PASS(nng_pair1_open_poly(&s1));
 	NUTS_PASS(nng_pair1_open_raw(&c1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 5));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 5));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 5));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 5));
 
 	// cannot set insane TTLs
-	NUTS_FAIL(nng_setopt_int(s1, NNG_OPT_MAXTTL, 0), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s1, NNG_OPT_MAXTTL, 1000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 0), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 1000), NNG_EINVAL);
 	ttl = 8;
-	NUTS_FAIL(nng_setopt(s1, NNG_OPT_MAXTTL, &ttl, 1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s1, NNG_OPT_MAXTTL, true), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s1, NNG_OPT_MAXTTL, &ttl, 1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s1, NNG_OPT_MAXTTL, true), NNG_EBADTYPE);
 
 	NUTS_MARRY(s1, c1);
 
 	// Let's check enforcement of TTL
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_MAXTTL, 4));
-	NUTS_PASS(nng_getopt_int(s1, NNG_OPT_MAXTTL, &ttl));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 4));
+	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_MAXTTL, &ttl));
 	NUTS_TRUE(ttl == 4);
 
 	// Bad TTL bounces
@@ -301,7 +301,7 @@ test_poly_ttl(void)
 	nng_msg_free(msg);
 
 	// Large TTL passes
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_MAXTTL, 15));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 15));
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_PASS(nng_msg_append_u32(msg, 1234));
 	NUTS_PASS(nng_msg_header_append_u32(msg, 14));
@@ -314,7 +314,7 @@ test_poly_ttl(void)
 	nng_msg_free(msg);
 
 	// Max TTL fails
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_MAXTTL, 15));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 15));
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_PASS(nng_msg_header_append_u32(msg, 15));
 	NUTS_PASS(nng_sendmsg(c1, msg, 0));

--- a/src/sp/protocol/pair1/pair1_test.c
+++ b/src/sp/protocol/pair1/pair1_test.c
@@ -81,10 +81,10 @@ test_mono_faithful(void)
 	NUTS_PASS(nng_pair1_open(&s1));
 	NUTS_PASS(nng_pair1_open(&c1));
 	NUTS_PASS(nng_pair1_open(&c2));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 4));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_int(c2, NNG_OPT_SENDBUF, 2));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 4));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c2, NNG_OPT_SENDTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_int(c2, NNG_OPT_SENDBUF, 2));
 
 	NUTS_PASS(nng_listen(s1, addr, NULL, 0));
 	NUTS_MARRY(s1, c1);
@@ -121,10 +121,10 @@ test_mono_back_pressure(void)
 
 	NUTS_PASS(nng_pair1_open(&s1));
 	NUTS_PASS(nng_pair1_open(&c1));
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(c1, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, to));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(c1, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, to));
 
 	NUTS_MARRY(s1, c1);
 
@@ -151,7 +151,7 @@ test_send_no_peer(void)
 	nng_duration to = 100;
 
 	NUTS_PASS(nng_pair1_open(&s1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, to));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, to));
 
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_FAIL(nng_sendmsg(s1, msg, 0), NNG_ETIMEDOUT);
@@ -171,8 +171,8 @@ test_mono_raw_exchange(void)
 	NUTS_PASS(nng_pair1_open_raw(&s1));
 	NUTS_PASS(nng_pair1_open_raw(&c1));
 
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_RECVTIMEO, SECOND));
 	NUTS_MARRY(s1, c1);
 
 	nng_pipe p = NNG_PIPE_INITIALIZER;
@@ -220,8 +220,8 @@ test_mono_raw_header(void)
 	NUTS_PASS(nng_pair1_open_raw(&s1));
 	NUTS_PASS(nng_pair1_open_raw(&c1));
 
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 5));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 5));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 5));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 5));
 	NUTS_MARRY(s1, c1);
 
 	// Missing bits in the header
@@ -292,15 +292,15 @@ test_pair1_raw(void)
 	bool       raw;
 
 	NUTS_PASS(nng_pair1_open(&s1));
-	NUTS_PASS(nng_getopt_bool(s1, NNG_OPT_RAW, &raw));
+	NUTS_PASS(nng_socket_get_bool(s1, NNG_OPT_RAW, &raw));
 	NUTS_TRUE(raw == false);
-	NUTS_FAIL(nng_setopt_bool(s1, NNG_OPT_RAW, true), NNG_EREADONLY);
+	NUTS_FAIL(nng_socket_set_bool(s1, NNG_OPT_RAW, true), NNG_EREADONLY);
 	NUTS_PASS(nng_close(s1));
 
 	NUTS_PASS(nng_pair1_open_raw(&s1));
-	NUTS_PASS(nng_getopt_bool(s1, NNG_OPT_RAW, &raw));
+	NUTS_PASS(nng_socket_get_bool(s1, NNG_OPT_RAW, &raw));
 	NUTS_TRUE(raw == true);
-	NUTS_FAIL(nng_setopt_bool(s1, NNG_OPT_RAW, false), NNG_EREADONLY);
+	NUTS_FAIL(nng_socket_set_bool(s1, NNG_OPT_RAW, false), NNG_EREADONLY);
 	NUTS_PASS(nng_close(s1));
 }
 
@@ -315,21 +315,21 @@ test_pair1_ttl(void)
 
 	NUTS_PASS(nng_pair1_open_raw(&s1));
 	NUTS_PASS(nng_pair1_open_raw(&c1));
-	NUTS_PASS(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 5));
-	NUTS_PASS(nng_setopt_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 5));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, SECOND / 5));
+	NUTS_PASS(nng_socket_set_ms(c1, NNG_OPT_RECVTIMEO, SECOND / 5));
 
 	// cannot set insane TTLs
-	NUTS_FAIL(nng_setopt_int(s1, NNG_OPT_MAXTTL, 0), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s1, NNG_OPT_MAXTTL, 1000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 0), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 1000), NNG_EINVAL);
 	ttl = 8;
-	NUTS_FAIL(nng_setopt(s1, NNG_OPT_MAXTTL, &ttl, 1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s1, NNG_OPT_MAXTTL, true), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s1, NNG_OPT_MAXTTL, &ttl, 1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s1, NNG_OPT_MAXTTL, true), NNG_EBADTYPE);
 
 	NUTS_MARRY(s1, c1);
 
 	// Let's check enforcement of TTL
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_MAXTTL, 4));
-	NUTS_PASS(nng_getopt_int(s1, NNG_OPT_MAXTTL, &ttl));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 4));
+	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_MAXTTL, &ttl));
 	NUTS_TRUE(ttl == 4);
 
 	// Bad TTL bounces
@@ -351,7 +351,7 @@ test_pair1_ttl(void)
 	nng_msg_free(msg);
 
 	// Large TTL passes
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_MAXTTL, 15));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 15));
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_PASS(nng_msg_append_u32(msg, 1234));
 	NUTS_PASS(nng_msg_header_append_u32(msg, 14));
@@ -364,7 +364,7 @@ test_pair1_ttl(void)
 	nng_msg_free(msg);
 
 	// Max TTL fails
-	NUTS_PASS(nng_setopt_int(s1, NNG_OPT_MAXTTL, 15));
+	NUTS_PASS(nng_socket_set_int(s1, NNG_OPT_MAXTTL, 15));
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_PASS(nng_msg_header_append_u32(msg, 15));
 	NUTS_PASS(nng_sendmsg(c1, msg, 0));
@@ -413,9 +413,9 @@ test_pair1_recv_no_header(void)
 
 	NUTS_PASS(nng_pair1_open(&s));
 	NUTS_PASS(nng_pair1_open(&c));
-	NUTS_PASS(nng_setopt_bool(c, "pair1_test_inject_header", true));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_bool(c, "pair1_test_inject_header", true));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_SENDTIMEO, 200));
 
 	NUTS_MARRY(c, s);
 
@@ -436,9 +436,9 @@ test_pair1_recv_garbage(void)
 
 	NUTS_PASS(nng_pair1_open(&s));
 	NUTS_PASS(nng_pair1_open(&c));
-	NUTS_PASS(nng_setopt_bool(c, "pair1_test_inject_header", true));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_setopt_ms(s, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_bool(c, "pair1_test_inject_header", true));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s, NNG_OPT_SENDTIMEO, 200));
 
 	NUTS_MARRY(c, s);
 
@@ -472,17 +472,17 @@ test_pair1_send_buffer(void)
 	size_t     sz;
 
 	NUTS_PASS(nng_pair1_open(&s));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_SENDBUF, &v));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_SENDBUF, &v));
 	NUTS_TRUE(v == 0);
-	NUTS_FAIL(nng_getopt_bool(s, NNG_OPT_SENDBUF, &b), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_get_bool(s, NNG_OPT_SENDBUF, &b), NNG_EBADTYPE);
 	sz = 1;
-	NUTS_FAIL(nng_getopt(s, NNG_OPT_SENDBUF, &b, &sz), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_SENDBUF, -1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_SENDBUF, 100000), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s, NNG_OPT_SENDBUF, false), NNG_EBADTYPE);
-	NUTS_FAIL(nng_setopt(s, NNG_OPT_SENDBUF, &b, 1), NNG_EINVAL);
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_SENDBUF, 100));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_SENDBUF, &v));
+	NUTS_FAIL(nng_socket_get(s, NNG_OPT_SENDBUF, &b, &sz), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_SENDBUF, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_SENDBUF, 100000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s, NNG_OPT_SENDBUF, false), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s, NNG_OPT_SENDBUF, &b, 1), NNG_EINVAL);
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_SENDBUF, 100));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_SENDBUF, &v));
 	NUTS_TRUE(v == 100);
 	NUTS_CLOSE(s);
 }
@@ -496,17 +496,17 @@ test_pair1_recv_buffer(void)
 	size_t     sz;
 
 	NUTS_PASS(nng_pair1_open(&s));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_RECVBUF, &v));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_RECVBUF, &v));
 	NUTS_TRUE(v == 0);
-	NUTS_FAIL(nng_getopt_bool(s, NNG_OPT_RECVBUF, &b), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_get_bool(s, NNG_OPT_RECVBUF, &b), NNG_EBADTYPE);
 	sz = 1;
-	NUTS_FAIL(nng_getopt(s, NNG_OPT_RECVBUF, &b, &sz), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_RECVBUF, -1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_RECVBUF, 100000), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s, NNG_OPT_RECVBUF, false), NNG_EBADTYPE);
-	NUTS_FAIL(nng_setopt(s, NNG_OPT_RECVBUF, &b, 1), NNG_EINVAL);
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_RECVBUF, 100));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_RECVBUF, &v));
+	NUTS_FAIL(nng_socket_get(s, NNG_OPT_RECVBUF, &b, &sz), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_RECVBUF, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_RECVBUF, 100000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s, NNG_OPT_RECVBUF, false), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s, NNG_OPT_RECVBUF, &b, 1), NNG_EINVAL);
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_RECVBUF, 100));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_RECVBUF, &v));
 	NUTS_TRUE(v == 100);
 	NUTS_CLOSE(s);
 }

--- a/src/sp/protocol/pipeline0/push_test.c
+++ b/src/sp/protocol/pipeline0/push_test.c
@@ -387,7 +387,7 @@ test_push_send_late_buffered(void)
 	NUTS_PASS(nng_push0_open(&s));
 	NUTS_PASS(nng_pull0_open(&pull));
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_SENDBUF, 2));
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_SENDBUF, 2));
 	NUTS_PASS(nng_msg_alloc(&m, 0));
 	NUTS_PASS(nng_msg_append(m, "123\0", 4));
 
@@ -429,7 +429,7 @@ test_push_load_balance_buffered(void)
 	NUTS_PASS(nng_pull0_open(&pull1));
 	NUTS_PASS(nng_pull0_open(&pull2));
 	NUTS_PASS(nng_pull0_open(&pull3));
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_SENDBUF, 4));
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_SENDBUF, 4));
 	NUTS_MARRY(s, pull1);
 	NUTS_MARRY(s, pull2);
 	NUTS_MARRY(s, pull3);
@@ -486,17 +486,17 @@ test_push_send_buffer(void)
 	size_t     sz;
 
 	NUTS_PASS(nng_push0_open(&s));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_SENDBUF, &v));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_SENDBUF, &v));
 	NUTS_TRUE(v == 0);
-	NUTS_FAIL(nng_getopt_bool(s, NNG_OPT_SENDBUF, &b), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_get_bool(s, NNG_OPT_SENDBUF, &b), NNG_EBADTYPE);
 	sz = 1;
-	NUTS_FAIL(nng_getopt(s, NNG_OPT_SENDBUF, &b, &sz), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_SENDBUF, -1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(s, NNG_OPT_SENDBUF, 100000), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(s, NNG_OPT_SENDBUF, false), NNG_EBADTYPE);
-	NUTS_FAIL(nng_setopt(s, NNG_OPT_SENDBUF, &b, 1), NNG_EINVAL);
-	NUTS_PASS(nng_setopt_int(s, NNG_OPT_SENDBUF, 100));
-	NUTS_PASS(nng_getopt_int(s, NNG_OPT_SENDBUF, &v));
+	NUTS_FAIL(nng_socket_get(s, NNG_OPT_SENDBUF, &b, &sz), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_SENDBUF, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(s, NNG_OPT_SENDBUF, 100000), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_bool(s, NNG_OPT_SENDBUF, false), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set(s, NNG_OPT_SENDBUF, &b, 1), NNG_EINVAL);
+	NUTS_PASS(nng_socket_set_int(s, NNG_OPT_SENDBUF, 100));
+	NUTS_PASS(nng_socket_get_int(s, NNG_OPT_SENDBUF, &v));
 	NUTS_TRUE(v == 100);
 	NUTS_CLOSE(s);
 }

--- a/src/sp/protocol/reqrep0/req_test.c
+++ b/src/sp/protocol/reqrep0/req_test.c
@@ -669,8 +669,8 @@ test_req_ctx_no_poll(void)
 
 	NUTS_PASS(nng_req0_open(&req));
 	NUTS_PASS(nng_ctx_open(&ctx, req));
-	NUTS_FAIL(nng_ctx_getopt_int(ctx, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
-	NUTS_FAIL(nng_ctx_getopt_int(ctx, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
+	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
+	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
 	NUTS_PASS(nng_ctx_close(ctx));
 	NUTS_CLOSE(req);
 }

--- a/src/sp/protocol/survey0/respond_test.c
+++ b/src/sp/protocol/survey0/respond_test.c
@@ -196,9 +196,9 @@ test_resp_close_pipe_before_send(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 	NUTS_PASS(nng_surveyor0_open(&surv));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
 	NUTS_PASS(nng_aio_alloc(&aio1, NULL, NULL));
 
 	NUTS_MARRY(surv, resp);
@@ -227,13 +227,13 @@ test_resp_close_pipe_during_send(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 200));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_SENDBUF, 20));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_RECVBUF, 20));
-	NUTS_PASS(nng_setopt_int(surv, NNG_OPT_SENDBUF, 20));
-	NUTS_PASS(nng_setopt_int(surv, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_SENDBUF, 20));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_RECVBUF, 20));
+	NUTS_PASS(nng_socket_set_int(surv, NNG_OPT_SENDBUF, 20));
+	NUTS_PASS(nng_socket_set_int(surv, NNG_OPT_RECVBUF, 1));
 
 	NUTS_MARRY(surv, resp);
 
@@ -291,13 +291,13 @@ test_resp_close_pipe_context_send(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_int(surv, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(surv, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_int(surv, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(surv, NNG_OPT_RECVBUF, 1));
 	for (i = 0; i < 10; i++) {
 		NUTS_PASS(nng_ctx_open(&ctx[i], resp));
 		NUTS_PASS(nng_aio_alloc(&aio[i], NULL, NULL));
@@ -350,13 +350,13 @@ test_resp_close_context_send(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_RECVBUF, 1));
-	NUTS_PASS(nng_setopt_int(surv, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_setopt_int(surv, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_RECVBUF, 1));
+	NUTS_PASS(nng_socket_set_int(surv, NNG_OPT_SENDBUF, 1));
+	NUTS_PASS(nng_socket_set_int(surv, NNG_OPT_RECVBUF, 1));
 	for (i = 0; i < 10; i++) {
 		NUTS_PASS(nng_ctx_open(&ctx[i], resp));
 		NUTS_PASS(nng_aio_alloc(&aio[i], NULL, NULL));
@@ -425,9 +425,9 @@ test_resp_ctx_send_nonblock(void)
 
 	NUTS_PASS(nng_surveyor0_open(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 1000));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 1000));
 	NUTS_PASS(nng_ctx_open(&ctx, resp));
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
 	NUTS_MARRY(surv, resp);
@@ -459,9 +459,9 @@ test_resp_recv_garbage(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 200));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_SENDTIMEO, 200));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 200));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 200));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
 
 	NUTS_MARRY(surv, resp);
 
@@ -485,12 +485,12 @@ test_resp_ttl_option(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 
-	NUTS_PASS(nng_setopt_int(resp, opt, 1));
-	NUTS_FAIL(nng_setopt_int(resp, opt, 0), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(resp, opt, -1), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(resp, opt, 16), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_int(resp, opt, 256), NNG_EINVAL);
-	NUTS_PASS(nng_setopt_int(resp, opt, 3));
+	NUTS_PASS(nng_socket_set_int(resp, opt, 1));
+	NUTS_FAIL(nng_socket_set_int(resp, opt, 0), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(resp, opt, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(resp, opt, 16), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set_int(resp, opt, 256), NNG_EINVAL);
+	NUTS_PASS(nng_socket_set_int(resp, opt, 3));
 	NUTS_PASS(nng_socket_get_int(resp, opt, &v));
 	NUTS_TRUE(v == 3);
 	v  = 0;
@@ -499,10 +499,10 @@ test_resp_ttl_option(void)
 	NUTS_TRUE(v == 3);
 	NUTS_TRUE(sz == sizeof(v));
 
-	NUTS_FAIL(nng_setopt(resp, opt, "", 1), NNG_EINVAL);
+	NUTS_FAIL(nng_socket_set(resp, opt, "", 1), NNG_EINVAL);
 	sz = 1;
 	NUTS_FAIL(nng_socket_get(resp, opt, &v, &sz), NNG_EINVAL);
-	NUTS_FAIL(nng_setopt_bool(resp, opt, true), NNG_EBADTYPE);
+	NUTS_FAIL(nng_socket_set_bool(resp, opt, true), NNG_EBADTYPE);
 	NUTS_FAIL(nng_socket_get_bool(resp, opt, &b), NNG_EBADTYPE);
 
 	NUTS_CLOSE(resp);
@@ -517,9 +517,9 @@ test_resp_ttl_drop(void)
 
 	NUTS_PASS(nng_respondent0_open(&resp));
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
-	NUTS_PASS(nng_setopt_int(resp, NNG_OPT_MAXTTL, 3));
-	NUTS_PASS(nng_setopt_ms(resp, NNG_OPT_RECVTIMEO, 200));
-	NUTS_PASS(nng_setopt_ms(surv, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_int(resp, NNG_OPT_MAXTTL, 3));
+	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 200));
+	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_SENDTIMEO, 1000));
 
 	NUTS_MARRY(surv, resp);
 

--- a/tests/device.c
+++ b/tests/device.c
@@ -82,8 +82,8 @@ Main({
 			So(nng_dial(end2, addr2, NULL, 0) == 0);
 
 			tmo = SECOND(1);
-			So(nng_setopt_ms(end1, NNG_OPT_RECVTIMEO, tmo) == 0);
-			So(nng_setopt_ms(end2, NNG_OPT_RECVTIMEO, tmo) == 0);
+			So(nng_socket_set_ms(end1, NNG_OPT_RECVTIMEO, tmo) == 0);
+			So(nng_socket_set_ms(end2, NNG_OPT_RECVTIMEO, tmo) == 0);
 
 			nng_msleep(100);
 			Convey("Device can send and receive", {

--- a/tests/ipc.c
+++ b/tests/ipc.c
@@ -36,47 +36,47 @@ check_props(nng_msg *msg)
 
 	p = nng_msg_get_pipe(msg);
 	So(nng_pipe_id(p) > 0);
-	So(nng_pipe_getopt_sockaddr(p, NNG_OPT_LOCADDR, &la) == 0);
+	So(nng_pipe_get_addr(p, NNG_OPT_LOCADDR, &la) == 0);
 	So(la.s_family == NNG_AF_IPC);
 	// untyped
 	z = sizeof(nng_sockaddr);
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == 0);
 	So(z == sizeof(ra));
 	So(ra.s_family == NNG_AF_IPC);
 
-	So(nng_pipe_getopt_size(p, NNG_OPT_REMADDR, &z) == NNG_EBADTYPE);
+	So(nng_pipe_get_size(p, NNG_OPT_REMADDR, &z) == NNG_EBADTYPE);
 	z = 1;
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == NNG_EINVAL);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == NNG_EINVAL);
 
 #ifdef _WIN32
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_UID, &id) ==
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_UID, &id) ==
 	    NNG_ENOTSUP);
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_GID, &id) ==
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_GID, &id) ==
 	    NNG_ENOTSUP);
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_ZONEID, &id) ==
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_ZONEID, &id) ==
 	    NNG_ENOTSUP);
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_PID, &id) == 0);
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_PID, &id) == 0);
 	So(id == GetCurrentProcessId());
 #else
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_UID, &id) == 0);
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_UID, &id) == 0);
 	So(id == (uint64_t) getuid());
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_GID, &id) == 0);
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_GID, &id) == 0);
 	So(id == (uint64_t) getgid());
 
 #if defined(NNG_HAVE_SOPEERCRED) || defined(NNG_HAVE_GETPEERUCRED) || \
     (defined(NNG_HAVE_LOCALPEERCRED) && defined(NNG_HAVE_LOCALPEERPID))
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_PID, &id) == 0);
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_PID, &id) == 0);
 	So(id == (uint64_t) getpid());
 #else
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_PID, &id) ==
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_PID, &id) ==
 	    NNG_ENOTSUP);
 #endif
 
 #ifdef NNG_HAVE_GETPEERUCRED
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_ZONEID, &id) == 0);
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_ZONEID, &id) == 0);
 	So(id == (uint64_t) getzoneid());
 #else
-	So(nng_pipe_getopt_uint64(p, NNG_OPT_IPC_PEER_ZONEID, &id) ==
+	So(nng_pipe_get_uint64(p, NNG_OPT_IPC_PEER_ZONEID, &id) ==
 	    NNG_ENOTSUP);
 #endif
 #endif

--- a/tests/multistress.c
+++ b/tests/multistress.c
@@ -585,7 +585,7 @@ pubsub0_test(int ntests)
 		if ((rv = nng_aio_alloc(&cli->recd, sub0_recd, cli)) != 0) {
 			fatal("nng_aio_alloc", rv);
 		}
-		rv = nng_setopt(cli->sock, NNG_OPT_SUB_SUBSCRIBE, "", 0);
+		rv = nng_socket_set(cli->sock, NNG_OPT_SUB_SUBSCRIBE, "", 0);
 		if (rv != 0) {
 			fatal("subscribe", rv);
 		}

--- a/tests/nonblock.c
+++ b/tests/nonblock.c
@@ -36,7 +36,7 @@ repthr(void *arg)
 
 	nng_listen(rep, addr, &l, NNG_FLAG_NONBLOCK);
 
-	nng_getopt_int(rep, NNG_OPT_RECVFD, &ifd);
+	nng_socket_get_int(rep, NNG_OPT_RECVFD, &ifd);
 	fd = ifd;
 
 	for (;;) {

--- a/tests/pipe.c
+++ b/tests/pipe.c
@@ -138,10 +138,10 @@ TestMain("Pipe notify works", {
 			nng_mtx_free(pull.lk);
 		});
 
-		So(nng_setopt_ms(push.s, NNG_OPT_RECONNMINT, 10) == 0);
-		So(nng_setopt_ms(push.s, NNG_OPT_RECONNMAXT, 10) == 0);
-		So(nng_setopt_ms(pull.s, NNG_OPT_RECONNMINT, 10) == 0);
-		So(nng_setopt_ms(pull.s, NNG_OPT_RECONNMAXT, 10) == 0);
+		So(nng_socket_set_ms(push.s, NNG_OPT_RECONNMINT, 10) == 0);
+		So(nng_socket_set_ms(push.s, NNG_OPT_RECONNMAXT, 10) == 0);
+		So(nng_socket_set_ms(pull.s, NNG_OPT_RECONNMINT, 10) == 0);
+		So(nng_socket_set_ms(pull.s, NNG_OPT_RECONNMAXT, 10) == 0);
 
 		So(nng_pipe_notify(
 		       push.s, NNG_PIPE_EV_ADD_PRE, notify, &push) == 0);
@@ -161,9 +161,9 @@ TestMain("Pipe notify works", {
 			So(nng_dialer_create(&push.d, push.s, addr) == 0);
 			So(nng_listener_id(pull.l) > 0);
 			So(nng_dialer_id(push.d) > 0);
-			So(nng_dialer_setopt_ms(
+			So(nng_dialer_set_ms(
 			       push.d, NNG_OPT_RECONNMINT, 10) == 0);
-			So(nng_dialer_setopt_ms(
+			So(nng_dialer_set_ms(
 			       push.d, NNG_OPT_RECONNMAXT, 10) == 0);
 			So(nng_listener_start(pull.l, 0) == 0);
 			So(nng_dialer_start(push.d, 0) == 0);

--- a/tests/pollfd.c
+++ b/tests/pollfd.c
@@ -58,13 +58,13 @@ TestMain("Poll FDs", {
 			size_t sz;
 
 			sz = sizeof(fd);
-			So(nng_getopt(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
+			So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
 			So(fd != (int) INVALID_SOCKET);
 
 			Convey("And it is always the same fd", {
 				int fd2;
 				sz = sizeof(fd2);
-				So(nng_getopt(s1, NNG_OPT_RECVFD, &fd2, &sz) ==
+				So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd2, &sz) ==
 				    0);
 				So(fd2 == fd);
 			});
@@ -96,7 +96,7 @@ TestMain("Poll FDs", {
 			size_t sz;
 
 			sz = sizeof(fd);
-			So(nng_getopt(s1, NNG_OPT_SENDFD, &fd, &sz) == 0);
+			So(nng_socket_get(s1, NNG_OPT_SENDFD, &fd, &sz) == 0);
 			So(fd != (int) INVALID_SOCKET);
 			So(nng_send(s1, "oops", 4, 0) == 0);
 		});
@@ -105,10 +105,10 @@ TestMain("Poll FDs", {
 			int    fd;
 			size_t sz;
 			sz = 1;
-			So(nng_getopt(s1, NNG_OPT_RECVFD, &fd, &sz) ==
+			So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd, &sz) ==
 			    NNG_EINVAL);
 			sz = 128;
-			So(nng_getopt(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
+			So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
 			So(sz == sizeof(fd));
 		});
 	});
@@ -118,7 +118,7 @@ TestMain("Poll FDs", {
 		int        fd;
 		So(nng_pull0_open(&s3) == 0);
 		Reset({ nng_close(s3); });
-		So(nng_getopt_int(s3, NNG_OPT_SENDFD, &fd) == NNG_ENOTSUP);
+		So(nng_socket_get_int(s3, NNG_OPT_SENDFD, &fd) == NNG_ENOTSUP);
 	});
 
 	Convey("We cannot get a recv FD for PUSH", {
@@ -126,6 +126,6 @@ TestMain("Poll FDs", {
 		int        fd;
 		So(nng_push0_open(&s3) == 0);
 		Reset({ nng_close(s3); });
-		So(nng_getopt_int(s3, NNG_OPT_RECVFD, &fd) == NNG_ENOTSUP);
+		So(nng_socket_get_int(s3, NNG_OPT_RECVFD, &fd) == NNG_ENOTSUP);
 	});
 })

--- a/tests/reqctx.c
+++ b/tests/reqctx.c
@@ -117,7 +117,7 @@ TestMain("REQ concurrent contexts", {
 			nng_aio_set_timeout(saios[i], 5000);
 		}
 
-		So(nng_setopt_int(rep_state.s, NNG_OPT_SENDBUF, NCTX) == 0);
+		So(nng_socket_set_int(rep_state.s, NNG_OPT_SENDBUF, NCTX) == 0);
 		So(i == NCTX);
 		for (i = 0; i < NCTX; i++) {
 			uint32_t tmp;

--- a/tests/scalability.c
+++ b/tests/scalability.c
@@ -53,8 +53,8 @@ openclients(nng_socket *clients, int num)
 		t = 100; // 100ms
 		nng_socket c;
 		if (((rv = nng_req_open(&c)) != 0) ||
-		    ((rv = nng_setopt_ms(c, NNG_OPT_RECVTIMEO, t)) != 0) ||
-		    ((rv = nng_setopt_ms(c, NNG_OPT_SENDTIMEO, t)) != 0) ||
+		    ((rv = nng_socket_set_ms(c, NNG_OPT_RECVTIMEO, t)) != 0) ||
+		    ((rv = nng_socket_set_ms(c, NNG_OPT_SENDTIMEO, t)) != 0) ||
 		    ((rv = nng_dial(c, addr, NULL, 0)) != 0)) {
 			return (rv);
 		}
@@ -93,8 +93,8 @@ Main({
 	results = calloc(nclients, sizeof(int));
 
 	if ((nng_rep_open(&rep) != 0) ||
-	    (nng_setopt_int(rep, NNG_OPT_RECVBUF, 256) != 0) ||
-	    (nng_setopt_int(rep, NNG_OPT_SENDBUF, 256) != 0) ||
+	    (nng_socket_set_int(rep, NNG_OPT_RECVBUF, 256) != 0) ||
+	    (nng_socket_set_int(rep, NNG_OPT_SENDBUF, 256) != 0) ||
 	    (nng_listen(rep, addr, NULL, 0) != 0) ||
 	    (nng_thread_create(&server, serve, NULL) != 0)) {
 		fprintf(stderr, "Unable to set up server!\n");

--- a/tests/stats.c
+++ b/tests/stats.c
@@ -42,17 +42,17 @@ TestMain("Stats Test", {
 			So(nng_pair_open(&s2) == 0);
 			Reset({ nng_close(s2); });
 
-			So(nng_setopt_int(s1, NNG_OPT_RECVBUF, 1) == 0);
-			So(nng_getopt_int(s1, NNG_OPT_RECVBUF, &len) == 0);
+			So(nng_socket_set_int(s1, NNG_OPT_RECVBUF, 1) == 0);
+			So(nng_socket_get_int(s1, NNG_OPT_RECVBUF, &len) == 0);
 			So(len == 1);
 
-			So(nng_setopt_int(s1, NNG_OPT_SENDBUF, 1) == 0);
-			So(nng_setopt_int(s2, NNG_OPT_SENDBUF, 1) == 0);
+			So(nng_socket_set_int(s1, NNG_OPT_SENDBUF, 1) == 0);
+			So(nng_socket_set_int(s2, NNG_OPT_SENDBUF, 1) == 0);
 
-			So(nng_setopt_ms(s1, NNG_OPT_SENDTIMEO, to) == 0);
-			So(nng_setopt_ms(s1, NNG_OPT_RECVTIMEO, to) == 0);
-			So(nng_setopt_ms(s2, NNG_OPT_SENDTIMEO, to) == 0);
-			So(nng_setopt_ms(s2, NNG_OPT_RECVTIMEO, to) == 0);
+			So(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, to) == 0);
+			So(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, to) == 0);
+			So(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, to) == 0);
+			So(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, to) == 0);
 
 			So(nng_listen(s1, a, NULL, 0) == 0);
 			So(nng_dial(s2, a, NULL, 0) == 0);

--- a/tests/tcp.c
+++ b/tests/tcp.c
@@ -33,7 +33,7 @@ check_props_v4(nng_msg *msg)
 
 	p = nng_msg_get_pipe(msg);
 	So(nng_pipe_id(p) > 0);
-	So(nng_pipe_getopt_sockaddr(p, NNG_OPT_LOCADDR, &la) == 0);
+	So(nng_pipe_get_addr(p, NNG_OPT_LOCADDR, &la) == 0);
 	So(la.s_family == NNG_AF_INET);
 	So(la.s_in.sa_port == htons(trantest_port - 1));
 	So(la.s_in.sa_port != 0);
@@ -41,20 +41,20 @@ check_props_v4(nng_msg *msg)
 
 	// untyped
 	z = sizeof(nng_sockaddr);
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == 0);
 	So(z == sizeof(ra));
 	So(ra.s_family == NNG_AF_INET);
 	So(ra.s_in.sa_port != 0);
 	So(ra.s_in.sa_addr == htonl(0x7f000001));
 
-	So(nng_pipe_getopt_size(p, NNG_OPT_REMADDR, &z) == NNG_EBADTYPE);
+	So(nng_pipe_get_size(p, NNG_OPT_REMADDR, &z) == NNG_EBADTYPE);
 	z = 1;
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == NNG_EINVAL);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == NNG_EINVAL);
 
-	So(nng_pipe_getopt_bool(p, NNG_OPT_TCP_KEEPALIVE, &b) == 0);
+	So(nng_pipe_get_bool(p, NNG_OPT_TCP_KEEPALIVE, &b) == 0);
 	So(b == false); // default
 
-	So(nng_pipe_getopt_bool(p, NNG_OPT_TCP_NODELAY, &b) == 0);
+	So(nng_pipe_get_bool(p, NNG_OPT_TCP_NODELAY, &b) == 0);
 	So(b == true); // default
 
 	return (0);

--- a/tests/tcp6.c
+++ b/tests/tcp6.c
@@ -53,7 +53,7 @@ check_props_v6(nng_msg *msg)
 	z = sizeof(nng_sockaddr);
 	p = nng_msg_get_pipe(msg);
 	So(nng_pipe_id(p) > 0);
-	So(nng_pipe_getopt(p, NNG_OPT_LOCADDR, &la, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_LOCADDR, &la, &z) == 0);
 	So(z == sizeof(la));
 	So(la.s_family == NNG_AF_INET6);
 	// So(la.s_in.sa_port == (trantest_port - 1));
@@ -65,7 +65,7 @@ check_props_v6(nng_msg *msg)
 	z = sizeof(nng_sockaddr);
 	p = nng_msg_get_pipe(msg);
 	So(nng_pipe_id(p) > 0);
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == 0);
 	So(z == sizeof(ra));
 	So(ra.s_family == NNG_AF_INET6);
 	So(ra.s_in6.sa_port != 0);

--- a/tests/trantest.h
+++ b/tests/trantest.h
@@ -282,7 +282,7 @@ trantest_send_recv(trantest *tt)
 		So(strcmp(nng_msg_body(recv), "acknowledge") == 0);
 		p = nng_msg_get_pipe(recv);
 		So(nng_pipe_id(p) > 0);
-		So(nng_pipe_getopt_string(p, NNG_OPT_URL, &url) == 0);
+		So(nng_pipe_get_string(p, NNG_OPT_URL, &url) == 0);
 		So(strcmp(url, tt->addr) == 0);
 		nng_strfree(url);
 		nng_msg_free(recv);
@@ -336,7 +336,7 @@ trantest_send_recv_multi(trantest *tt)
 			So(strcmp(nng_msg_body(recv), msgbuf) == 0);
 			p = nng_msg_get_pipe(recv);
 			So(nng_pipe_id(p) > 0);
-			So(nng_pipe_getopt_string(p, NNG_OPT_URL, &url) == 0);
+			So(nng_pipe_get_string(p, NNG_OPT_URL, &url) == 0);
 			So(strcmp(url, tt->addr) == 0);
 			nng_strfree(url);
 			nng_msg_free(recv);

--- a/tests/ws.c
+++ b/tests/ws.c
@@ -33,14 +33,14 @@ check_props_v4(nng_msg *msg)
 	p = nng_msg_get_pipe(msg);
 	So(nng_pipe_id(p) > 0);
 
-	So(nng_pipe_getopt_sockaddr(p, NNG_OPT_LOCADDR, &la) == 0);
+	So(nng_pipe_get_addr(p, NNG_OPT_LOCADDR, &la) == 0);
 	So(la.s_family == NNG_AF_INET);
 	So(la.s_in.sa_port == htons(trantest_port - 1));
 	So(la.s_in.sa_port != 0);
 	So(la.s_in.sa_addr == htonl(0x7f000001));
 
 	z = sizeof(nng_sockaddr);
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == 0);
 	So(z == sizeof(ra));
 	So(ra.s_family == NNG_AF_INET);
 	So(ra.s_in.sa_port != 0);
@@ -49,32 +49,32 @@ check_props_v4(nng_msg *msg)
 	// Request Header
 	z   = 0;
 	buf = NULL;
-	So(nng_pipe_getopt(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) ==
+	So(nng_pipe_get(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) ==
 	    NNG_EINVAL);
 	So(z > 0);
 	len = z;
 	So((buf = nng_alloc(len)) != NULL);
-	So(nng_pipe_getopt(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) == 0);
 	So(strstr(buf, "Sec-WebSocket-Key") != NULL);
 	So(z == len);
 	nng_free(buf, len);
-	So(nng_pipe_getopt_string(p, NNG_OPT_WS_REQUEST_HEADERS, &buf) == 0);
+	So(nng_pipe_get_string(p, NNG_OPT_WS_REQUEST_HEADERS, &buf) == 0);
 	So(strlen(buf) == len - 1);
 	nng_strfree(buf);
 
 	// Response Header
 	z   = 0;
 	buf = NULL;
-	So(nng_pipe_getopt(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) ==
+	So(nng_pipe_get(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) ==
 	    NNG_EINVAL);
 	So(z > 0);
 	len = z;
 	So((buf = nng_alloc(len)) != NULL);
-	So(nng_pipe_getopt(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) == 0);
 	So(strstr(buf, "Sec-WebSocket-Accept") != NULL);
 	So(z == len);
 	nng_free(buf, len);
-	So(nng_pipe_getopt_string(p, NNG_OPT_WS_RESPONSE_HEADERS, &buf) == 0);
+	So(nng_pipe_get_string(p, NNG_OPT_WS_RESPONSE_HEADERS, &buf) == 0);
 	So(strlen(buf) == len - 1);
 	nng_strfree(buf);
 

--- a/tests/wss.c
+++ b/tests/wss.c
@@ -143,24 +143,24 @@ check_props(nng_msg *msg)
 	So(nng_pipe_id(p) > 0);
 
 	z = sizeof(nng_sockaddr);
-	So(nng_pipe_getopt(p, NNG_OPT_LOCADDR, &la, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_LOCADDR, &la, &z) == 0);
 	So(z == sizeof(la));
 	So(validloopback(&la));
 
 	z = sizeof(nng_sockaddr);
-	So(nng_pipe_getopt(p, NNG_OPT_REMADDR, &ra, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_REMADDR, &ra, &z) == 0);
 	So(z == sizeof(ra));
 	So(validloopback(&ra));
 
 	// Request header
 	z   = 0;
 	buf = NULL;
-	So(nng_pipe_getopt(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) ==
+	So(nng_pipe_get(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) ==
 	    NNG_EINVAL);
 	So(z > 0);
 	len = z;
 	So((buf = nng_alloc(len)) != NULL);
-	So(nng_pipe_getopt(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_WS_REQUEST_HEADERS, buf, &z) == 0);
 	So(strstr(buf, "Sec-WebSocket-Key") != NULL);
 	So(z == len);
 	nng_free(buf, len);
@@ -168,12 +168,12 @@ check_props(nng_msg *msg)
 	// Response header
 	z   = 0;
 	buf = NULL;
-	So(nng_pipe_getopt(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) ==
+	So(nng_pipe_get(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) ==
 	    NNG_EINVAL);
 	So(z > 0);
 	len = z;
 	So((buf = nng_alloc(len)) != NULL);
-	So(nng_pipe_getopt(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) == 0);
+	So(nng_pipe_get(p, NNG_OPT_WS_RESPONSE_HEADERS, buf, &z) == 0);
 	So(strstr(buf, "Sec-WebSocket-Accept") != NULL);
 	So(z == len);
 	nng_free(buf, len);
@@ -200,7 +200,7 @@ init_dialer_wss(nng_dialer d)
 	    0) {
 		goto out;
 	}
-	rv = nng_dialer_setopt_ptr(d, NNG_OPT_TLS_CONFIG, cfg);
+	rv = nng_dialer_set_ptr(d, NNG_OPT_TLS_CONFIG, cfg);
 
 out:
 	nng_tls_config_free(cfg);
@@ -220,7 +220,7 @@ init_listener_wss(nng_listener l)
 		goto out;
 	}
 
-	if ((rv = nng_listener_setopt_ptr(l, NNG_OPT_TLS_CONFIG, cfg)) != 0) {
+	if ((rv = nng_listener_set_ptr(l, NNG_OPT_TLS_CONFIG, cfg)) != 0) {
 		// We can wind up with EBUSY from the server already running.
 		if (rv == NNG_EBUSY) {
 			rv = 0;

--- a/tests/zt.c
+++ b/tests/zt.c
@@ -50,7 +50,7 @@ check_props(nng_msg *msg)
 	// Check local address.
 	Convey("Local address property works", {
 		nng_sockaddr la;
-		So(nng_pipe_getopt_sockaddr(p, NNG_OPT_LOCADDR, &la) == 0);
+		So(nng_pipe_get_addr(p, NNG_OPT_LOCADDR, &la) == 0);
 
 		So(la.s_family == NNG_AF_ZT);
 		So(la.s_zt.sa_port == (trantest_port - 1));
@@ -63,12 +63,12 @@ check_props(nng_msg *msg)
 		uint64_t     mynode;
 		nng_sockaddr ra;
 
-		So(nng_pipe_getopt_sockaddr(p, NNG_OPT_REMADDR, &ra) == 0);
+		So(nng_pipe_get_addr(p, NNG_OPT_REMADDR, &ra) == 0);
 		So(ra.s_family == NNG_AF_ZT);
 		So(ra.s_zt.sa_port != 0);
 		So(ra.s_zt.sa_nwid == NWID_NUM);
 
-		So(nng_pipe_getopt_uint64(p, NNG_OPT_ZT_NODE, &mynode) == 0);
+		So(nng_pipe_get_uint64(p, NNG_OPT_ZT_NODE, &mynode) == 0);
 		So(mynode != 0);
 		So(ra.s_zt.sa_nodeid == mynode);
 	});
@@ -76,14 +76,14 @@ check_props(nng_msg *msg)
 	Convey("NWID property works", {
 		uint64_t nwid = 0;
 
-		So(nng_pipe_getopt_uint64(p, NNG_OPT_ZT_NWID, &nwid) == 0);
+		So(nng_pipe_get_uint64(p, NNG_OPT_ZT_NWID, &nwid) == 0);
 		So(nwid = 0xa09acf02337b057bull);
 	});
 
 	Convey("Network status property works", {
 		int s = 0;
 
-		So(nng_pipe_getopt_int(p, NNG_OPT_ZT_NETWORK_STATUS, &s) == 0);
+		So(nng_pipe_get_int(p, NNG_OPT_ZT_NETWORK_STATUS, &s) == 0);
 		So(s == NNG_ZT_STATUS_UP);
 	});
 
@@ -91,16 +91,16 @@ check_props(nng_msg *msg)
 		int          c = 0;
 		nng_duration t = 0;
 
-		So(nng_pipe_getopt_int(p, NNG_OPT_ZT_PING_TRIES, &c) == 0);
+		So(nng_pipe_get_int(p, NNG_OPT_ZT_PING_TRIES, &c) == 0);
 		So(c > 0 && c <= 10);
 
-		So(nng_pipe_getopt_ms(p, NNG_OPT_ZT_PING_TIME, &t) == 0);
+		So(nng_pipe_get_ms(p, NNG_OPT_ZT_PING_TIME, &t) == 0);
 		So(t > 1000 && t < 3600000); // 1 sec - 1 hour
 	});
 
 	Convey("Home property works", {
 		char *v;
-		So(nng_pipe_getopt_string(p, NNG_OPT_ZT_HOME, &v) == 0);
+		So(nng_pipe_get_string(p, NNG_OPT_ZT_HOME, &v) == 0);
 		nng_strfree(v);
 	});
 
@@ -108,14 +108,14 @@ check_props(nng_msg *msg)
 		size_t mtu;
 
 		// Check MTU
-		So(nng_pipe_getopt_size(p, NNG_OPT_ZT_MTU, &mtu) == 0);
+		So(nng_pipe_get_size(p, NNG_OPT_ZT_MTU, &mtu) == 0);
 		So(mtu >= 1000 && mtu <= 10000);
 	});
 
 	Convey("Network name property works", {
 		char *name;
 
-		So(nng_pipe_getopt_string(p, NNG_OPT_ZT_NETWORK_NAME, &name) ==
+		So(nng_pipe_get_string(p, NNG_OPT_ZT_NETWORK_NAME, &name) ==
 		    0);
 		So(strcmp(name, "nng_test_open") == 0);
 		nng_strfree(name);
@@ -158,7 +158,7 @@ TestMain("ZeroTier Transport", {
 
 			Convey("It has the right local address", {
 				nng_sockaddr sa;
-				So(nng_listener_getopt_sockaddr(
+				So(nng_listener_get_addr(
 				       l, NNG_OPT_LOCADDR, &sa) == 0);
 				So(sa.s_zt.sa_family == NNG_AF_ZT);
 				So(sa.s_zt.sa_nwid == NWID_NUM);
@@ -218,7 +218,7 @@ TestMain("ZeroTier Transport", {
 
 		So(nng_listener_create(&l, s, addr) == 0);
 
-		So(nng_listener_getopt_uint64(l, NNG_OPT_ZT_NODE, &node1) ==
+		So(nng_listener_get_uint64(l, NNG_OPT_ZT_NODE, &node1) ==
 		    0);
 		So(node1 != 0);
 
@@ -226,7 +226,7 @@ TestMain("ZeroTier Transport", {
 			snprintf(addr, sizeof(addr), "zt://%llx." NWID ":%u",
 			    (unsigned long long) node1, 42u);
 			So(nng_dialer_create(&d, s, addr) == 0);
-			So(nng_dialer_getopt_uint64(
+			So(nng_dialer_get_uint64(
 			       d, NNG_OPT_ZT_NODE, &node2) == 0);
 			So(node2 == node1);
 			So(nng_dialer_start(d, 0) == NNG_ECONNREFUSED);
@@ -262,7 +262,7 @@ TestMain("ZeroTier Transport", {
 
 		So(nng_listener_start(l, 0) == 0);
 		node = 0;
-		So(nng_listener_getopt_uint64(l, NNG_OPT_ZT_NODE, &node) == 0);
+		So(nng_listener_get_uint64(l, NNG_OPT_ZT_NODE, &node) == 0);
 		So(node != 0);
 		nng_msleep(40);
 		snprintf(addr2, sizeof(addr2), "zt://%llx." NWID ":%u",
@@ -285,7 +285,7 @@ TestMain("ZeroTier Transport", {
 	So(nng_pair_open(&s_test) == 0);
 	So(nng_listener_create(&l_test, s_test, "zt://*." NWID ":0") == 0);
 	So(nng_listener_start(l_test, 0) == 0);
-	So(nng_listener_getopt_uint64(l_test, NNG_OPT_ZT_NODE, &node) == 0);
+	So(nng_listener_get_uint64(l_test, NNG_OPT_ZT_NODE, &node) == 0);
 	snprintf(fmt, sizeof(fmt), "zt://%llx." NWID ":%%u",
 	    (unsigned long long) node);
 	nng_listener_close(l_test);


### PR DESCRIPTION
This updates (most) tests to not use deprecated function.

There are only two remaining calls to nng_closeall() that remain.  Not sure how you want to handle those two
