### PR TITLE
Update url.c

### DIFF
--- a/src/core/url.c
+++ b/src/core/url.c
@@ -294,6 +294,9 @@ nni_url_default_port(const char *scheme)
 int
 nni_url_parse(nni_url **urlp, const char *raw)
 {
+	if(NULL == raw){
+		return(NNG_EINVAL);
+	}
 	nni_url *   url;
 	size_t      len;
 	const char *s;


### PR DESCRIPTION
 When the cross-compiled versions of the protocol stack and the application are inconsistent, the raw URL may sometimes be cleared, leading to a core dump. 

aarch64--glibc--stable-2022.03-1
gcc-linaro-6.5.0-2018.12-x86_64_aarch64-linux-gnu