### PR TITLE
Add header to posix_rand_getrandom.c

### DIFF
--- a/src/platform/posix/posix_rand_getrandom.c
+++ b/src/platform/posix/posix_rand_getrandom.c
@@ -15,6 +15,7 @@
 // normally be running.  This is the only time it can fail with correct
 // arguments, and then only if it is interrupted with a signal.
 
+#include <stddef.h>
 #include <sys/random.h>
 
 #include "core/nng_impl.h"


### PR DESCRIPTION
fixes #1804 Missing Header in posix_rand_getrandom.c

Can confirm that cross-compilation succeeds afterwards: https://github.com/r-universe/shikokuchuo/actions/runs/8639056802/job/23684720195#step:5:507

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
