### PR TITLE
Normalize ifdef macro handlings for configs

### DIFF
--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -46,7 +46,7 @@ nni_dialer_destroy(nni_dialer *d)
 	NNI_FREE_STRUCT(d);
 }
 
-#if NNG_ENABLE_STATS
+#ifdef NNG_ENABLE_STATS
 static void
 dialer_stat_init(nni_dialer *d, nni_stat_item *item, const nni_stat_info *info)
 {

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -491,7 +491,7 @@ nni_listener_getopt(
 void
 nni_listener_add_stat(nni_listener *l, nni_stat_item *item)
 {
-#if NNG_ENABLE_STATS
+#ifdef NNG_ENABLE_STATS
 	nni_stat_add(&l->st_root, item);
 #else
 	NNI_ARG_UNUSED(l);

--- a/src/core/panic.c
+++ b/src/core/panic.c
@@ -23,7 +23,7 @@
 void
 nni_show_backtrace(void)
 {
-#if NNG_HAVE_BACKTRACE
+#ifdef NNG_HAVE_BACKTRACE
 	void *frames[50];
 	int   nframes;
 

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -312,7 +312,7 @@ nni_pipe_create_listener(nni_pipe **pp, nni_listener *l, void *tran_data)
 		return (rv);
 	}
 	p->p_listener = l;
-#if NNG_ENABLE_STATS
+#ifdef NNG_ENABLE_STATS
 	static const nni_stat_info listener_info = {
 		.si_name = "listener",
 		.si_desc = "listener for pipe",

--- a/src/sp/protocol/pair1/pair.c
+++ b/src/sp/protocol/pair1/pair.c
@@ -498,7 +498,7 @@ pair1_pipe_send(pair1_pipe *p, nni_msg *m)
 	// assumption: we have unique access to the message at this point.
 	NNI_ASSERT(!nni_msg_shared(m));
 
-#if NNG_TEST_LIB
+#ifdef NNG_TEST_LIB
 	if (s->inject_header) {
 		goto inject;
 	}
@@ -506,7 +506,7 @@ pair1_pipe_send(pair1_pipe *p, nni_msg *m)
 	NNI_ASSERT(nni_msg_header_len(m) == sizeof(uint32_t));
 	nni_msg_header_poke_u32(m, nni_msg_header_peek_u32(m) + 1);
 
-#if NNG_TEST_LIB
+#ifdef NNG_TEST_LIB
 inject:
 #endif
 
@@ -531,7 +531,7 @@ pair1_sock_send(void *arg, nni_aio *aio)
 		return;
 	}
 
-#if NNG_TEST_LIB
+#ifdef NNG_TEST_LIB
 	if (s->inject_header) {
 		goto inject;
 	}
@@ -554,7 +554,7 @@ pair1_sock_send(void *arg, nni_aio *aio)
 		nni_msg_header_append_u32(m, 0);
 	}
 
-#if NNG_TEST_LIB
+#ifdef NNG_TEST_LIB
 inject:
 #endif
 


### PR DESCRIPTION
fixes warnings or build error when macros are undefined or set to `0`

When they are set to `0`, nng does not even build due to undefined references.

When they are unset, we get many warnings, like:

```
nng/src/core/panic.c:26:5: warning: "NNG_HAVE_BACKTRACE" is not defined, evaluates to 0 [-Wundef]
   26 | #if NNG_HAVE_BACKTRACE
```

This fixes by using `ifdef` everywhere, so we don't get any warnings when the macros are not set.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.