### PR TITLE
Fixes the call to setsockopt(SO_UPDATE_ACCEPT_CONTEXT) on Windows (#1598)

### DIFF
--- a/src/platform/windows/win_tcplisten.c
+++ b/src/platform/windows/win_tcplisten.c
@@ -88,7 +88,6 @@ tcp_accept_cb(nni_win_io *io, int rv, size_t cnt)
 	int               len2;
 	SOCKADDR *        sa1;
 	SOCKADDR *        sa2;
-	DWORD             yes;
 	BOOL              nd;
 	BOOL              ka;
 
@@ -123,9 +122,8 @@ tcp_accept_cb(nni_win_io *io, int rv, size_t cnt)
 	memcpy(&c->sockname, sa1, len1);
 	memcpy(&c->peername, sa2, len2);
 
-	yes = 1;
 	(void) setsockopt(c->s, SOL_SOCKET, SO_UPDATE_ACCEPT_CONTEXT,
-	    (char *) &yes, sizeof(yes));
+	    (char *) &l->s, sizeof(l->s));
 
 	(void) setsockopt(
 	    c->s, SOL_SOCKET, SO_KEEPALIVE, (char *) &ka, sizeof(ka));


### PR DESCRIPTION
From the [docs](https://docs.microsoft.com/en-us/windows/win32/api/mswsock/nf-mswsock-acceptex), this function requires as a parameter the listener socket, not a boolean value.
With this change, `shutdown` now can start the socket closing process correctly.

fixes #1598
