### PR TITLE
make safe http_schemes.c

### DIFF
--- a/src/supplemental/http/http_schemes.c
+++ b/src/supplemental/http/http_schemes.c
@@ -76,10 +76,12 @@ static struct {
 const char *
 nni_http_stream_scheme(const char *upper)
 {
-	for (int i = 0; http_schemes[i].upper != NULL; i++) {
-		if (strcmp(http_schemes[i].upper, upper) == 0) {
-			return (http_schemes[i].lower);
-		}
+	if (upper != NULL) {
+	  for (int i = 0; http_schemes[i].upper != NULL; i++) {
+	    if (strncmp(http_schemes[i].upper, upper, 7) == 0) {
+	      return (http_schemes[i].lower);
+	    }
+	  }
 	}
 	return (NULL);
 }


### PR DESCRIPTION
Fixes #1704 Rare segfault in nng_http_client_alloc()

Adds a guard for `upper` being NULL, and at the same time replaces `strcmp()` with the safer `strncmp()`.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
