### PR TITLE
Add a new nni_list_node named a_finish_node in struct nng_aio

### DIFF
--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -209,6 +209,7 @@ struct nng_aio {
 	nni_aio_expire_q *a_expire_q;
 	nni_list_node     a_expire_node; // Expiration node
 	nni_reap_node     a_reap_node;
+	nni_list_node     a_finish_node; // Finished node
 };
 
 #endif // CORE_AIO_H

--- a/src/sp/protocol/pubsub0/sub.c
+++ b/src/sp/protocol/pubsub0/sub.c
@@ -326,7 +326,7 @@ sub0_recv_cb(void *arg)
 		return;
 	}
 
-	nni_aio_list_init(&finish);
+	NNI_LIST_INIT(&finish, nng_aio, a_finish_node);
 
 	msg = nni_aio_get_msg(&p->aio_recv);
 	nni_aio_set_msg(&p->aio_recv, NULL);
@@ -388,6 +388,7 @@ sub0_recv_cb(void *arg)
 			nni_pollable_raise(&sock->readable);
 		}
 	}
+	nni_mtx_unlock(&sock->lk);
 
 	// NB: This is slightly less efficient in that we may have
 	// created an extra copy in the face of e.g. two subscriptions,
@@ -404,7 +405,6 @@ sub0_recv_cb(void *arg)
 		nni_list_remove(&finish, aio);
 		nni_aio_finish_sync(aio, 0, len);
 	}
-	nni_mtx_unlock(&sock->lk);
 
 	nni_pipe_recv(p->pipe, &p->aio_recv);
 }

--- a/src/sp/protocol/pubsub0/sub.c
+++ b/src/sp/protocol/pubsub0/sub.c
@@ -388,7 +388,6 @@ sub0_recv_cb(void *arg)
 			nni_pollable_raise(&sock->readable);
 		}
 	}
-	nni_mtx_unlock(&sock->lk);
 
 	// NB: This is slightly less efficient in that we may have
 	// created an extra copy in the face of e.g. two subscriptions,
@@ -405,6 +404,7 @@ sub0_recv_cb(void *arg)
 		nni_list_remove(&finish, aio);
 		nni_aio_finish_sync(aio, 0, len);
 	}
+	nni_mtx_unlock(&sock->lk);
 
 	nni_pipe_recv(p->pipe, &p->aio_recv);
 }


### PR DESCRIPTION
Assume that sub0_ctx_cancel and sub0_recv_cb are executed concurrently.

When sub0_recv_cb is unlocked, and before aio is deleted from the finish queue. nni_list_active in sub0_ctx_cancel may mistakenly believe that aio is still on recv_queue, thus triggering repeated execution of nni_list_remove. The second execution will trigger a null pointer access.

So unlocking  after aio is deleted from the finish list.

fixes #1682  <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
