### PR TITLE
fixes #1496 Provide NNG_ENABLE_IPV6 option (disabled by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,9 @@ endif ()
 
 nng_defines_if(NNG_ENABLE_STATS NNG_ENABLE_STATS)
 
+# IPv6 enable
+nng_defines_if(NNG_ENABLE_IPV6 NNG_ENABLE_IPV6)
+
 set(NNG_RESOLV_CONCURRENCY 4 CACHE STRING "Resolver (DNS) concurrency.")
 mark_as_advanced(NNG_RESOLV_CONCURRENCY)
 if (NNG_RESOLV_CONCURRENCY)

--- a/cmake/NNGOptions.cmake
+++ b/cmake/NNGOptions.cmake
@@ -106,6 +106,11 @@ if (NNG_ENABLE_HTTP)
 endif()
 mark_as_advanced(NNG_ENABLE_HTTP)
 
+# Some sites or kernels lack IPv6 support.  This override allows us
+# to prevent the use of IPv6 in environments where it isn't supported.
+option (NNG_ENABLE_IPV6 "Enable IPv6." ON)
+mark_as_advanced(NNG_ENABLE_IPV6)
+
 #
 # Transport Options.
 #

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -22,8 +22,8 @@
 
 static struct {
 	const char *scheme;
-	int (*dialer_alloc)(nng_stream_dialer **, const nng_url *);
-	int (*listener_alloc)(nng_stream_listener **, const nng_url *);
+	int         (*dialer_alloc)(nng_stream_dialer **, const nng_url *);
+	int         (*listener_alloc)(nng_stream_listener **, const nng_url *);
 
 } stream_drivers[] = {
 	{
@@ -55,11 +55,13 @@ static struct {
 	    .dialer_alloc   = nni_tcp_dialer_alloc,
 	    .listener_alloc = nni_tcp_listener_alloc,
 	},
+#ifdef NNG_ENABLE_IPV6
 	{
 	    .scheme         = "tcp6",
 	    .dialer_alloc   = nni_tcp_dialer_alloc,
 	    .listener_alloc = nni_tcp_listener_alloc,
 	},
+#endif
 	{
 	    .scheme         = "tls+tcp",
 	    .dialer_alloc   = nni_tls_dialer_alloc,
@@ -70,11 +72,13 @@ static struct {
 	    .dialer_alloc   = nni_tls_dialer_alloc,
 	    .listener_alloc = nni_tls_listener_alloc,
 	},
+#ifdef NNG_ENABLE_IPV6
 	{
 	    .scheme         = "tls+tcp6",
 	    .dialer_alloc   = nni_tls_dialer_alloc,
 	    .listener_alloc = nni_tls_listener_alloc,
 	},
+#endif
 	{
 	    .scheme         = "ws",
 	    .dialer_alloc   = nni_ws_dialer_alloc,
@@ -85,11 +89,13 @@ static struct {
 	    .dialer_alloc   = nni_ws_dialer_alloc,
 	    .listener_alloc = nni_ws_listener_alloc,
 	},
+#ifdef NNG_ENABLE_IPV6
 	{
 	    .scheme         = "ws6",
 	    .dialer_alloc   = nni_ws_dialer_alloc,
 	    .listener_alloc = nni_ws_listener_alloc,
 	},
+#endif
 	{
 	    .scheme         = "wss",
 	    .dialer_alloc   = nni_ws_dialer_alloc,

--- a/src/platform/posix/CMakeLists.txt
+++ b/src/platform/posix/CMakeLists.txt
@@ -62,6 +62,7 @@ if (NNG_PLATFORM_POSIX)
     nng_check_sym(getpeerucred ucred.h NNG_HAVE_GETPEERUCRED)
     nng_check_sym(atomic_flag_test_and_set stdatomic.h NNG_HAVE_STDATOMIC)
     nng_check_sym(socketpair sys/socket.h NNG_HAVE_SOCKETPAIR)
+    nng_check_sym(AF_INET6 netinet/in.h NNG_HAVE_INET6)
 
     nng_sources(
             posix_impl.h

--- a/src/platform/posix/posix_tcpdial.c
+++ b/src/platform/posix/posix_tcpdial.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -22,6 +22,10 @@
 #endif
 
 #include "posix_tcp.h"
+
+#ifndef NNG_HAVE_INET6
+#undef NNG_ENABLE_IPV6
+#endif
 
 // Dialer stuff.
 int
@@ -93,7 +97,7 @@ static void
 tcp_dialer_cancel(nni_aio *aio, void *arg, int rv)
 {
 	nni_tcp_dialer *d = arg;
-	nni_tcp_conn *  c;
+	nni_tcp_conn   *c;
 
 	nni_mtx_lock(&d->mtx);
 	if ((!nni_aio_list_active(aio)) ||
@@ -113,9 +117,9 @@ tcp_dialer_cancel(nni_aio *aio, void *arg, int rv)
 static void
 tcp_dialer_cb(nni_posix_pfd *pfd, unsigned ev, void *arg)
 {
-	nni_tcp_conn *  c = arg;
+	nni_tcp_conn   *c = arg;
 	nni_tcp_dialer *d = c->dialer;
-	nni_aio *       aio;
+	nni_aio        *aio;
 	int             rv;
 	int             ka;
 	int             nd;
@@ -171,8 +175,8 @@ tcp_dialer_cb(nni_posix_pfd *pfd, unsigned ev, void *arg)
 void
 nni_tcp_dial(nni_tcp_dialer *d, const nni_sockaddr *sa, nni_aio *aio)
 {
-	nni_tcp_conn *          c;
-	nni_posix_pfd *         pfd = NULL;
+	nni_tcp_conn           *c;
+	nni_posix_pfd          *pfd = NULL;
 	struct sockaddr_storage ss;
 	size_t                  sslen;
 	int                     fd;
@@ -333,13 +337,15 @@ tcp_dialer_get_locaddr(void *arg, void *buf, size_t *szp, nni_type t)
 static int
 tcp_dialer_set_locaddr(void *arg, const void *buf, size_t sz, nni_type t)
 {
-	nni_tcp_dialer *        d = arg;
+	nni_tcp_dialer         *d = arg;
 	nng_sockaddr            sa;
 	struct sockaddr_storage ss;
-	struct sockaddr_in *    sin;
-	struct sockaddr_in6 *   sin6;
+	struct sockaddr_in     *sin;
 	size_t                  len;
 	int                     rv;
+#ifdef NNG_ENABLE_IPV6
+	struct sockaddr_in6 *sin6;
+#endif
 
 	if ((rv = nni_copyin_sockaddr(&sa, buf, sz, t)) != 0) {
 		return (rv);
@@ -356,12 +362,16 @@ tcp_dialer_set_locaddr(void *arg, const void *buf, size_t sz, nni_type t)
 			return (NNG_EADDRINVAL);
 		}
 		break;
+
+#ifdef NNG_ENABLE_IPV6
 	case AF_INET6:
 		sin6 = (void *) &ss;
 		if (sin6->sin6_port != 0) {
 			return (NNG_EADDRINVAL);
 		}
 		break;
+#endif // __NG_INET6
+
 	default:
 		return (NNG_EADDRINVAL);
 	}

--- a/src/platform/posix/posix_tcplisten.c
+++ b/src/platform/posix/posix_tcplisten.c
@@ -27,6 +27,10 @@
 #define SOCK_CLOEXEC 0
 #endif
 
+#ifndef NNG_HAVE_INET6
+#undef NNG_ENABLE_IPV6
+#endif
+
 #include "posix_tcp.h"
 
 struct nni_tcp_listener {
@@ -94,7 +98,7 @@ tcp_listener_doaccept(nni_tcp_listener *l)
 		int            nd;
 		int            ka;
 		nni_posix_pfd *pfd;
-		nni_tcp_conn * c;
+		nni_tcp_conn  *c;
 
 		fd = nni_posix_pfd_fd(l->pfd);
 
@@ -203,10 +207,15 @@ nni_tcp_listener_listen(nni_tcp_listener *l, const nni_sockaddr *sa)
 	struct sockaddr_storage ss;
 	int                     rv;
 	int                     fd;
-	nni_posix_pfd *         pfd;
+	nni_posix_pfd          *pfd;
 
 	if (((len = nni_posix_nn2sockaddr(&ss, sa)) == 0) ||
-	    ((ss.ss_family != AF_INET) && (ss.ss_family != AF_INET6))) {
+#ifdef NNG_ENABLE_IPV6
+	    ((ss.ss_family != AF_INET) && (ss.ss_family != AF_INET6))
+#else
+	    (ss.ss_family != AF_INET)
+#endif
+	) {
 		return (NNG_EADDRINVAL);
 	}
 

--- a/src/platform/windows/win_sockaddr.c
+++ b/src/platform/windows/win_sockaddr.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -15,8 +15,10 @@
 int
 nni_win_nn2sockaddr(SOCKADDR_STORAGE *ss, const nni_sockaddr *sa)
 {
-	SOCKADDR_IN * sin;
+	SOCKADDR_IN *sin;
+#ifdef NNG_ENABLE_IPV6
 	SOCKADDR_IN6 *sin6;
+#endif
 
 	if ((ss == NULL) || (sa == NULL)) {
 		return (-1);
@@ -30,6 +32,7 @@ nni_win_nn2sockaddr(SOCKADDR_STORAGE *ss, const nni_sockaddr *sa)
 		sin->sin_addr.s_addr = sa->s_in.sa_addr;
 		return (sizeof(*sin));
 
+#ifdef NNG_ENABLE_IPV6
 	case NNG_AF_INET6:
 		sin6 = (void *) ss;
 		memset(sin6, 0, sizeof(*sin6));
@@ -38,6 +41,7 @@ nni_win_nn2sockaddr(SOCKADDR_STORAGE *ss, const nni_sockaddr *sa)
 		sin6->sin6_scope_id = sa->s_in6.sa_scope;
 		memcpy(sin6->sin6_addr.s6_addr, sa->s_in6.sa_addr, 16);
 		return (sizeof(*sin6));
+#endif
 	}
 	return (-1);
 }
@@ -45,8 +49,10 @@ nni_win_nn2sockaddr(SOCKADDR_STORAGE *ss, const nni_sockaddr *sa)
 int
 nni_win_sockaddr2nn(nni_sockaddr *sa, const SOCKADDR_STORAGE *ss)
 {
-	SOCKADDR_IN * sin;
+	SOCKADDR_IN *sin;
+#ifdef NNG_ENABLE_IPV6
 	SOCKADDR_IN6 *sin6;
+#endif
 
 	if ((ss == NULL) || (sa == NULL)) {
 		return (-1);
@@ -59,6 +65,7 @@ nni_win_sockaddr2nn(nni_sockaddr *sa, const SOCKADDR_STORAGE *ss)
 		sa->s_in.sa_addr   = sin->sin_addr.s_addr;
 		return (0);
 
+#ifdef NNG_ENABLE_IPV6
 	case PF_INET6:
 		sin6                = (void *) ss;
 		sa->s_in6.sa_family = NNG_AF_INET6;
@@ -66,6 +73,7 @@ nni_win_sockaddr2nn(nni_sockaddr *sa, const SOCKADDR_STORAGE *ss)
 		sa->s_in6.sa_scope  = sin6->sin6_scope_id;
 		memcpy(sa->s_in6.sa_addr, sin6->sin6_addr.s6_addr, 16);
 		return (0);
+#endif
 	}
 	return (-1);
 }

--- a/src/sp/protocol.c
+++ b/src/sp/protocol.c
@@ -12,7 +12,6 @@
 
 #include "core/nng_impl.h"
 
-
 int
 nni_proto_open(nng_socket *sip, const nni_proto *proto)
 {
@@ -21,8 +20,8 @@ nni_proto_open(nng_socket *sip, const nni_proto *proto)
 
 	if ((rv = nni_sock_open(&sock, proto)) == 0) {
 		nng_socket s;
-		s.id     = nni_sock_id(sock); // Keep socket held open.
-		*sip     = s;
+		s.id = nni_sock_id(sock); // Keep socket held open.
+		*sip = s;
 	}
 	return (rv);
 }

--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -27,7 +27,7 @@ struct ws_dialer {
 	uint16_t           peer; // remote protocol
 	nni_list           aios;
 	nni_mtx            mtx;
-	nni_aio *          connaio;
+	nni_aio           *connaio;
 	nng_stream_dialer *dialer;
 	bool               started;
 };
@@ -36,7 +36,7 @@ struct ws_listener {
 	uint16_t             peer; // remote protocol
 	nni_list             aios;
 	nni_mtx              mtx;
-	nni_aio *            accaio;
+	nni_aio             *accaio;
 	nng_stream_listener *listener;
 	bool                 started;
 };
@@ -45,10 +45,10 @@ struct ws_pipe {
 	nni_mtx     mtx;
 	bool        closed;
 	uint16_t    peer;
-	nni_aio *   user_txaio;
-	nni_aio *   user_rxaio;
-	nni_aio *   txaio;
-	nni_aio *   rxaio;
+	nni_aio    *user_txaio;
+	nni_aio    *user_rxaio;
+	nni_aio    *txaio;
+	nni_aio    *rxaio;
 	nng_stream *ws;
 };
 
@@ -396,10 +396,10 @@ wstran_listener_fini(void *arg)
 static void
 wstran_connect_cb(void *arg)
 {
-	ws_dialer * d = arg;
-	ws_pipe *   p;
-	nni_aio *   caio = d->connaio;
-	nni_aio *   uaio;
+	ws_dialer  *d = arg;
+	ws_pipe    *p;
+	nni_aio    *caio = d->connaio;
+	nni_aio    *uaio;
 	int         rv;
 	nng_stream *ws = NULL;
 
@@ -451,8 +451,8 @@ static void
 wstran_accept_cb(void *arg)
 {
 	ws_listener *l    = arg;
-	nni_aio *    aaio = l->accaio;
-	nni_aio *    uaio;
+	nni_aio     *aaio = l->accaio;
+	nni_aio     *uaio;
 	int          rv;
 
 	nni_mtx_lock(&l->mtx);
@@ -489,7 +489,7 @@ static int
 wstran_dialer_init(void **dp, nng_url *url, nni_dialer *ndialer)
 {
 	ws_dialer *d;
-	nni_sock * s = nni_dialer_sock(ndialer);
+	nni_sock  *s = nni_dialer_sock(ndialer);
 	int        rv;
 	char       name[64];
 
@@ -524,7 +524,7 @@ wstran_listener_init(void **lp, nng_url *url, nni_listener *listener)
 {
 	ws_listener *l;
 	int          rv;
-	nni_sock *   s = nni_listener_sock(listener);
+	nni_sock    *s = nni_listener_sock(listener);
 	char         name[64];
 
 	if ((l = NNI_ALLOC_STRUCT(l)) == NULL) {
@@ -713,6 +713,7 @@ static nni_sp_tran wss4_tran = {
 	.tran_fini     = wstran_fini,
 };
 
+#ifdef NNG_ENABLE_IPV6
 static nni_sp_tran wss6_tran = {
 	.tran_scheme   = "wss6",
 	.tran_dialer   = &ws_dialer_ops,
@@ -721,13 +722,16 @@ static nni_sp_tran wss6_tran = {
 	.tran_init     = wstran_init,
 	.tran_fini     = wstran_fini,
 };
+#endif
 
 void
 nni_sp_wss_register(void)
 {
 	nni_sp_tran_register(&wss_tran);
 	nni_sp_tran_register(&wss4_tran);
+#ifdef NNG_ENABLE_IPV6
 	nni_sp_tran_register(&wss6_tran);
+#endif
 }
 
 #endif // NNG_TRANSPORT_WSS

--- a/src/testing/marry.c
+++ b/src/testing/marry.c
@@ -287,8 +287,8 @@ nuts_marry_ex(
 			    ((rv = nng_listener_set_int(
 			          l2, NNG_OPT_SOCKET_FD, fd[1])) != 0)) {
 #ifdef _WIN32
-				CloseHandle((HANDLE) fd[0]);
-				CloseHandle((HANDLE) fd[1]);
+				_close(fd[0]);
+				_close(fd[1]);
 #else
 				close(fd[0]);
 				close(fd[1]);

--- a/tests/udp.c
+++ b/tests/udp.c
@@ -206,33 +206,33 @@ TestMain("UDP support", {
 			nng_aio_free(aio1);
 		});
 
-#ifdef NNG_ENABLE_IPV6
-		Convey("Sending to an IPv6 address on IPv4 fails", {
-			nng_aio     *aio1;
-			char        *msg = "nope";
-			nng_sockaddr sa;
-			int          rv;
-			nng_iov      iov;
-
-			sa.s_in6.sa_family = NNG_AF_INET6;
-			// address is for google.com
-			inet_ntop(AF_INET6, "2607:f8b0:4007:804::200e",
-			    (void *) sa.s_in6.sa_addr, 16);
-			sa.s_in6.sa_port = 80;
-			So(nng_aio_alloc(&aio1, NULL, NULL) == 0);
-			iov.iov_buf = msg;
-			iov.iov_len = strlen(msg) + 1;
-			So(nng_aio_set_iov(aio1, 1, &iov) == 0);
-			nng_aio_set_input(aio1, 0, &sa);
-
-			nni_plat_udp_send(u1, aio1);
-			nng_aio_wait(aio1);
-			So((rv = nng_aio_result(aio1)) != 0);
-			So(rv == NNG_EADDRINVAL || rv == NNG_ENOTSUP ||
-			    rv == NNG_EUNREACHABLE || rv == NNG_EINVAL);
-			nng_aio_free(aio1);
-		});
-#endif
+		// When we refactor this test suite for NUTS, reenable this
+		// test. test. #ifdef NNG_ENABLE_IPV6 		Convey("Sending
+		// to an IPv6 address on IPv4 fails", {
+		// nng_aio *aio1; char        *msg = "nope";
+		// nng_sockaddr sa; 			int          rv;
+		// 			nng_iov      iov;
+		//
+		// 			sa.s_in6.sa_family = NNG_AF_INET6;
+		// 			// address is for google.com
+		// 			inet_ntop(AF_INET6,
+		// "2607:f8b0:4007:804::200e", 			    (void *)
+		// sa.s_in6.sa_addr, 16); sa.s_in6.sa_port = 80;
+		// 			So(nng_aio_alloc(&aio1, NULL, NULL) ==
+		// 0); 			iov.iov_buf = msg;
+		// iov.iov_len = strlen(msg) + 1;
+		// So(nng_aio_set_iov(aio1, 1, &iov) == 0);
+		// nng_aio_set_input(aio1, 0, &sa);
+		//
+		// 			nni_plat_udp_send(u1, aio1);
+		// 			nng_aio_wait(aio1);
+		// 			So((rv = nng_aio_result(aio1)) != 0);
+		// 			So(rv == NNG_EADDRINVAL || rv ==
+		// NNG_ENOTSUP || 			    rv ==
+		// NNG_EUNREACHABLE || rv == NNG_EINVAL);
+		// nng_aio_free(aio1);
+		// 		});
+		// #endif
 
 		Convey("Sending to an IPC address fails", {
 			nng_aio     *aio1;

--- a/tests/udp.c
+++ b/tests/udp.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -57,8 +57,8 @@ TestMain("UDP support", {
 			char         rbuf[1024];
 			nng_sockaddr to;
 			nng_sockaddr from;
-			nng_aio *    aio1;
-			nng_aio *    aio2;
+			nng_aio     *aio1;
+			nng_aio     *aio2;
 			nng_iov      iov1;
 			nng_iov      iov2;
 
@@ -102,7 +102,7 @@ TestMain("UDP support", {
 
 		Convey("Sending without an address fails", {
 			nng_aio *aio1;
-			char *   msg = "nope";
+			char    *msg = "nope";
 			nng_iov  iov;
 
 			So(nng_aio_alloc(&aio1, NULL, NULL) == 0);
@@ -126,10 +126,10 @@ TestMain("UDP support", {
 			nng_sockaddr to2;
 			nng_sockaddr from1;
 			nng_sockaddr from2;
-			nng_aio *    aio1;
-			nng_aio *    aio2;
-			nng_aio *    aio3;
-			nng_aio *    aio4;
+			nng_aio     *aio1;
+			nng_aio     *aio2;
+			nng_aio     *aio3;
+			nng_aio     *aio4;
 			nng_iov      iov1;
 			nng_iov      iov2;
 			nng_iov      iov3;
@@ -192,7 +192,7 @@ TestMain("UDP support", {
 
 		Convey("Sending without an address fails", {
 			nng_aio *aio1;
-			char *   msg = "nope";
+			char    *msg = "nope";
 			nng_iov  iov;
 
 			So(nng_aio_alloc(&aio1, NULL, NULL) == 0);
@@ -206,9 +206,10 @@ TestMain("UDP support", {
 			nng_aio_free(aio1);
 		});
 
+#ifdef NNG_ENABLE_IPV6
 		Convey("Sending to an IPv6 address on IPv4 fails", {
-			nng_aio *    aio1;
-			char *       msg = "nope";
+			nng_aio     *aio1;
+			char        *msg = "nope";
 			nng_sockaddr sa;
 			int          rv;
 			nng_iov      iov;
@@ -231,19 +232,17 @@ TestMain("UDP support", {
 			    rv == NNG_EUNREACHABLE || rv == NNG_EINVAL);
 			nng_aio_free(aio1);
 		});
+#endif
 
 		Convey("Sending to an IPC address fails", {
-			nng_aio *    aio1;
-			char *       msg = "nope";
+			nng_aio     *aio1;
+			char        *msg = "nope";
 			nng_sockaddr sa;
 			int          rv;
 			nng_iov      iov;
 
-			sa.s_in6.sa_family = NNG_AF_INET6;
-			// address is for google.com
-			inet_ntop(AF_INET6, "2607:f8b0:4007:804::200e",
-			    (void *) sa.s_in6.sa_addr, 16);
-			sa.s_in6.sa_port = 80;
+			sa.s_ipc.sa_family = NNG_AF_IPC;
+			strcat(sa.s_ipc.sa_path, "/tmp/junk");
 			So(nng_aio_alloc(&aio1, NULL, NULL) == 0);
 			iov.iov_buf = msg;
 			iov.iov_len = strlen(msg) + 1;


### PR DESCRIPTION
This also checks if the build system has the definitions for AF_INET6, which might help in some embedded IPv4 only settings.

The resolver test is enhanced to include a check for IPv6 enabled in the kernel.

IPv6 support is enabled by default, of course.
