### PR TITLE
Allow and demonstrate NNG usage with CMake FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ endif ()
 # to obtain details about how the public library was built, so that we can
 # include or not include code based on what's actually present.
 add_library(nng)
+add_library(nng::nng ALIAS nng)
 
 add_library(nng_testing STATIC EXCLUDE_FROM_ALL)
 target_compile_definitions(nng_testing PUBLIC NNG_STATIC_LIB NNG_TEST_LIB NNG_PRIVATE)

--- a/demo/fetch_content/CMakeLists.txt
+++ b/demo/fetch_content/CMakeLists.txt
@@ -1,0 +1,24 @@
+# This software is supplied under the terms of the MIT License, a
+# copy of which should be located in the distribution where this
+# file was obtained (LICENSE.txt).  A copy of the license may also be
+# found online at https://opensource.org/licenses/MIT.
+
+cmake_minimum_required (VERSION 3.11)
+
+include(FetchContent)
+
+FetchContent_Declare(
+	nng
+	GIT_REPOSITORY https://github.com/dksmiffs/nng.git
+	GIT_TAG        cb1597d86c4527178b71598c510889db0741fa09
+	FIND_PACKAGE_ARGS
+)
+
+FetchContent_MakeAvailable(nng)
+
+project(fetch_content)
+
+find_package(nng)
+
+add_executable(version version.c)
+target_link_libraries(version PRIVATE nng::nng)

--- a/demo/fetch_content/README.adoc
+++ b/demo/fetch_content/README.adoc
@@ -1,0 +1,41 @@
+= CMake FetchContent demo
+
+This demonstration simply outputs the NNG version. Its main purpose is to show
+an alternate way for downstream developers to consume NNG with certain
+advantages.
+
+NNG Quick Start instructions (as of this writing) assume a final step of
+`ninja install`. While this is one valid choice for NNG clients, it does require
+elevated privilege in many environments. For modern CMake usage, this is not
+the only valid choice.
+
+== Compiling, Running
+
+This build assumes installations of cmake and a modern C compiler. Note that it
+intentionally DOES NOT assume a pre-installed version of NNG:
+
+[source, bash]
+----
+% cmake -B ./build -S . -G Ninja
+% cmake --build ./build
+% ./build/version
+----
+
+== Supporting Evidence for this Approach
+
+* @craigscott-crascit, author of "Professional CMake: A Practical Guide" has the
+following relevant recommendation in his 19th Edition: "For each library that
+will be installed or packaged, a common pattern is to also create a matching
+library alias with a name of the form projNamespace::targetName" (p. 236).
+Further justification in this book also encourages this approach.
+* The
+https://cmake.org/cmake/help/latest/module/FetchContent.html[FetchContent]
+Overview section explains that the FetchContent "module enables populating
+content at configure time" (as opposed to build time).
+* The following popular projects use this approach:
+https://github.com/catchorg/Catch2[catchorg/Catch2],
+https://github.com/google/benchmark[google/benchmark],
+https://gitlab.com/libeigen/eigen[libeigen/eigen],
+https://github.com/gabime/spdlog[gabime/spdlog],
+https://github.com/rollbear/trompeloeil[rollbear/trompeloeil],
+https://github.com/jbeder/yaml-cpp[jbeder/yaml-cpp]

--- a/demo/fetch_content/version.c
+++ b/demo/fetch_content/version.c
@@ -1,0 +1,15 @@
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+
+#include <stdio.h>
+
+#include <nng/nng.h>
+
+int
+main(int argc, char **argv)
+{
+	printf("NNG version is: %s\n", nng_version());
+	return (0);
+}


### PR DESCRIPTION
@gdamore, this PR breaks two CONTRIBUTING rules, but for these reasons:

1. I couldn't squash to one commit, because the second commit needs the SHA1 of the first.
2. If you accept this change, a follow-up change will be required to the new demo's `CMakeLists.txt`, to refer to your repo instead of my fork.

I hope you understand this awkwardness was necessary because the change I'm suggesting isn't in your repo yet, and yet my demo's `CMakeLists.txt` requires SHA1 access to the repo itself with the single line suggested change to the top-level `CMakeLists.txt`.

I promise I will respond to review feedback, and not leave this baby on your doorstep.