### PR TITLE
tls: reap the connection mutex

### DIFF
--- a/src/supplemental/tls/tls_common.c
+++ b/src/supplemental/tls/tls_common.c
@@ -910,6 +910,7 @@ tls_reap(void *arg)
 	if (conn->tcp_recv_buf != NULL) {
 		nni_free(conn->tcp_recv_buf, NNG_TLS_MAX_RECV_SIZE);
 	}
+	nni_mtx_fini(&conn->lock);
 	NNI_FREE_STRUCT(conn);
 }
 


### PR DESCRIPTION
On some systems mutexes acquire memory, and we need to make sure finalize the mutex.

This was reported by Jaylin Yu.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
