### PR TITLE
Fixes #1825 Compiler warnings / errors from new logging feature on Window

### DIFF
--- a/src/platform/windows/CMakeLists.txt
+++ b/src/platform/windows/CMakeLists.txt
@@ -14,6 +14,7 @@
 if (NNG_PLATFORM_WINDOWS)
     nng_check_sym(InitializeConditionVariable windows.h NNG_HAVE_CONDVAR)
     nng_check_sym(snprintf stdio.h NNG_HAVE_SNPRINTF)
+    nng_check_sym(timespec_get time.h NNG_HAVE_TIMESPEC_GET)
     if (NOT NNG_HAVE_CONDVAR OR NOT NNG_HAVE_SNPRINTF)
         message(FATAL_ERROR
                 "Modern Windows API support is missing. "

--- a/src/platform/windows/win_clock.c
+++ b/src/platform/windows/win_clock.c
@@ -24,7 +24,6 @@ nni_clock(void)
 int
 nni_time_get(uint64_t *seconds, uint32_t *nanoseconds)
 {
-	int             rv;
 	struct timespec ts;
 	if (timespec_get(&ts, TIME_UTC) == TIME_UTC) {
 		*seconds     = ts.tv_sec;

--- a/src/platform/windows/win_clock.c
+++ b/src/platform/windows/win_clock.c
@@ -24,12 +24,14 @@ nni_clock(void)
 int
 nni_time_get(uint64_t *seconds, uint32_t *nanoseconds)
 {
+#if defined(NNG_HAVE_TIMESPEC_GET)
 	struct timespec ts;
 	if (timespec_get(&ts, TIME_UTC) == TIME_UTC) {
 		*seconds     = ts.tv_sec;
 		*nanoseconds = ts.tv_nsec;
 		return (0);
 	}
+#endif
 	return (nni_win_error(GetLastError()));
 }
 


### PR DESCRIPTION
fixes #1825  <Compiler warnings / errors from new logging feature on Windows>

The first commit should be uncontroversial.

The second is good enough for me as I don't make use of logging. But a cleaner solution would be to have an alternative that works, or a CMake option that disables logging entirely.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
