### PR TITLE
fixes #1673 High CPU usage with TLS

### DIFF
--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -867,6 +867,7 @@ tls_alloc(tls_conn **conn_p, nng_tls_config *cfg, nng_aio *user_aio)
 	nni_aio_list_init(&conn->send_queue);
 	nni_aio_list_init(&conn->recv_queue);
 	nni_mtx_init(&conn->lock);
+	nni_aio_set_timeout(&conn->conn_aio, NNG_DURATION_INFINITE);
 	nni_aio_set_timeout(&conn->tcp_send, NNG_DURATION_INFINITE);
 	nni_aio_set_timeout(&conn->tcp_recv, NNG_DURATION_INFINITE);
 


### PR DESCRIPTION
The aio for connections was meant to have an infinite sleep (no timeout), but was getting an initial value of zero, so we were spinning on accept.
