### PR TITLE
nni_aio_fini can be simpler.

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -26,7 +26,7 @@ typedef void (*nni_aio_cancel_fn)(nni_aio *, void *, int);
 extern void nni_aio_init(nni_aio *, nni_cb, void *arg);
 
 // nni_aio_fini finalizes an aio object, releasing associated resources.
-// It waits for the callback to complete.
+// It should only be called if the aio is already stopped.
 extern void nni_aio_fini(nni_aio *);
 
 // nni_aio_reap is used to asynchronously reap the aio.  It can
@@ -42,7 +42,7 @@ extern int nni_aio_alloc(nni_aio **, nni_cb, void *arg);
 // nni_aio_free frees the aio, releasing resources (locks)
 // associated with it. This is safe to call on zeroed memory.
 // This must only be called on an object that was allocated
-// with nni_aio_allocate.
+// with nni_aio_alloc.  It stops the aio implicitly.
 extern void nni_aio_free(nni_aio *aio);
 
 // nni_aio_stop cancels any unfinished I/O, running completion callbacks,

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -223,11 +223,9 @@ nni_task_init(nni_task *task, nni_taskq *tq, nni_cb cb, void *arg)
 void
 nni_task_fini(nni_task *task)
 {
-	nni_mtx_lock(&task->task_mtx);
-	while (task->task_busy) {
-		nni_cv_wait(&task->task_cv);
+	if (task->task_busy) {
+		nni_panic("fini called on busy task");
 	}
-	nni_mtx_unlock(&task->task_mtx);
 	nni_cv_fini(&task->task_cv);
 	nni_mtx_fini(&task->task_mtx);
 }


### PR DESCRIPTION
We don't have to do the close, because all callers should have done
nni_aio_stop first.  This may simplify some of our code paths later
by allowing us to eliminate reap calls that exist solely to permit
clean shut down of aios.
