### PR TITLE
Simplifies mbedtls CMakeLists.txt

### DIFF
--- a/docs/man/nng_socket.7.adoc
+++ b/docs/man/nng_socket.7.adoc
@@ -16,7 +16,7 @@ nng_socket - BSD Socket transport (experimental)
 
 (((BSD Socket)))(((transport, _socket_)))
 The ((_socket_ transport)) provides communication support between
-peers across a arbitrary BSD sockets, such as those that are
+peers across arbitrary BSD sockets, such as those that are
 created with xref:nng_socket_pair.3supp.adoc[`nng_socket_pair()`].
 
 This transport only supports xref:nng_listener.5.adoc[listeners], using xref:nng_listener_create.3.adoc[`nng_listener_create()`].
@@ -24,8 +24,8 @@ This transport only supports xref:nng_listener.5.adoc[listeners], using xref:nng
 NOTE: Attempts to create a xref:nng_dialer.5.adoc[dialer] using this transport will result in `NNG_ENOTSUP`.
 
 The socket file descriptor is passed to the listener using the `NNG_OPT_SOCKET_FD` option (as an integer).
-Setting this option (which is read-only and can be set multiple times) will cause the listener
-to create a xref:nng_pipe.5.adoc[pipe] associated backed by the file descriptor.
+Setting this option (which is write-only and can be set multiple times) will cause the listener
+to create a xref:nng_pipe.5.adoc[pipe] backed by the file descriptor.
 
 The protocol between peers using this pipe is at present compatible with the protocol used for the
 xref:nng_tcp.7.adoc[TCP] transport, but this is an implementation detail and subject to change without notice.

--- a/src/supplemental/tls/mbedtls/CMakeLists.txt
+++ b/src/supplemental/tls/mbedtls/CMakeLists.txt
@@ -23,17 +23,7 @@ if (NNG_TLS_ENGINE STREQUAL "mbed")
     if (TARGET mbedtls)
         nng_link_libraries(mbedtls)
     else()
-        # We want to prefer config mode over our local find package.
-        # mbedTLS v3 has a config file, which should work better than
-        # what we do here.  We do restore the setting though because
-        # user applications might not expect this.
-        if (NOT CMAKE_FIND_PAKCAGE_PREFER_CONFIG)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
-            find_package(MbedTLS REQUIRED)
-            set(CMAKE_FIND_PACKAGE_PREFER_CONFIG FALSE)
-        else()
-            find_package(MbedTLS REQUIRED)
-        endif()
+        find_package(MbedTLS REQUIRED)
         nng_link_libraries_public(MbedTLS::mbedtls MbedTLS::mbedcrypto MbedTLS::mbedx509)
     endif()
 endif()


### PR DESCRIPTION
Fixes #1771 The new findMbedTLS from NNG 1.7.2 fails

The first commit simplifies the logic such that is works again (as described in the issue).
The second commit just tidies up the new BSD socket transport documentation.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
