### PR TITLE
Skip URI parameters when serving a directory (http_server)

### DIFF
--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -272,7 +272,7 @@ nni_http_handler_set_method(nni_http_handler *h, const char *method)
 
 static nni_list http_servers =
     NNI_LIST_INITIALIZER(http_servers, nni_http_server, node);
-static nni_mtx  http_servers_lk = NNI_MTX_INITIALIZER;
+static nni_mtx http_servers_lk = NNI_MTX_INITIALIZER;
 
 static void
 http_sc_reap(void *arg)
@@ -1156,7 +1156,7 @@ nni_http_server_res_error(nni_http_server *s, nni_http_res *res)
 	http_error *epage;
 	char *      body = NULL;
 	char *      html = NULL;
-	size_t      len = 0;
+	size_t      len  = 0;
 	uint16_t    code = nni_http_res_get_status(res);
 	int         rv;
 
@@ -1550,7 +1550,10 @@ http_handle_dir(nni_aio *aio)
 	}
 
 	for (uri = uri + len; *uri != '\0'; uri++) {
-		if (*uri == '/') {
+		if (*uri == '?') {
+			// Skip URI parameters
+			break;
+		} else if (*uri == '/') {
 			strcpy(dst, NNG_PLATFORM_DIR_SEP);
 			dst += sizeof(NNG_PLATFORM_DIR_SEP) - 1;
 		} else {

--- a/tests/httpserver.c
+++ b/tests/httpserver.c
@@ -387,6 +387,24 @@ TestMain("HTTP Server", {
 			nng_free(data, size);
 		});
 
+		Convey("Named file with URI parameters works", {
+			char     fullurl[256];
+			void *   data;
+			size_t   size;
+			uint16_t stat;
+			char *   ctype;
+
+			snprintf(
+			    fullurl, sizeof(fullurl), "%s/file.txt?param=123456", urlstr);
+			So(httpget(fullurl, &data, &size, &stat, &ctype) == 0);
+			So(stat == NNG_HTTP_STATUS_OK);
+			So(size == strlen(doc2));
+			So(memcmp(data, doc2, size) == 0);
+			So(strcmp(ctype, "text/plain") == 0);
+			nni_strfree(ctype);
+			nng_free(data, size);
+		});
+
 		Convey("Missing index gives 404", {
 			char     fullurl[256];
 			void *   data;
@@ -440,6 +458,7 @@ TestMain("HTTP Server", {
 			nng_url_free(curl);
 			nng_free(data, size);
 		});
+
 		Convey("Version 0.9 gives 505", {
 			char          fullurl[256];
 			void *        data;
@@ -462,6 +481,7 @@ TestMain("HTTP Server", {
 			nng_url_free(curl);
 			nng_free(data, size);
 		});
+
 		Convey("Missing Host gives 400", {
 			char          fullurl[256];
 			void *        data;
@@ -643,6 +663,7 @@ TestMain("HTTP Server", {
 			nng_url_free(curl);
 			nng_free(data, size);
 		});
+
 		Convey("Version 0.9 gives 505", {
 			char          fullurl[256];
 			void *        data;
@@ -665,6 +686,7 @@ TestMain("HTTP Server", {
 			nng_url_free(curl);
 			nng_free(data, size);
 		});
+
 		Convey("Missing Host gives 400", {
 			char          fullurl[256];
 			void *        data;


### PR DESCRIPTION
When serving a directory, an URI such as `http://127.0.0.1/flutter_service_worker.js?v=666216136` will fail because the HTTP server thinks the URI parameter is part of the filename. This PR drops the URI parameters when serving a directory.