### PR TITLE
fix potential deadlock in nni_reap_drain

### DIFF
--- a/src/core/reap.c
+++ b/src/core/reap.c
@@ -19,7 +19,7 @@ static nni_reap_list *reap_list = NULL;
 static nni_thr        reap_thr;
 static bool           reap_exit = false;
 static nni_mtx        reap_mtx = NNI_MTX_INITIALIZER;
-static bool           reap_empty;
+static volatile bool  reap_empty;
 static nni_cv         reap_work_cv = NNI_CV_INITIALIZER(&reap_mtx);
 static nni_cv         reap_empty_cv = NNI_CV_INITIALIZER(&reap_mtx);
 


### PR DESCRIPTION
`reap_empty` must be marked as `volatile` as it changed from another thread while being polled in the `nni_reap_drain`
```C
nni_reap_drain(void)
{
	nni_mtx_lock(&reap_mtx);
	while (!reap_empty) {
		nni_cv_wait(&reap_empty_cv);
	}
	nni_mtx_unlock(&reap_mtx);
}
```
compiler must be aware to not apply any optimizations to the `reap_empty` - otherwise on highly optimized code this `while` will spin forever