### PR TITLE
Fix UBSAN error in idhash.c

### DIFF
--- a/src/core/idhash.c
+++ b/src/core/idhash.c
@@ -129,7 +129,8 @@ id_map_register(nni_id_map *m)
 			return (NNG_ENOMEM);
 		}
 		id_reg_len = len;
-		memcpy(mr, id_reg_map, id_reg_num * sizeof(nni_id_map *));
+		if (id_reg_map != NULL)
+			memcpy(mr, id_reg_map, id_reg_num * sizeof(nni_id_map *));
 		id_reg_map = mr;
 	}
 	id_reg_map[id_reg_num++] = m;


### PR DESCRIPTION
Fix for UBSAN error, such as excerpt below:

```
idhash.c:132:14: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
```

As `id_reg_map` is initialised as NULL and passing NULL to `memcpy()` is undefined. Should make no difference to compiled code. Purely to appease the automated checks I have to deal with on my side. Thanks!
