### PR TITLE
fixes #1683 NNG_MAX_EXPIRE_THREADS tunable documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ endif ()
 # reduces contention on the common locks used for aio expiration.
 # The default is to allocate up to max(8, ncpu).  The upper limit can be
 # overridden here.
-set(NNG_MAX_EXPIRE_THREADS 8 CACHE STRING "Upper bound on expire threads, 0 for no limit")
+set(NNG_MAX_EXPIRE_THREADS 8 CACHE STRING "Upper bound on expire threads, between 1...256")
 mark_as_advanced(NNG_MAX_EXPIRE_THREADS)
 if (NNG_MAX_EXPIRE_THREADS)
     add_definitions(-DNNG_MAX_EXPIRE_THREADS=${NNG_MAX_EXPIRE_THREADS})


### PR DESCRIPTION
NNG_MAX_EXPIRE_THREADS docs say that 0 means unlimited, but there is a code check that imposes a limit between [1, 256].

This commit fixes the doc.