### PR TITLE
build: Mbed TLS should use MBEDTLS_ROOT first.

### DIFF
--- a/cmake/FindMbedTLS.cmake
+++ b/cmake/FindMbedTLS.cmake
@@ -28,10 +28,13 @@
 #
 # Hints:
 #
-# Set ``MBEDTLS_ROOT_DIR`` to the root directory of Mbed TLS installation.
+# Set ``MBEDTLS_ROOT`` to the root directory of Mbed TLS installation.
 #
 
-set(_MBEDTLS_ROOT_HINTS ${MBEDTLS_ROOT_DIR} ENV MBEDTLS_ROOT_DIR)
+set(_MBEDTLS_ROOT_HINTS ${MBEDTLS_ROOT} ENV MBEDTLS_ROOT)
+if (NOT _MBEDTLS_ROOT_HINTS)
+    set(_MBEDTLS_ROOT_HINTS ${MBEDTLS_ROOT_DIR} ENV MBEDTLS_ROOT_DIR)
+endif()
 
 set(_MBED_REQUIRED_VARS MbedTLS_TARGET MbedX509_TARGET MbedCrypto_TARGET MbedTLS_VERSION)
 


### PR DESCRIPTION
The old MBEDTLS_ROOT_DIR is still honored for legacy compat, but the version 4.3 find script won't use it by default.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
