### PR TITLE
posix: add getentropy() based RNG

### DIFF
--- a/src/platform/posix/CMakeLists.txt
+++ b/src/platform/posix/CMakeLists.txt
@@ -26,6 +26,7 @@ if (NNG_PLATFORM_POSIX)
 
     nng_check_func(lockf NNG_HAVE_LOCKF)
     nng_check_func(flock NNG_HAVE_FLOCK)
+    nng_check_func(getentropy NNG_HAVE_GETENTROPY)
     nng_check_func(getrandom NNG_HAVE_GETRANDOM)
     nng_check_func(arc4random_buf NNG_HAVE_ARC4RANDOM)
 
@@ -69,6 +70,7 @@ if (NNG_PLATFORM_POSIX)
     nng_check_sym(socketpair sys/socket.h NNG_HAVE_SOCKETPAIR)
     nng_check_sym(AF_INET6 netinet/in.h NNG_HAVE_INET6)
     nng_check_sym(timespec_get time.h NNG_HAVE_TIMESPEC_GET)
+    nng_check_sym(getentropy sys/random.h NNG_HAVE_SYS_RANDOM)
 
     nng_sources(
             posix_impl.h
@@ -111,6 +113,8 @@ if (NNG_PLATFORM_POSIX)
 
     if (NNG_HAVE_ARC4RANDOM)
         nng_sources(posix_rand_arc4random.c)
+    elseif (NNG_HAVE_GETENTROPY)
+        nng_sources(posix_rand_getentropy.c)
     elseif (NNG_HAVE_GETRANDOM)
         nng_sources(posix_rand_getrandom.c)
     else ()

--- a/src/platform/posix/posix_rand_getentropy.c
+++ b/src/platform/posix/posix_rand_getentropy.c
@@ -1,0 +1,39 @@
+//
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+// getrandom is not as nice as arc4random, but on platforms where it
+// exists and arc4random does not, we should use it.
+//
+// getrandom will block only if the urandom device is not seeded yet.
+// That can only happen during very early boot (earlier than we should
+// normally be running.  This is the only time it can fail with correct
+// arguments, and then only if it is interrupted with a signal.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <unistd.h>
+#ifdef NNG_HAVE_SYS_RANDOM
+#include <sys/random.h>
+#endif
+
+#include "core/panic.h"
+
+#ifdef NNG_HAVE_GETENTROPY
+
+uint32_t
+nni_random(void)
+{
+	uint32_t val;
+	if (getentropy(&val, sizeof(val)) != 0) {
+		nni_panic("getentropy failed");
+	}
+	return (val);
+}
+
+#endif


### PR DESCRIPTION
XPG8 defines getentropy() as the only good source for random numbers. However, real world use a bit more nuanced.  On BSD systems, we would prefer to use arc4random as it avoids unnecessary system calls.  On Linux however, getentropy is implemented in terms of getrandom, and should be used directly when available.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
