### PR TITLE
fixes #1590 Undefined reference to nni_atomic_dec & nni_atomic_dec64 on Windows.

### DIFF
--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -265,6 +265,16 @@ nni_atomic_dec64_nv(nni_atomic_u64 *v)
 #endif
 }
 
+void
+nni_atomic_dec64(nni_atomic_u64 *v)
+{
+#ifdef _WIN64
+	InterlockedDecrementAcquire64(&v->v);
+#else
+	InterlockedDecrement64(&v->v);
+#endif
+}
+
 bool
 nni_atomic_cas64(nni_atomic_u64 *v, uint64_t comp, uint64_t new)
 {
@@ -321,6 +331,12 @@ int
 nni_atomic_dec_nv(nni_atomic_int *v)
 {
 	return (InterlockedDecrementRelease(&v->v));
+}
+
+void
+nni_atomic_dec(nni_atomic_int *v)
+{
+	(void) InterlockedDecrementAcquire(&v->v);
 }
 
 bool


### PR DESCRIPTION
fixes https://github.com/nanomsg/nng/issues/1590

