### PR TITLE
Replace nni_aio_prov_set_extra with nni_aio_prov_set_data.

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -618,15 +618,15 @@ nni_aio_expire_loop(void *arg)
 }
 
 void *
-nni_aio_get_prov_extra(nni_aio *aio, unsigned index)
+nni_aio_get_prov_data(nni_aio *aio)
 {
-	return (aio->a_prov_extra[index]);
+	return (aio->a_prov_data);
 }
 
 void
-nni_aio_set_prov_extra(nni_aio *aio, unsigned index, void *data)
+nni_aio_set_prov_data(nni_aio *aio, void *data)
 {
-	aio->a_prov_extra[index] = data;
+	aio->a_prov_data = data;
 }
 
 void

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -133,8 +133,8 @@ extern void nni_aio_abort(nni_aio *, int rv);
 // nng_aio_finish family of functions.)
 extern int nni_aio_begin(nni_aio *);
 
-extern void *nni_aio_get_prov_extra(nni_aio *, unsigned);
-extern void  nni_aio_set_prov_extra(nni_aio *, unsigned, void *);
+extern void *nni_aio_get_prov_data(nni_aio *);
+extern void  nni_aio_set_prov_data(nni_aio *, void *);
 // nni_aio_advance_iov moves up the iov, reflecting that some I/O as
 // been performed.  It returns the amount of data remaining in the argument;
 // i.e. if the count refers to more data than the iov can support, then
@@ -200,9 +200,8 @@ struct nng_aio {
 	// Provider-use fields.
 	nni_aio_cancel_fn a_cancel_fn;
 	void	     *a_cancel_arg;
-	nni_list_node     a_prov_node;     // Linkage on provider list.
-	void	     *a_prov_extra[2]; // Extra data used by provider
-
+	void	     *a_prov_data;
+	nni_list_node     a_prov_node; // Linkage on provider list.
 	nni_aio_expire_q *a_expire_q;
 	nni_list_node     a_expire_node; // Expiration node
 	nni_reap_node     a_reap_node;

--- a/src/platform/posix/posix_ipcdial.c
+++ b/src/platform/posix/posix_ipcdial.c
@@ -37,9 +37,9 @@ ipc_dialer_close(void *arg)
 		while ((aio = nni_list_first(&d->connq)) != NULL) {
 			nni_ipc_conn *c;
 			nni_list_remove(&d->connq, aio);
-			if ((c = nni_aio_get_prov_extra(aio, 0)) != NULL) {
+			if ((c = nni_aio_get_prov_data(aio)) != NULL) {
 				c->dial_aio = NULL;
-				nni_aio_set_prov_extra(aio, 0, NULL);
+				nni_aio_set_prov_data(aio, NULL);
 				nng_stream_close(&c->stream);
 				nng_stream_free(&c->stream);
 			}
@@ -84,13 +84,13 @@ ipc_dialer_cancel(nni_aio *aio, void *arg, int rv)
 
 	nni_mtx_lock(&d->mtx);
 	if ((!nni_aio_list_active(aio)) ||
-	    ((c = nni_aio_get_prov_extra(aio, 0)) == NULL)) {
+	    ((c = nni_aio_get_prov_data(aio)) == NULL)) {
 		nni_mtx_unlock(&d->mtx);
 		return;
 	}
 	nni_aio_list_remove(aio);
 	c->dial_aio = NULL;
-	nni_aio_set_prov_extra(aio, 0, NULL);
+	nni_aio_set_prov_data(aio, NULL);
 	nni_mtx_unlock(&d->mtx);
 
 	nni_aio_finish_error(aio, rv);
@@ -133,7 +133,7 @@ ipc_dialer_cb(nni_posix_pfd *pfd, unsigned ev, void *arg)
 
 	c->dial_aio = NULL;
 	nni_aio_list_remove(aio);
-	nni_aio_set_prov_extra(aio, 0, NULL);
+	nni_aio_set_prov_data(aio, NULL);
 	nni_mtx_unlock(&d->mtx);
 
 	if (rv != 0) {
@@ -217,14 +217,14 @@ ipc_dialer_dial(void *arg, nni_aio *aio)
 			goto error;
 		}
 		c->dial_aio = aio;
-		nni_aio_set_prov_extra(aio, 0, c);
+		nni_aio_set_prov_data(aio, c);
 		nni_list_append(&d->connq, aio);
 		nni_mtx_unlock(&d->mtx);
 		return;
 	}
 	// Immediate connect, cool!  This probably only happens
-	// on loopback, and probably not on every platform.
-	nni_aio_set_prov_extra(aio, 0, NULL);
+	// on loop back, and probably not on every platform.
+	nni_aio_set_prov_data(aio, NULL);
 	nni_mtx_unlock(&d->mtx);
 	nni_posix_ipc_start(c);
 	nni_aio_set_output(aio, 0, c);
@@ -232,7 +232,7 @@ ipc_dialer_dial(void *arg, nni_aio *aio)
 	return;
 
 error:
-	nni_aio_set_prov_extra(aio, 0, NULL);
+	nni_aio_set_prov_data(aio, NULL);
 	nni_mtx_unlock(&d->mtx);
 	nng_stream_free(&c->stream);
 	nni_aio_finish_error(aio, rv);

--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -56,11 +56,11 @@ resolv_cancel(nni_aio *aio, void *arg, int rv)
 	resolv_item *item = arg;
 
 	nni_mtx_lock(&resolv_mtx);
-	if (item != nni_aio_get_prov_extra(aio, 0)) {
+	if (item != nni_aio_get_prov_data(aio)) {
 		nni_mtx_unlock(&resolv_mtx);
 		return;
 	}
-	nni_aio_set_prov_extra(aio, 0, NULL);
+	nni_aio_set_prov_data(aio, NULL);
 	if (nni_aio_list_active(aio)) {
 		// We have not been picked up by a resolver thread yet,
 		// so we can just discard everything.
@@ -248,7 +248,7 @@ nni_resolv_ip(const char *host, const char *serv, int family, bool passive,
 	if (resolv_fini) {
 		rv = NNG_ECLOSED;
 	} else {
-		nni_aio_set_prov_extra(aio, 0, item);
+		nni_aio_set_prov_data(aio, item);
 		rv = nni_aio_schedule(aio, resolv_cancel, item);
 	}
 	if (rv != 0) {
@@ -282,7 +282,7 @@ resolv_worker(void *notused)
 			continue;
 		}
 
-		item = nni_aio_get_prov_extra(aio, 0);
+		item = nni_aio_get_prov_data(aio);
 		nni_aio_list_remove(aio);
 
 		// Now attempt to do the work.  This runs synchronously.
@@ -292,7 +292,7 @@ resolv_worker(void *notused)
 
 		// Check to make sure we were not canceled.
 		if ((aio = item->aio) != NULL) {
-			nni_aio_set_prov_extra(aio, 0, NULL);
+			nni_aio_set_prov_data(aio, NULL);
 			item->aio = NULL;
 			item->sa  = NULL;
 

--- a/src/platform/windows/win_tcpdial.c
+++ b/src/platform/windows/win_tcpdial.c
@@ -79,7 +79,7 @@ nni_tcp_dialer_close(nni_tcp_dialer *d)
 		NNI_LIST_FOREACH (&d->aios, aio) {
 			nni_tcp_conn *c;
 
-			if ((c = nni_aio_get_prov_extra(aio, 0)) != NULL) {
+			if ((c = nni_aio_get_prov_data(aio)) != NULL) {
 				c->conn_rv = NNG_ECLOSED;
 				CancelIoEx((HANDLE) c->s, &c->conn_io.olpd);
 			}
@@ -116,7 +116,7 @@ tcp_dial_cancel(nni_aio *aio, void *arg, int rv)
 	nni_tcp_conn *  c;
 
 	nni_mtx_lock(&d->mtx);
-	if ((c = nni_aio_get_prov_extra(aio, 0)) != NULL) {
+	if ((c = nni_aio_get_prov_data(aio)) != NULL) {
 		if (c->conn_rv == 0) {
 			c->conn_rv = rv;
 		}
@@ -144,7 +144,7 @@ tcp_dial_cb(nni_win_io *io, int rv, size_t cnt)
 	}
 
 	c->conn_aio = NULL;
-	nni_aio_set_prov_extra(aio, 0, NULL);
+	nni_aio_set_prov_data(aio, NULL);
 	nni_aio_list_remove(aio);
 	if (c->conn_rv != 0) {
 		rv = c->conn_rv;
@@ -240,7 +240,7 @@ nni_tcp_dial(nni_tcp_dialer *d, const nni_sockaddr *sa, nni_aio *aio)
 	}
 
 	c->dialer = d;
-	nni_aio_set_prov_extra(aio, 0, c);
+	nni_aio_set_prov_data(aio, c);
 	if ((rv = nni_aio_schedule(aio, tcp_dial_cancel, d)) != 0) {
 		nni_mtx_unlock(&d->mtx);
 		nng_stream_free(&c->ops);

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -714,7 +714,7 @@ ws_write_cancel(nni_aio *aio, void *arg, int rv)
 		nni_mtx_unlock(&ws->mtx);
 		return;
 	}
-	frame = nni_aio_get_prov_extra(aio, 0);
+	frame = nni_aio_get_prov_data(aio);
 	if (frame == ws->txframe) {
 		nni_aio_abort(ws->txaio, rv);
 		// We will wait for callback on the txaio to finish aio.
@@ -2739,7 +2739,7 @@ ws_str_send(void *arg, nni_aio *aio)
 		ws_frame_fini(frame);
 		return;
 	}
-	nni_aio_set_prov_extra(aio, 0, frame);
+	nni_aio_set_prov_data(aio, frame);
 	nni_list_append(&ws->sendq, aio);
 	nni_list_append(&ws->txq, frame);
 	ws_start_write(ws);


### PR DESCRIPTION
This takes one less parameter, and is simpler.  It will let us
reclaim the aio_prov_extra data space as well, so that we can
use it for other purposes.
