### PR TITLE
Add dynamic functionality to lmq

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,11 @@ if (NNG_MAX_EXPIRE_THREADS)
     add_definitions(-DNNG_MAX_EXPIRE_THREADS=${NNG_MAX_EXPIRE_THREADS})
 endif()
 
+if (DEFINED NNG_SENDBUF_SIZE)
+    add_definitions(-DNNG_SENDBUF_SIZE=${NNG_SENDBUF_SIZE})
+endif ()
+mark_as_advanced(NNG_SENDBUF_SIZE)
+
 #  Platform checks.
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/src/core/lmq.h
+++ b/src/core/lmq.h
@@ -22,6 +22,7 @@ typedef struct nni_lmq {
 	size_t    lmq_len;
 	size_t    lmq_get;
 	size_t    lmq_put;
+	bool      lmq_dyna;
 	nng_msg **lmq_msgs;
 	nng_msg  *lmq_buf[2]; // default minimal buffer
 } nni_lmq;

--- a/src/sp/protocol/pubsub0/pub.c
+++ b/src/sp/protocol/pubsub0/pub.c
@@ -73,7 +73,11 @@ pub0_sock_init(void *arg, nni_sock *ns)
 	nni_pollable_init(&sock->sendable);
 	nni_mtx_init(&sock->mtx);
 	NNI_LIST_INIT(&sock->pipes, pub0_pipe, node);
-	sock->sendbuf = 16; // fairly arbitrary
+	#ifdef NNG_SENDBUF_SIZE
+		sock->sendbuf = NNG_SENDBUF_SIZE;
+	#else
+		sock->sendbuf = 16;
+	#endif
 }
 
 static void


### PR DESCRIPTION
fixes #1699  Demand for dynamic size event queue

Added NNG_SENDBUF_SIZE parameter to set event queue size. When then lmq cap is set to 0 it works with dynamic size. 
lmq_get and lmq_put change allocated size if needed.
