### PR TITLE
posix_resolv_gai.c: add AI_NUMERICSERV where undefined

### DIFF
--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -33,6 +33,10 @@
 #define NNG_RESOLV_CONCURRENCY 4
 #endif
 
+#ifndef AI_NUMERICSERV
+#define AI_NUMERICSERV 0
+#endif
+
 static nni_mtx  resolv_mtx  = NNI_MTX_INITIALIZER;
 static nni_cv   resolv_cv   = NNI_CV_INITIALIZER(&resolv_mtx);
 static bool     resolv_fini = false;


### PR DESCRIPTION
Borrowed from: https://github.com/macports/macports-legacy-support/blob/2806f66dbd0a7a47fb97fda5f9caedbac4b5f18b/include/netdb.h#L28-L30