### PR TITLE
provide NNG_MAX_POLLER_THREADS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,14 @@ if (NNG_MAX_EXPIRE_THREADS)
     add_definitions(-DNNG_MAX_EXPIRE_THREADS=${NNG_MAX_EXPIRE_THREADS})
 endif()
 
+# Poller threads.  These threads run the pollers.  This is mostly used
+# on Windows right now, as the POSIX platforms use a single threaded poller.
+set(NNG_MAX_POLLER_THREADS 8 CACHE STRING "Upper bound on I/O poller threads, 0 for no limit")
+mark_as_advanced(NNG_MAX_POLLER_THREADS)
+if (NNG_MAX_POLLER_THREADS)
+    add_definitions(-DNNG_MAX_POLLER_THREADS=${NNG_MAX_POLLER_THREADS})
+endif()
+
 #  Platform checks.
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/src/platform/windows/win_io.c
+++ b/src/platform/windows/win_io.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -92,12 +92,17 @@ nni_win_io_sysinit(void)
 	int    nthr = nni_plat_ncpu() * 2;
 
 	// Limits on the thread count.  This is fairly arbitrary.
-	if (nthr < 4) {
-		nthr = 4;
+	if (nthr < 2) {
+		nthr = 2;
 	}
-	if (nthr > 64) {
-		nthr = 64;
+#ifndef NNG_MAX_POLLER_THREADS
+#define NNG_MAX_POLLER_THREADS 8
+#endif
+#if NNG_MAX_POLLER_THREADS > 0
+	if (nthr > NNG_MAX_POLLER_THREADS) {
+		nthr = NNG_MAX_POLLER_THREADS;
 	}
+#endif
 	if ((win_io_thrs = NNI_ALLOC_STRUCTS(win_io_thrs, nthr)) == NULL) {
 		return (NNG_ENOMEM);
 	}


### PR DESCRIPTION
This (defaults to 8) sets a limit on the number of poller threads that will be used for servicing I/Os.  This is the size of the I/O completion port thread pool on Windows.  POSIX pollers are generally not concurrent at present.
