### PR TITLE
src: sp: tcp: Finish receive aio on close

### DIFF
--- a/src/sp/transport/tcp/tcp.c
+++ b/src/sp/transport/tcp/tcp.c
@@ -361,6 +361,11 @@ tcptran_pipe_recv_cb(void *arg)
 		goto recv_error;
 	}
 
+	if (p->closed) {
+	  rv = NNG_ECLOSED;
+	  goto recv_error;
+	}
+
 	n = nni_aio_count(rxaio);
 	nni_aio_iov_advance(rxaio, n);
 	if (nni_aio_iov_count(rxaio) > 0) {


### PR DESCRIPTION
Issue:
I use bus protocol on tcp. Programm some times hangs on closing socket.

This change fixes hangs on socket close. I saw hang with bus protocol on close from time to time. It hangs in bus0_pipe_stop() on nni_aio_stop(&p->aio_recv); As I found protocol's aio calls on stopping tcptran_pipe_recv_cancel() that should remove it from tcp->recvq, but tcp->rxaio is stopped at that time by tcp close function. As I understand tcptran_pipe_recv_cb() some times is called in between of setting up closed flag and real stopping of tcp->rxaio. This change should fix handling of this scenario
