### PR TITLE
change windows IPC prefix

### DIFF
--- a/src/platform/windows/win_ipc.h
+++ b/src/platform/windows/win_ipc.h
@@ -17,7 +17,7 @@
 #include "core/nng_impl.h"
 #include "win_impl.h"
 
-#define IPC_PIPE_PREFIX "\\\\.\\pipe\\"
+#define IPC_PIPE_PREFIX "\\\\.\\pipe\\LOCAL\\"
 
 extern int nni_win_ipc_init(nng_stream **, HANDLE, const nng_sockaddr *, bool);
 


### PR DESCRIPTION
according to MS documentation:
> Windows 10, version 1709:  Pipes are only supported within an app-container; ie, from one UWP process to another UWP process that's part of the same app. Also, named pipes must use the syntax **"\.\pipe\LOCAL"** for the pipe name.

references:
https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea#remarks https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-disconnectnamedpipe#remarks
