### PR TITLE
Add missing `nng_tls_config_hold` stub function

### DIFF
--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -1644,6 +1644,12 @@ nng_tls_config_alloc(nng_tls_config **cfgp, nng_tls_mode mode)
 }
 
 void
+nng_tls_config_hold(nng_tls_config *cfg)
+{
+	NNI_ARG_UNUSED(cfg);
+}
+
+void
 nng_tls_config_free(nng_tls_config *cfg)
 {
 	NNI_ARG_UNUSED(cfg);


### PR DESCRIPTION
Add the missing stub function implementation for `nng_tls_config_hold()`. Fixes an error when loading the library and expecting to have this symbol available.

Build with `-DBUILD_SHARED_LIBS=ON`

The availability of the symbol can be checked with nm:
```
nm -D cmake-build-release/libnng.so.1.7.3  | grep nng_tls_config_hold
```