### PR TITLE
Fix PAIR v0 not finalizing the pollables when closing socket

### DIFF
--- a/src/sp/protocol/pair0/pair.c
+++ b/src/sp/protocol/pair0/pair.c
@@ -80,6 +80,8 @@ pair0_sock_fini(void *arg)
 
 	nni_lmq_fini(&s->rmq);
 	nni_lmq_fini(&s->wmq);
+	nni_pollable_fini(&s->writable);
+	nni_pollable_fini(&s->readable);
 	nni_mtx_fini(&s->mtx);
 }
 


### PR DESCRIPTION
This function needs to be pretty much identical between PAIR v0 and v1, it was missing just the call to release the pollable resources.


I was testing the compat API and i discovered that when using PAIR v0, it was leaking file descriptors because of this. This solves the problem completely mirroring the same logic present in PAIR v1 (https://github.com/nanomsg/nng/blob/master/src/sp/protocol/pair1/pair.c#L79-L80).


