### PR TITLE
Fix mingw atomics undefined

### DIFF
--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -29,7 +29,7 @@ static pfnSetThreadDescription set_thread_desc;
 #define InterlockedDecrementAcquire64(a) \
 	__atomic_sub_fetch(a, 1, __ATOMIC_ACQUIRE)
 #define InterlockedDecrementRelease64(a) \
-	__atomic_fetch_sub(a, 1, __ATOMIC_RELEASE)
+	__atomic_sub_fetch(a, 1, __ATOMIC_RELEASE)
 #endif
 
 #include <stdlib.h>

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -26,6 +26,8 @@ static pfnSetThreadDescription set_thread_desc;
 	__atomic_add_fetch(a, b, __ATOMIC_RELAXED)
 #define InterlockedIncrementAcquire64(a) \
 	__atomic_add_fetch(a, 1, __ATOMIC_ACQUIRE)
+#define InterlockedDecrementAcquire64(a) \
+	__atomic_sub_fetch(a, 1, __ATOMIC_ACQUIRE)
 #define InterlockedDecrementRelease64(a) \
 	__atomic_fetch_sub(a, 1, __ATOMIC_RELEASE)
 #endif


### PR DESCRIPTION
There are two issues with Mingw atomics defines which are solved by this PR's commits:

1. `InterlockedDecrementAcquire64` was not defined, so the build failed on Mingw.
2. `InterlockedDecrementRelease64` was incorrect. The docs for this function state that 
"The function returns the resulting decremented value."
The equivalent function for this in Mingw is `__atomic_sub_fetch`, and not `__atomic_fetch_sub` (which returns the value previous to the decrement).