### PR TITLE
Master drbitboy async demo client part 1

### DIFF
--- a/demo/async/arun.sh
+++ b/demo/async/arun.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+########################################################################
+### Start asynchronous clients that can
+### wait for asynchronous server to start
+########################################################################
+
+### Usage:  ./arun.sh [client#]
+### - client# => do not start server until just before this client
+
+### Socket file; client count
+ADDR=ipc:///tmp/async_demo
+COUNT=10
+
+### Client # to match when server should be started; clear server PID
+SERVER_ORDINAL=$1
+unset SERVER_PID
+
+### Create CLIENT_PID as an array
+typeset -a CLIENT_PID
+i=0
+while (( i < COUNT ))
+do
+	i=$(( i + 1 ))
+
+	### Start server before the matching client
+	if [ "$SERVER_ORDINAL" == "$i" ] ; then
+		./server $ADDR &
+		SERVER_PID=$!
+		echo Started server before client $i
+		trap "kill $SERVER_PID" 0
+	fi
+
+	### Start start client with NONBLOCK envvar set
+	### so client will wait for socket to be open on nng_dial
+	rnd=$(( RANDOM % 1000 + 500 ))
+	echo "Starting client $i: server will reply after $rnd msec"
+	NONBLOCK= ./client $ADDR $rnd &
+	### Add this client's PID to client PID array
+	eval CLIENT_PID[$i]=$!
+done
+
+### Start server if not yet started
+[ "$SERVER_PID" ] || \
+{
+	./server $ADDR &
+	SERVER_PID=$!
+	echo Starting server after last client - SERVER_PID=$SERVER_PID
+	trap "kill $SERVER_PID" 0
+}
+
+### Wait for clients to complete
+i=0
+while (( i < COUNT ))
+do
+	i=$(( i + 1 ))
+	wait ${CLIENT_PID[$i]}
+done
+### Kill server
+kill $SERVER_PID

--- a/demo/async/client.c
+++ b/demo/async/client.c
@@ -53,7 +53,8 @@ client(const char *url, const char *msecstr)
 		fatal("nng_req0_open", rv);
 	}
 
-	if ((rv = nng_dial(sock, url, NULL, 0)) != 0) {
+	if ((rv = nng_dial(sock, url, NULL,
+	         getenv("NONBLOCK") ? NNG_FLAG_NONBLOCK : 0)) != 0) {
 		fatal("nng_dial", rv);
 	}
 


### PR DESCRIPTION
fixes #N/A

Very minor change to enable non-blocking dialing in the client of the async demo (**/demo/async/**).

Client's dial will wait for server to start, and reconnect, but recv and send are still synchronous.

This is a prelude to the development of an async client.