### PR TITLE
Fixes Compiler Warnings (Windows)

### DIFF
--- a/src/platform/windows/win_ipclisten.c
+++ b/src/platform/windows/win_ipclisten.c
@@ -92,6 +92,7 @@ ipc_accept_start(ipc_listener *l)
 		if (l->closed) {
 			nni_aio_list_remove(aio);
 			nni_aio_finish_error(aio, NNG_ECLOSED);
+			rv = NNG_ECLOSED;
 		} else if (ConnectNamedPipe(l->f, &l->io.olpd)) {
 			rv = 0;
 		} else if ((rv = GetLastError()) == ERROR_IO_PENDING) {

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -260,8 +260,8 @@ tcp_close(void *arg)
 		c->s      = INVALID_SOCKET;
 
 		if (s != INVALID_SOCKET) {
-			CancelIoEx(s, &c->send_io.olpd);
-			CancelIoEx(s, &c->recv_io.olpd);
+			CancelIoEx((HANDLE) s, &c->send_io.olpd);
+			CancelIoEx((HANDLE) s, &c->recv_io.olpd);
 			shutdown(s, SD_BOTH);
 			closesocket(s);
 		}


### PR DESCRIPTION
Resulting from latest changes in #1828 and #1848 affecting the Windows platform only.

Eliminates `-Wint-to-pointer-cast` and `-Wmaybe-uninitialized` warnings. Commits should be self-explanatory.