### PR TITLE
fixes issue #1543 - Deadlock in nng_close(socket)

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -216,6 +216,9 @@ nni_aio_stop(nni_aio *aio)
 		if (fn != NULL) {
 			fn(aio, arg, NNG_ECANCELED);
 		}
+		
+		// catch any tasks that have been prepped but not yet started.
+		nni_task_abort(&aio->a_task);
 
 		nni_aio_wait(aio);
 	}


### PR DESCRIPTION
fixes #1543 by aborting tasks that may have been prepped, but not yet started. otherwise on a socket close the reap thread can get stuck waiting for the task to start/finish.
