### PR TITLE
Fix out-of-bounds error in http_uri_canonify().

### DIFF
--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -455,10 +455,11 @@ http_uri_canonify(char *path)
 			c += http_hexval(tmp[2]);
 			*dst++ = c;
 			tmp += 3;
+		} else {
+			// garbage in, garbage out
+			*dst++ = c;
+			tmp++;
 		}
-		// garbage in, garbage out
-		*dst++ = c;
-		tmp++;
 	}
 	*dst = '\0';
 


### PR DESCRIPTION
fixes #1594 undefined behaviour due to out-of-bounds in http_uri_canonify().

A small, but important change was done in http_uri_canonify() to mend the issue.