### PR TITLE
fix testcase crash on NUTTX When log_buf is null for the first time.

### DIFF
--- a/tests/convey.c
+++ b/tests/convey.c
@@ -691,7 +691,9 @@ convey_vlogf(struct convey_log *log, const char *fmt, va_list va, int addnl)
 		if (ptr == NULL) {
 			return;
 		}
-		memcpy(ptr, log->log_buf, log->log_length);
+		if (log->log_buf != NULL && log->log_length != 0) {
+			memcpy(ptr, log->log_buf, log->log_length);
+		}
 		memset(ptr + log->log_length, 0, newsz - log->log_length);
 		free(log->log_buf);
 		log->log_buf  = ptr;


### PR DESCRIPTION
fix testcase crash on NUTTX When log_buf is null for the first time.

Then the memcpy params will be null which cause crash.


fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
