### PR TITLE
Add a simple SNDPRIO implemention  on req0

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -706,6 +706,7 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 #define NNG_OPT_RECVMAXSZ "recv-size-max"
 #define NNG_OPT_RECONNMINT "reconnect-time-min"
 #define NNG_OPT_RECONNMAXT "reconnect-time-max"
+#define NNG_OPT_SNDPRIO "send-prio"
 
 // TLS options are only used when the underlying transport supports TLS.
 

--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -481,7 +481,15 @@ nni_dialer_setopt(
 		nni_mtx_unlock(&d->d_mtx);
 		return (rv);
 	}
+	if (strcmp(name, NNG_OPT_SNDPRIO) == 0) {
+		int rv;
 
+		nni_mtx_lock(&d->d_mtx);
+		rv = nni_copyin_int(&d->sndprio, val, sz, 1, 16, t);
+		nni_mtx_unlock(&d->d_mtx);
+		return (rv);
+	}
+	
 	if (d->d_ops.d_setopt != NULL) {
 		int rv = d->d_ops.d_setopt(d->d_data, name, val, sz, t);
 		if (rv != NNG_ENOTSUP) {
@@ -523,7 +531,14 @@ nni_dialer_getopt(
 		nni_mtx_unlock(&d->d_mtx);
 		return (rv);
 	}
-
+	if (strcmp(name, NNG_OPT_SNDPRIO) == 0) {
+		int rv;
+		nni_mtx_lock(&d->d_mtx);
+		rv = nni_copyout_int(d->sndprio, valp, szp, t);
+		nni_mtx_unlock(&d->d_mtx);
+		return (rv);
+	}
+	
 	if (d->d_ops.d_getopt != NULL) {
 		int rv = d->d_ops.d_getopt(d->d_data, name, valp, szp, t);
 		if (rv != NNG_ENOTSUP) {

--- a/src/core/sockimpl.h
+++ b/src/core/sockimpl.h
@@ -37,7 +37,7 @@ struct nni_dialer {
 	nni_duration      d_currtime; // current time for reconnect
 	nni_duration      d_inirtime; // initial time for reconnect
 	nni_reap_node     d_reap;
-
+        int               sndprio;
 #ifdef NNG_ENABLE_STATS
 	nni_stat_item st_root;
 	nni_stat_item st_id;

--- a/src/sp/protocol/reqrep0/req.c
+++ b/src/sp/protocol/reqrep0/req.c
@@ -76,6 +76,7 @@ struct req0_pipe {
 	bool          closed;
 	nni_aio       aio_send;
 	nni_aio       aio_recv;
+	int           sndprio; 
 };
 
 static void req0_sock_fini(void *);
@@ -190,18 +191,42 @@ req0_pipe_init(void *arg, nni_pipe *pipe, void *s)
 	return (0);
 }
 
+static void req0_pipe_insert_by_prio(nni_list *ready_pipes, req0_pipe *p){
+	req0_pipe *p2 = NULL;
+	int sndprio = p->sndprio;
+
+	if(sndprio < 1){
+		return nni_list_append(ready_pipes, p);
+	}
+
+    NNI_LIST_FOREACH(ready_pipes, p2) {
+        if (sndprio > p2->sndprio) {
+            nni_list_insert_before(ready_pipes, p, p2);
+            return ;
+        }
+    }
+    if (p2 == NULL) {
+        nni_list_append(ready_pipes, p);
+    }
+}
+
 static int
 req0_pipe_start(void *arg)
 {
 	req0_pipe *p = arg;
 	req0_sock *s = p->req;
-
+	int prio = 0;
+	
 	if (nni_pipe_peer(p->pipe) != NNG_REQ0_PEER) {
 		return (NNG_EPROTO);
 	}
-
+	if(p->pipe->p_dialer && nni_dialer_getopt(p->pipe->p_dialer, NNG_OPT_SNDPRIO, &prio, NULL, NNI_TYPE_INT32) == 0 && prio > 0){
+		// the first time copy sndprio from dialer
+		p -> sndprio = prio;
+	}
 	nni_mtx_lock(&s->mtx);
-	nni_list_append(&s->ready_pipes, p);
+	req0_pipe_insert_by_prio(&s->ready_pipes, p);
+	//nni_list_append(&s->ready_pipes, p);
 	nni_pollable_raise(&s->writable);
 	req0_run_send_queue(s, NULL);
 	nni_mtx_unlock(&s->mtx);
@@ -294,7 +319,8 @@ req0_send_cb(void *arg)
 		return;
 	}
 	nni_list_remove(&s->busy_pipes, p);
-	nni_list_append(&s->ready_pipes, p);
+	req0_pipe_insert_by_prio(&s->ready_pipes, p);
+	// nni_list_append(&s->ready_pipes, p);
 	if (nni_list_empty(&s->send_queue)) {
 		nni_pollable_raise(&s->writable);
 	}

--- a/src/sp/protocol/reqrep0/req.c
+++ b/src/sp/protocol/reqrep0/req.c
@@ -11,6 +11,7 @@
 
 #include "core/nng_impl.h"
 #include "nng/protocol/reqrep0/req.h"
+#include "core/sockimpl.h"
 
 // Request protocol.  The REQ protocol is the "request" side of a
 // request-reply pair.  This is useful for building RPC clients, for example.


### PR DESCRIPTION
fixes #104   Need RCVPRIO and SNDPRIO options

I have added a very simple implemention on req0 to solve my connected two rep server. would you like to merge this into your master?
I add the NNG_OPT_SNDPRIO on the dialer, then copy the sndpri to  the nni_pipe on req0_pipe_start function. then resort the ready_pipes.

Maybe you can  provide better implementation methods. thanks!
