### PR TITLE
NNG_OPT_RECVFD and NNG_OPT_SENDFD converted to functions.

### DIFF
--- a/docs/ref/migrate/nanomsg.md
+++ b/docs/ref/migrate/nanomsg.md
@@ -66,24 +66,24 @@ NNG approach to messages. Likewise there is no `struct nn_cmsghdr` equivalent.
 
 The following options are changed.
 
-| Nanomsg Option         | NNG Eqvaivalent      | Notes                                                   |
-| ---------------------- | -------------------- | ------------------------------------------------------- |
-| `NN_LINGER`            | None                 | NNG does not support tuning this.                       |
-| `NN_SNDBUF`            | `NNG_OPT_SENDBUF`    | NNG value is given in messages, not bytes.              |
-| `NN_RCVBUF`            | `NNG_OPT_RECVBUF`    | NNG value is given in messages, not bytes.              |
-| `NN_SNDTIMEO`          | `NNG_OPT_SENDTIMEO`  |
-| `NN_RCVTIMEO`          | `NNG_OPT_RECVTIMEO`  |
-| `NN_RECONNECT_IVL`     | `NNG_OPT_RECONNMINT` |
-| `NN_RECONNECT_IVL_MAX` | `NNG_OPT_RECONNMAXT` |
-| `NN_SNDPRIO`           | None                 | Not supported in NNG yet.                               |
-| `NN_RCVPRIO`           | None                 | Not supported in NNG yet.                               |
-| `NN_RCVFD`             | `NNG_OPT_RECVFD`     |
-| `NN_SNDFD`             | `NNG_OPT_SENDFD`     |
-| `NN_DOMAIN`            | None                 | NNG options are not divided by domain or protocol.      |
-| `NN_PROTOCOL`          | `NNG_OPT_PROTO`      | See also `NNG_OPT_PROTONAME`.                           |
-| `NN_IPV4ONLY`          | None                 | Use URL such as `tcp4://` to obtain this functionality. |
-| `NN_SOCKET_NAME`       | `NNG_OPT_SOCKNAME`   |
-| `NN_MAXTTL`            | `NNG_OPT_MAXTTL`     |
+| Nanomsg Option         | NNG Eqvaivalent                | Notes                                                   |
+| ---------------------- | ------------------------------ | ------------------------------------------------------- |
+| `NN_LINGER`            | None                           | NNG does not support tuning this.                       |
+| `NN_SNDBUF`            | `NNG_OPT_SENDBUF`              | NNG value is given in messages, not bytes.              |
+| `NN_RCVBUF`            | `NNG_OPT_RECVBUF`              | NNG value is given in messages, not bytes.              |
+| `NN_SNDTIMEO`          | `NNG_OPT_SENDTIMEO`            |
+| `NN_RCVTIMEO`          | `NNG_OPT_RECVTIMEO`            |
+| `NN_RECONNECT_IVL`     | `NNG_OPT_RECONNMINT`           |
+| `NN_RECONNECT_IVL_MAX` | `NNG_OPT_RECONNMAXT`           |
+| `NN_SNDPRIO`           | None                           | Not supported in NNG yet.                               |
+| `NN_RCVPRIO`           | None                           | Not supported in NNG yet.                               |
+| `NN_RCVFD`             | `+nng_socket_get_recv_poll_fd` | No longer an option, use a function call.               |
+| `NN_SNDFD`             | `+nng_socket_get_send_poll_fd` | No longer an option, use a function call.               |
+| `NN_DOMAIN`            | None                           | NNG options are not divided by domain or protocol.      |
+| `NN_PROTOCOL`          | `NNG_OPT_PROTO`                | See also `NNG_OPT_PROTONAME`.                           |
+| `NN_IPV4ONLY`          | None                           | Use URL such as `tcp4://` to obtain this functionality. |
+| `NN_SOCKET_NAME`       | `NNG_OPT_SOCKNAME`             |
+| `NN_MAXTTL`            | `NNG_OPT_MAXTTL`               |
 
 ## Error Codes
 

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -255,6 +255,18 @@ NNG_DECL int nng_socket_get_ptr(nng_socket, const char *, void **);
 NNG_DECL int nng_socket_get_ms(nng_socket, const char *, nng_duration *);
 NNG_DECL int nng_socket_get_addr(nng_socket, const char *, nng_sockaddr *);
 
+// These functions are used to obtain a file descriptor that will poll
+// as readable if the socket can receive or send. Applications must never
+// read or write to the file descriptor directly, but simply check it
+// with poll, epoll, kqueue, or similar functions.  This is intended to
+// aid in integration NNG with external event loops based on polling I/O.
+// Note that using these functions will force NNG to make extra system calls,
+// and thus impact performance.  The file descriptor pollability is
+// level-triggered.  These file descriptors will be closed when the socket
+// is closed.
+NNG_DECL int nng_socket_get_recv_poll_fd(nng_socket id, int *fdp);
+NNG_DECL int nng_socket_get_send_poll_fd(nng_socket id, int *fdp);
+
 // Utility function for getting a printable form of the socket address
 // for display in logs, etc.  It is not intended to be parsed, and the
 // display format may change without notice.  Generally you should alow
@@ -722,8 +734,6 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 #define NNG_OPT_PEERNAME "peer-name"
 #define NNG_OPT_RECVBUF "recv-buffer"
 #define NNG_OPT_SENDBUF "send-buffer"
-#define NNG_OPT_RECVFD "recv-fd"
-#define NNG_OPT_SENDFD "send-fd"
 #define NNG_OPT_RECVTIMEO "recv-timeout"
 #define NNG_OPT_SENDTIMEO "send-timeout"
 #define NNG_OPT_LOCADDR "local-address"

--- a/src/core/protocol.h
+++ b/src/core/protocol.h
@@ -108,6 +108,12 @@ struct nni_proto_sock_ops {
 	// Receive a message.
 	void (*sock_recv)(void *, nni_aio *);
 
+	// Return the receive poll FD.
+	int (*sock_recv_poll_fd)(void *, int *);
+
+	// Return the send poll FD.
+	int (*sock_send_poll_fd)(void *, int *);
+
 	// Options. Must not be NULL. Final entry should have NULL name.
 	nni_option *sock_options;
 };
@@ -124,7 +130,7 @@ struct nni_proto {
 	uint32_t                  proto_flags;    // Protocol flags
 	const nni_proto_sock_ops *proto_sock_ops; // Per-socket operations
 	const nni_proto_pipe_ops *proto_pipe_ops; // Per-pipe operations
-	const nni_proto_ctx_ops * proto_ctx_ops;  // Context operations
+	const nni_proto_ctx_ops  *proto_ctx_ops;  // Context operations
 };
 
 // We quite intentionally use a signature where the upper word is nonzero,

--- a/src/core/sock_test.c
+++ b/src/core/sock_test.c
@@ -79,16 +79,6 @@ test_send_nonblock(void)
 }
 
 void
-test_readonly_options(void)
-{
-	nng_socket s1;
-	NUTS_OPEN(s1);
-	NUTS_FAIL(nng_socket_set_int(s1, NNG_OPT_RECVFD, 0), NNG_EREADONLY);
-	NUTS_FAIL(nng_socket_set_int(s1, NNG_OPT_SENDFD, 0), NNG_EREADONLY);
-	NUTS_CLOSE(s1);
-}
-
-void
 test_socket_base(void)
 {
 	nng_socket s1 = NNG_SOCKET_INITIALIZER;
@@ -596,7 +586,6 @@ NUTS_TESTS = {
 	{ "recv non-block", test_recv_nonblock },
 	{ "send timeout", test_send_timeout },
 	{ "send non-block", test_send_nonblock },
-	{ "read only options", test_readonly_options },
 	{ "socket base", test_socket_base },
 	{ "socket name", test_socket_name },
 	{ "socket name oversize", test_socket_name_oversize },

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -34,6 +34,8 @@ extern int nni_sock_getopt(
 extern void     nni_sock_send(nni_sock *, nni_aio *);
 extern void     nni_sock_recv(nni_sock *, nni_aio *);
 extern uint32_t nni_sock_id(nni_sock *);
+extern int      nni_sock_get_send_fd(nni_sock *s, int *fdp);
+extern int      nni_sock_get_recv_fd(nni_sock *s, int *fdp);
 
 // These are socket methods that protocol operations can expect to call.
 // Note that each of these should be called without any locks held, since

--- a/src/nng.c
+++ b/src/nng.c
@@ -11,6 +11,7 @@
 #include "nng/nng.h"
 #include "core/nng_impl.h"
 #include "core/platform.h"
+#include "core/socket.h"
 
 // This file provides the "public" API.  This is a thin wrapper around
 // internal API functions.  We use the public prefix instead of internal,
@@ -1139,6 +1140,38 @@ int
 nng_socket_get_addr(nng_socket id, const char *n, nng_sockaddr *v)
 {
 	return (socket_get(id, n, v, NULL, NNI_TYPE_SOCKADDR));
+}
+
+int
+nng_socket_get_recv_poll_fd(nng_socket id, int *fdp)
+{
+	int       rv;
+	nni_sock *sock;
+
+	if (((rv = nni_init()) != 0) ||
+	    ((rv = nni_sock_find(&sock, id.id)) != 0)) {
+		return (rv);
+	}
+
+	rv = nni_sock_get_recv_fd(sock, fdp);
+	nni_sock_rele(sock);
+	return (rv);
+}
+
+int
+nng_socket_get_send_poll_fd(nng_socket id, int *fdp)
+{
+	int       rv;
+	nni_sock *sock;
+
+	if (((rv = nni_init()) != 0) ||
+	    ((rv = nni_sock_find(&sock, id.id)) != 0)) {
+		return (rv);
+	}
+
+	rv = nni_sock_get_send_fd(sock, fdp);
+	nni_sock_rele(sock);
+	return (rv);
 }
 
 int

--- a/src/sp/protocol/bus0/bus_test.c
+++ b/src/sp/protocol/bus0/bus_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 #include <nng/protocol/bus0/bus.h>
@@ -244,7 +245,7 @@ test_bus_poll_readable(void)
 	NUTS_PASS(nng_bus0_open(&s2));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(s1, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -277,10 +278,10 @@ test_bus_poll_writeable(void)
 	NUTS_PASS(nng_bus0_open(&s1));
 	NUTS_PASS(nng_bus0_open(&s2));
 	NUTS_PASS(nng_socket_set_int(s2, NNG_OPT_SENDBUF, 1));
-	NUTS_PASS(nng_socket_get_int(s2, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(s2, &fd));
 	NUTS_TRUE(fd >= 0);
 
-	// Pub is *always* writeable
+	// Bus is *always* writeable
 	NUTS_TRUE(nuts_poll_fd(fd));
 
 	// Even after connect (no message yet)

--- a/src/sp/protocol/pair0/pair.c
+++ b/src/sp/protocol/pair0/pair.c
@@ -513,40 +513,22 @@ pair0_get_recv_buf_len(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-pair0_sock_get_recv_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+pair0_sock_get_recv_fd(void *arg, int *fdp)
 {
 	pair0_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->readable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->readable, fdp));
 }
 
 static int
-pair0_sock_get_send_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+pair0_sock_get_send_fd(void *arg, int *fdp)
 {
 	pair0_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->writable, fdp));
 }
 
 static nni_option pair0_sock_options[] = {
-	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = pair0_sock_get_recv_fd,
-	},
-	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = pair0_sock_get_send_fd,
-	},
 	{
 	    .o_name = NNG_OPT_SENDBUF,
 	    .o_get  = pair0_get_send_buf_len,
@@ -573,14 +555,16 @@ static nni_proto_pipe_ops pair0_pipe_ops = {
 };
 
 static nni_proto_sock_ops pair0_sock_ops = {
-	.sock_size    = sizeof(pair0_sock),
-	.sock_init    = pair0_sock_init,
-	.sock_fini    = pair0_sock_fini,
-	.sock_open    = pair0_sock_open,
-	.sock_close   = pair0_sock_close,
-	.sock_send    = pair0_sock_send,
-	.sock_recv    = pair0_sock_recv,
-	.sock_options = pair0_sock_options,
+	.sock_size         = sizeof(pair0_sock),
+	.sock_init         = pair0_sock_init,
+	.sock_fini         = pair0_sock_fini,
+	.sock_open         = pair0_sock_open,
+	.sock_close        = pair0_sock_close,
+	.sock_send         = pair0_sock_send,
+	.sock_recv         = pair0_sock_recv,
+	.sock_recv_poll_fd = pair0_sock_get_recv_fd,
+	.sock_send_poll_fd = pair0_sock_get_send_fd,
+	.sock_options      = pair0_sock_options,
 };
 
 // Legacy protocol (v0)

--- a/src/sp/protocol/pair0/pair0_test.c
+++ b/src/sp/protocol/pair0/pair0_test.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -8,6 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 #define SECOND 1000
@@ -340,7 +341,7 @@ test_pair0_poll_readable(void)
 	NUTS_PASS(nng_pair0_open(&s2));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(s1, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -386,7 +387,7 @@ test_pair0_poll_writable(void)
 	NUTS_PASS(nng_pair0_open(&s2));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(s1, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable if not connected!

--- a/src/sp/protocol/pair1/pair.c
+++ b/src/sp/protocol/pair1/pair.c
@@ -724,29 +724,19 @@ pair1_get_recv_buf_len(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-pair1_sock_get_recv_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+pair1_sock_get_recv_fd(void *arg, int *fdp)
 {
 	pair1_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->readable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->readable, fdp));
 }
 
 static int
-pair1_sock_get_send_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+pair1_sock_get_send_fd(void *arg, int *fdp)
 {
 	pair1_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->writable, fdp));
 }
 
 static nni_proto_pipe_ops pair1_pipe_ops = {
@@ -763,14 +753,6 @@ static nni_option pair1_sock_options[] = {
 	    .o_name = NNG_OPT_MAXTTL,
 	    .o_get  = pair1_sock_get_max_ttl,
 	    .o_set  = pair1_sock_set_max_ttl,
-	},
-	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = pair1_sock_get_recv_fd,
-	},
-	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = pair1_sock_get_send_fd,
 	},
 	{
 	    .o_name = NNG_OPT_SENDBUF,
@@ -797,14 +779,16 @@ static nni_option pair1_sock_options[] = {
 };
 
 static nni_proto_sock_ops pair1_sock_ops = {
-	.sock_size    = sizeof(pair1_sock),
-	.sock_init    = pair1_sock_init,
-	.sock_fini    = pair1_sock_fini,
-	.sock_open    = pair1_sock_open,
-	.sock_close   = pair1_sock_close,
-	.sock_recv    = pair1_sock_recv,
-	.sock_send    = pair1_sock_send,
-	.sock_options = pair1_sock_options,
+	.sock_size         = sizeof(pair1_sock),
+	.sock_init         = pair1_sock_init,
+	.sock_fini         = pair1_sock_fini,
+	.sock_open         = pair1_sock_open,
+	.sock_close        = pair1_sock_close,
+	.sock_recv         = pair1_sock_recv,
+	.sock_send         = pair1_sock_send,
+	.sock_recv_poll_fd = pair1_sock_get_recv_fd,
+	.sock_send_poll_fd = pair1_sock_get_send_fd,
+	.sock_options      = pair1_sock_options,
 };
 
 static nni_proto pair1_proto = {
@@ -823,14 +807,16 @@ nng_pair1_open(nng_socket *sock)
 }
 
 static nni_proto_sock_ops pair1_sock_ops_raw = {
-	.sock_size    = sizeof(pair1_sock),
-	.sock_init    = pair1_sock_init_raw,
-	.sock_fini    = pair1_sock_fini,
-	.sock_open    = pair1_sock_open,
-	.sock_close   = pair1_sock_close,
-	.sock_recv    = pair1_sock_recv,
-	.sock_send    = pair1_sock_send,
-	.sock_options = pair1_sock_options,
+	.sock_size         = sizeof(pair1_sock),
+	.sock_init         = pair1_sock_init_raw,
+	.sock_fini         = pair1_sock_fini,
+	.sock_open         = pair1_sock_open,
+	.sock_close        = pair1_sock_close,
+	.sock_recv         = pair1_sock_recv,
+	.sock_send         = pair1_sock_send,
+	.sock_recv_poll_fd = pair1_sock_get_recv_fd,
+	.sock_send_poll_fd = pair1_sock_get_send_fd,
+	.sock_options      = pair1_sock_options,
 };
 
 static nni_proto pair1_proto_raw = {

--- a/src/sp/protocol/pair1/pair1_test.c
+++ b/src/sp/protocol/pair1/pair1_test.c
@@ -8,6 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 #define SECOND 1000
@@ -524,7 +525,7 @@ test_pair1_poll_readable(void)
 	NUTS_PASS(nng_pair1_open(&s2));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(s1, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -570,7 +571,7 @@ test_pair1_poll_writable(void)
 	NUTS_PASS(nng_pair1_open(&s2));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(s1, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(s1, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable if not connected!

--- a/src/sp/protocol/pipeline0/pull.c
+++ b/src/sp/protocol/pipeline0/pull.c
@@ -253,23 +253,14 @@ pull0_sock_recv(void *arg, nni_aio *aio)
 }
 
 static int
-pull0_sock_get_recv_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+pull0_sock_get_recv_fd(void *arg, int *fdp)
 {
 	pull0_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->readable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->readable, fdp));
 }
 
 static nni_option pull0_sock_options[] = {
-	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = pull0_sock_get_recv_fd,
-	},
 	// terminate list
 	{
 	    .o_name = NULL,
@@ -286,14 +277,15 @@ static nni_proto_pipe_ops pull0_pipe_ops = {
 };
 
 static nni_proto_sock_ops pull0_sock_ops = {
-	.sock_size    = sizeof(pull0_sock),
-	.sock_init    = pull0_sock_init,
-	.sock_fini    = pull0_sock_fini,
-	.sock_open    = pull0_sock_open,
-	.sock_close   = pull0_sock_close,
-	.sock_send    = pull0_sock_send,
-	.sock_recv    = pull0_sock_recv,
-	.sock_options = pull0_sock_options,
+	.sock_size         = sizeof(pull0_sock),
+	.sock_init         = pull0_sock_init,
+	.sock_fini         = pull0_sock_fini,
+	.sock_open         = pull0_sock_open,
+	.sock_close        = pull0_sock_close,
+	.sock_send         = pull0_sock_send,
+	.sock_recv         = pull0_sock_recv,
+	.sock_recv_poll_fd = pull0_sock_get_recv_fd,
+	.sock_options      = pull0_sock_options,
 };
 
 static nni_proto pull0_proto = {

--- a/src/sp/protocol/pipeline0/pull_test.c
+++ b/src/sp/protocol/pipeline0/pull_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -58,7 +59,7 @@ test_pull_not_writeable(void)
 	nng_socket s;
 
 	NUTS_PASS(nng_pull0_open(&s));
-	NUTS_FAIL(nng_socket_get_int(s, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
+	NUTS_FAIL(nng_socket_get_send_poll_fd(s, &fd), NNG_ENOTSUP);
 	NUTS_CLOSE(s);
 }
 
@@ -73,7 +74,7 @@ test_pull_poll_readable(void)
 	NUTS_PASS(nng_push0_open(&push));
 	NUTS_PASS(nng_socket_set_ms(pull, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(push, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(pull, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(pull, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -110,7 +111,7 @@ test_pull_close_pending(void)
 
 	NUTS_PASS(nng_pull0_open(&pull));
 	NUTS_PASS(nng_push0_open(&push));
-	NUTS_PASS(nng_socket_get_int(pull, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(pull, &fd));
 	NUTS_TRUE(fd >= 0);
 	NUTS_MARRY_EX(pull, push, addr, &p1, &p2);
 

--- a/src/sp/protocol/pipeline0/push.c
+++ b/src/sp/protocol/pipeline0/push.c
@@ -364,16 +364,11 @@ push0_get_send_buf_len(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-push0_sock_get_send_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+push0_sock_get_send_fd(void *arg, int *fdp)
 {
 	push0_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->writable, fdp));
 }
 
 static nni_proto_pipe_ops push0_pipe_ops = {
@@ -387,10 +382,6 @@ static nni_proto_pipe_ops push0_pipe_ops = {
 
 static nni_option push0_sock_options[] = {
 	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = push0_sock_get_send_fd,
-	},
-	{
 	    .o_name = NNG_OPT_SENDBUF,
 	    .o_get  = push0_get_send_buf_len,
 	    .o_set  = push0_set_send_buf_len,
@@ -402,14 +393,15 @@ static nni_option push0_sock_options[] = {
 };
 
 static nni_proto_sock_ops push0_sock_ops = {
-	.sock_size    = sizeof(push0_sock),
-	.sock_init    = push0_sock_init,
-	.sock_fini    = push0_sock_fini,
-	.sock_open    = push0_sock_open,
-	.sock_close   = push0_sock_close,
-	.sock_options = push0_sock_options,
-	.sock_send    = push0_sock_send,
-	.sock_recv    = push0_sock_recv,
+	.sock_size         = sizeof(push0_sock),
+	.sock_init         = push0_sock_init,
+	.sock_fini         = push0_sock_fini,
+	.sock_open         = push0_sock_open,
+	.sock_close        = push0_sock_close,
+	.sock_options      = push0_sock_options,
+	.sock_send         = push0_sock_send,
+	.sock_recv         = push0_sock_recv,
+	.sock_send_poll_fd = push0_sock_get_send_fd,
 };
 
 static nni_proto push0_proto = {

--- a/src/sp/protocol/pipeline0/push_test.c
+++ b/src/sp/protocol/pipeline0/push_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -59,7 +60,7 @@ test_push_not_readable(void)
 	nng_socket s;
 
 	NUTS_PASS(nng_push0_open(&s));
-	NUTS_FAIL(nng_socket_get_int(s, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
+	NUTS_FAIL(nng_socket_get_recv_poll_fd(s, &fd), NNG_ENOTSUP);
 	NUTS_CLOSE(s);
 }
 
@@ -74,7 +75,7 @@ test_push_poll_writable(void)
 	NUTS_PASS(nng_push0_open(&push));
 	NUTS_PASS(nng_socket_set_ms(pull, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(push, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(push, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(push, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// This tests unbuffered sockets for now.
@@ -118,7 +119,7 @@ test_push_poll_buffered(void)
 	NUTS_PASS(nng_socket_set_ms(pull, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(push, NNG_OPT_SENDTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_int(push, NNG_OPT_SENDBUF, 2));
-	NUTS_PASS(nng_socket_get_int(push, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(push, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// We can write two message while unbuffered.
@@ -168,7 +169,7 @@ test_push_poll_truncate(void)
 	NUTS_PASS(nng_socket_set_ms(pull, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(push, NNG_OPT_SENDTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_int(push, NNG_OPT_SENDBUF, 3));
-	NUTS_PASS(nng_socket_get_int(push, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(push, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// We can write two message while unbuffered.

--- a/src/sp/protocol/pubsub0/pub_test.c
+++ b/src/sp/protocol/pubsub0/pub_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -58,7 +59,7 @@ test_pub_not_readable(void)
 	nng_socket pub;
 
 	NUTS_PASS(nng_pub0_open(&pub));
-	NUTS_FAIL(nng_socket_get_int(pub, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
+	NUTS_FAIL(nng_socket_get_recv_poll_fd(pub, &fd), NNG_ENOTSUP);
 	NUTS_CLOSE(pub);
 }
 
@@ -71,7 +72,7 @@ test_pub_poll_writeable(void)
 
 	NUTS_PASS(nng_sub0_open(&sub));
 	NUTS_PASS(nng_pub0_open(&pub));
-	NUTS_PASS(nng_socket_get_int(pub, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(pub, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Pub is *always* writeable

--- a/src/sp/protocol/pubsub0/sub.c
+++ b/src/sp/protocol/pubsub0/sub.c
@@ -615,16 +615,11 @@ sub0_sock_recv(void *arg, nni_aio *aio)
 }
 
 static int
-sub0_sock_get_recv_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+sub0_sock_get_recv_fd(void *arg, int *fdp)
 {
 	sub0_sock *sock = arg;
-	int        rv;
-	int        fd;
 
-	if ((rv = nni_pollable_getfd(&sock->readable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&sock->readable, fdp));
 }
 
 static int
@@ -699,10 +694,6 @@ static nni_option sub0_sock_options[] = {
 	    .o_set  = sub0_sock_unsubscribe,
 	},
 	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = sub0_sock_get_recv_fd,
-	},
-	{
 	    .o_name = NNG_OPT_RECVBUF,
 	    .o_get  = sub0_sock_get_recv_buf_len,
 	    .o_set  = sub0_sock_set_recv_buf_len,
@@ -719,14 +710,15 @@ static nni_option sub0_sock_options[] = {
 };
 
 static nni_proto_sock_ops sub0_sock_ops = {
-	.sock_size    = sizeof(sub0_sock),
-	.sock_init    = sub0_sock_init,
-	.sock_fini    = sub0_sock_fini,
-	.sock_open    = sub0_sock_open,
-	.sock_close   = sub0_sock_close,
-	.sock_send    = sub0_sock_send,
-	.sock_recv    = sub0_sock_recv,
-	.sock_options = sub0_sock_options,
+	.sock_size         = sizeof(sub0_sock),
+	.sock_init         = sub0_sock_init,
+	.sock_fini         = sub0_sock_fini,
+	.sock_open         = sub0_sock_open,
+	.sock_close        = sub0_sock_close,
+	.sock_send         = sub0_sock_send,
+	.sock_recv         = sub0_sock_recv,
+	.sock_recv_poll_fd = sub0_sock_get_recv_fd,
+	.sock_options      = sub0_sock_options,
 };
 
 static nni_proto sub0_proto = {

--- a/src/sp/protocol/pubsub0/xsub_test.c
+++ b/src/sp/protocol/pubsub0/xsub_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -47,7 +48,7 @@ test_xsub_not_writeable(void)
 	nng_socket sub;
 
 	NUTS_PASS(nng_sub0_open_raw(&sub));
-	NUTS_FAIL(nng_socket_get_int(sub, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
+	NUTS_FAIL(nng_socket_get_send_poll_fd(sub, &fd), NNG_ENOTSUP);
 	NUTS_CLOSE(sub);
 }
 
@@ -62,7 +63,7 @@ test_xsub_poll_readable(void)
 	NUTS_PASS(nng_pub0_open(&pub));
 	NUTS_PASS(nng_socket_set_ms(sub, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(pub, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(sub, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(sub, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -101,7 +102,7 @@ test_xsub_recv_late(void)
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
 	NUTS_PASS(nng_socket_set_ms(sub, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(pub, NNG_OPT_SENDTIMEO, 1000));
-	NUTS_PASS(nng_socket_get_int(sub, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(sub, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!

--- a/src/sp/protocol/reqrep0/rep.c
+++ b/src/sp/protocol/reqrep0/rep.c
@@ -595,30 +595,19 @@ rep0_sock_get_max_ttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-rep0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+rep0_sock_get_sendfd(void *arg, int *fdp)
 {
 	rep0_sock *s = arg;
-	int        rv;
-	int        fd;
 
-	if ((rv = nni_pollable_getfd(&s->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->writable, fdp));
 }
 
 static int
-rep0_sock_get_recvfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+rep0_sock_get_recvfd(void *arg, int *fdp)
 {
 	rep0_sock *s = arg;
-	int        rv;
-	int        fd;
 
-	if ((rv = nni_pollable_getfd(&s->readable, &fd)) != 0) {
-		return (rv);
-	}
-
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->readable, fdp));
 }
 
 static void
@@ -662,14 +651,6 @@ static nni_option rep0_sock_options[] = {
 	    .o_get  = rep0_sock_get_max_ttl,
 	    .o_set  = rep0_sock_set_max_ttl,
 	},
-	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = rep0_sock_get_recvfd,
-	},
-	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = rep0_sock_get_sendfd,
-	},
 	// terminate list
 	{
 	    .o_name = NULL,
@@ -677,14 +658,16 @@ static nni_option rep0_sock_options[] = {
 };
 
 static nni_proto_sock_ops rep0_sock_ops = {
-	.sock_size    = sizeof(rep0_sock),
-	.sock_init    = rep0_sock_init,
-	.sock_fini    = rep0_sock_fini,
-	.sock_open    = rep0_sock_open,
-	.sock_close   = rep0_sock_close,
-	.sock_options = rep0_sock_options,
-	.sock_send    = rep0_sock_send,
-	.sock_recv    = rep0_sock_recv,
+	.sock_size         = sizeof(rep0_sock),
+	.sock_init         = rep0_sock_init,
+	.sock_fini         = rep0_sock_fini,
+	.sock_open         = rep0_sock_open,
+	.sock_close        = rep0_sock_close,
+	.sock_send         = rep0_sock_send,
+	.sock_recv         = rep0_sock_recv,
+	.sock_send_poll_fd = rep0_sock_get_sendfd,
+	.sock_recv_poll_fd = rep0_sock_get_recvfd,
+	.sock_options      = rep0_sock_options,
 };
 
 static nni_proto rep0_proto = {

--- a/src/sp/protocol/reqrep0/rep_test.c
+++ b/src/sp/protocol/reqrep0/rep_test.c
@@ -54,7 +54,7 @@ test_rep_poll_writeable(void)
 
 	NUTS_PASS(nng_req0_open(&req));
 	NUTS_PASS(nng_rep0_open(&rep));
-	NUTS_PASS(nng_socket_get_int(rep, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(rep, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable before connect.
@@ -91,7 +91,7 @@ test_rep_poll_readable(void)
 
 	NUTS_PASS(nng_req0_open(&req));
 	NUTS_PASS(nng_rep0_open(&rep));
-	NUTS_PASS(nng_socket_get_int(rep, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(rep, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -117,21 +117,6 @@ test_rep_poll_readable(void)
 
 	NUTS_CLOSE(req);
 	NUTS_CLOSE(rep);
-}
-
-void
-test_rep_context_no_poll(void)
-{
-	int        fd;
-	nng_socket req;
-	nng_ctx    ctx;
-
-	NUTS_PASS(nng_rep0_open(&req));
-	NUTS_PASS(nng_ctx_open(&ctx, req));
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
-	NUTS_PASS(nng_ctx_close(ctx));
-	NUTS_CLOSE(req);
 }
 
 void
@@ -763,7 +748,6 @@ NUTS_TESTS = {
 	{ "rep send bad state", test_rep_send_bad_state },
 	{ "rep poll readable", test_rep_poll_readable },
 	{ "rep poll writable", test_rep_poll_writeable },
-	{ "rep context does not poll", test_rep_context_no_poll },
 	{ "rep validate peer", test_rep_validate_peer },
 	{ "rep huge send", test_rep_huge_send },
 	{ "rep huge send socket", test_rep_huge_send_socket },

--- a/src/sp/protocol/reqrep0/req.c
+++ b/src/sp/protocol/reqrep0/req.c
@@ -838,30 +838,19 @@ req0_sock_get_resend_tick(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-req0_sock_get_send_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+req0_sock_get_send_fd(void *arg, int *fdp)
 {
 	req0_sock *s = arg;
-	int        rv;
-	int        fd;
 
-	if ((rv = nni_pollable_getfd(&s->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->writable, fdp));
 }
 
 static int
-req0_sock_get_recv_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+req0_sock_get_recv_fd(void *arg, int *fdp)
 {
 	req0_sock *s = arg;
-	int        rv;
-	int        fd;
 
-	if ((rv = nni_pollable_getfd(&s->readable, &fd)) != 0) {
-		return (rv);
-	}
-
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->readable, fdp));
 }
 
 static nni_proto_pipe_ops req0_pipe_ops = {
@@ -905,14 +894,6 @@ static nni_option req0_sock_options[] = {
 	    .o_set  = req0_sock_set_resend_time,
 	},
 	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = req0_sock_get_recv_fd,
-	},
-	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = req0_sock_get_send_fd,
-	},
-	{
 	    .o_name = NNG_OPT_REQ_RESENDTICK,
 	    .o_get  = req0_sock_get_resend_tick,
 	    .o_set  = req0_sock_set_resend_tick,
@@ -925,14 +906,16 @@ static nni_option req0_sock_options[] = {
 };
 
 static nni_proto_sock_ops req0_sock_ops = {
-	.sock_size    = sizeof(req0_sock),
-	.sock_init    = req0_sock_init,
-	.sock_fini    = req0_sock_fini,
-	.sock_open    = req0_sock_open,
-	.sock_close   = req0_sock_close,
-	.sock_options = req0_sock_options,
-	.sock_send    = req0_sock_send,
-	.sock_recv    = req0_sock_recv,
+	.sock_size         = sizeof(req0_sock),
+	.sock_init         = req0_sock_init,
+	.sock_fini         = req0_sock_fini,
+	.sock_open         = req0_sock_open,
+	.sock_close        = req0_sock_close,
+	.sock_send         = req0_sock_send,
+	.sock_recv         = req0_sock_recv,
+	.sock_recv_poll_fd = req0_sock_get_recv_fd,
+	.sock_send_poll_fd = req0_sock_get_send_fd,
+	.sock_options      = req0_sock_options,
 };
 
 static nni_proto req0_proto = {

--- a/src/sp/protocol/reqrep0/req_test.c
+++ b/src/sp/protocol/reqrep0/req_test.c
@@ -8,6 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -517,7 +518,7 @@ test_req_poll_writeable(void)
 
 	NUTS_PASS(nng_req0_open(&req));
 	NUTS_PASS(nng_rep0_open(&rep));
-	NUTS_PASS(nng_socket_get_int(req, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(req, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable before connect.
@@ -570,7 +571,7 @@ test_req_poll_contention(void)
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 
-	NUTS_PASS(nng_socket_get_int(req, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(req, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable before connect.
@@ -627,7 +628,7 @@ test_req_poll_multi_pipe(void)
 	NUTS_PASS(nng_socket_set_int(req, NNG_OPT_SENDBUF, 1));
 	NUTS_PASS(nng_socket_set_ms(req, NNG_OPT_SENDTIMEO, 1000));
 
-	NUTS_PASS(nng_socket_get_int(req, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(req, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable before connect.
@@ -655,7 +656,7 @@ test_req_poll_readable(void)
 
 	NUTS_PASS(nng_req0_open(&req));
 	NUTS_PASS(nng_rep0_open(&rep));
-	NUTS_PASS(nng_socket_get_int(req, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(req, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -686,21 +687,6 @@ test_req_poll_readable(void)
 
 	NUTS_CLOSE(req);
 	NUTS_CLOSE(rep);
-}
-
-static void
-test_req_ctx_no_poll(void)
-{
-	int        fd;
-	nng_socket req;
-	nng_ctx    ctx;
-
-	NUTS_PASS(nng_req0_open(&req));
-	NUTS_PASS(nng_ctx_open(&ctx, req));
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
-	NUTS_PASS(nng_ctx_close(ctx));
-	NUTS_CLOSE(req);
 }
 
 static void
@@ -1027,7 +1013,6 @@ NUTS_TESTS = {
 	{ "req context send abort", test_req_ctx_send_abort },
 	{ "req context send twice", test_req_ctx_send_twice },
 	{ "req context send recv abort", test_req_ctx_send_recv_abort },
-	{ "req context does not poll", test_req_ctx_no_poll },
 	{ "req context recv close socket", test_req_ctx_recv_close_socket },
 	{ "req context recv nonblock", test_req_ctx_recv_nonblock },
 	{ "req context send nonblock", test_req_ctx_send_nonblock },

--- a/src/sp/protocol/reqrep0/xrep_test.c
+++ b/src/sp/protocol/reqrep0/xrep_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -63,7 +64,7 @@ test_xrep_poll_writeable(void)
 
 	NUTS_PASS(nng_rep0_open_raw(&rep));
 	NUTS_PASS(nng_req0_open(&req));
-	NUTS_PASS(nng_socket_get_int(rep, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(rep, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// We are always writeable, even before connect.  This is so that
@@ -91,7 +92,7 @@ test_xrep_poll_readable(void)
 
 	NUTS_PASS(nng_req0_open(&req));
 	NUTS_PASS(nng_rep0_open_raw(&rep));
-	NUTS_PASS(nng_socket_get_int(rep, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(rep, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!

--- a/src/sp/protocol/reqrep0/xreq_test.c
+++ b/src/sp/protocol/reqrep0/xreq_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -63,7 +64,7 @@ test_xreq_poll_writeable(void)
 
 	NUTS_PASS(nng_req0_open_raw(&req));
 	NUTS_PASS(nng_rep0_open(&rep));
-	NUTS_PASS(nng_socket_get_int(req, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(req, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// We can't write until we have a connection.
@@ -88,7 +89,7 @@ test_xreq_poll_readable(void)
 
 	NUTS_PASS(nng_req0_open_raw(&req));
 	NUTS_PASS(nng_rep0_open(&rep));
-	NUTS_PASS(nng_socket_get_int(req, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(req, &fd));
 	NUTS_PASS(nng_socket_set_ms(rep, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(req, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(rep, NNG_OPT_SENDTIMEO, 1000));

--- a/src/sp/protocol/survey0/respond.c
+++ b/src/sp/protocol/survey0/respond.c
@@ -585,29 +585,19 @@ resp0_sock_get_max_ttl(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-resp0_sock_get_sendfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+resp0_sock_get_sendfd(void *arg, int *fdp)
 {
 	resp0_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->writable, fdp));
 }
 
 static int
-resp0_sock_get_recvfd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+resp0_sock_get_recvfd(void *arg, int *fdp)
 {
 	resp0_sock *s = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&s->readable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&s->readable, fdp));
 }
 
 static void
@@ -649,16 +639,6 @@ static nni_option resp0_sock_options[] = {
 	    .o_get  = resp0_sock_get_max_ttl,
 	    .o_set  = resp0_sock_set_max_ttl,
 	},
-	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = resp0_sock_get_recvfd,
-	    .o_set  = NULL,
-	},
-	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = resp0_sock_get_sendfd,
-	    .o_set  = NULL,
-	},
 	// terminate list
 	{
 	    .o_name = NULL,
@@ -666,14 +646,16 @@ static nni_option resp0_sock_options[] = {
 };
 
 static nni_proto_sock_ops resp0_sock_ops = {
-	.sock_size    = sizeof(resp0_sock),
-	.sock_init    = resp0_sock_init,
-	.sock_fini    = resp0_sock_fini,
-	.sock_open    = resp0_sock_open,
-	.sock_close   = resp0_sock_close,
-	.sock_send    = resp0_sock_send,
-	.sock_recv    = resp0_sock_recv,
-	.sock_options = resp0_sock_options,
+	.sock_size         = sizeof(resp0_sock),
+	.sock_init         = resp0_sock_init,
+	.sock_fini         = resp0_sock_fini,
+	.sock_open         = resp0_sock_open,
+	.sock_close        = resp0_sock_close,
+	.sock_send         = resp0_sock_send,
+	.sock_recv         = resp0_sock_recv,
+	.sock_send_poll_fd = resp0_sock_get_sendfd,
+	.sock_recv_poll_fd = resp0_sock_get_recvfd,
+	.sock_options      = resp0_sock_options,
 };
 
 static nni_proto resp0_proto = {

--- a/src/sp/protocol/survey0/respond_test.c
+++ b/src/sp/protocol/survey0/respond_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 void
@@ -52,7 +53,7 @@ test_resp_poll_writeable(void)
 
 	NUTS_PASS(nng_surveyor0_open(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_socket_get_int(resp, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(resp, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not writable before connect.
@@ -89,7 +90,7 @@ test_resp_poll_readable(void)
 
 	NUTS_PASS(nng_surveyor0_open(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_socket_get_int(resp, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(resp, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -114,21 +115,6 @@ test_resp_poll_readable(void)
 	// TODO verify unsolicited response
 
 	NUTS_CLOSE(surv);
-	NUTS_CLOSE(resp);
-}
-
-void
-test_resp_context_no_poll(void)
-{
-	int        fd;
-	nng_socket resp;
-	nng_ctx    ctx;
-
-	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_ctx_open(&ctx, resp));
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
-	NUTS_PASS(nng_ctx_close(ctx));
 	NUTS_CLOSE(resp);
 }
 
@@ -568,7 +554,6 @@ TEST_LIST = {
 	{ "respond send bad state", test_resp_send_bad_state },
 	{ "respond poll readable", test_resp_poll_readable },
 	{ "respond poll writable", test_resp_poll_writeable },
-	{ "respond context does not poll", test_resp_context_no_poll },
 	{ "respond validate peer", test_resp_validate_peer },
 	{ "respond double recv", test_resp_double_recv },
 	{ "respond close pipe before send", test_resp_close_pipe_before_send },

--- a/src/sp/protocol/survey0/survey.c
+++ b/src/sp/protocol/survey0/survey.c
@@ -520,29 +520,19 @@ surv0_sock_get_survey_time(void *arg, void *buf, size_t *szp, nni_opt_type t)
 }
 
 static int
-surv0_sock_get_send_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+surv0_sock_get_send_fd(void *arg, int *fdp)
 {
 	surv0_sock *sock = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&sock->writable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&sock->writable, fdp));
 }
 
 static int
-surv0_sock_get_recv_fd(void *arg, void *buf, size_t *szp, nni_opt_type t)
+surv0_sock_get_recv_fd(void *arg, int *fdp)
 {
 	surv0_sock *sock = arg;
-	int         rv;
-	int         fd;
 
-	if ((rv = nni_pollable_getfd(&sock->readable, &fd)) != 0) {
-		return (rv);
-	}
-	return (nni_copyout_int(fd, buf, szp, t));
+	return (nni_pollable_getfd(&sock->readable, fdp));
 }
 
 static void
@@ -598,14 +588,6 @@ static nni_option surv0_sock_options[] = {
 	    .o_get  = surv0_sock_get_max_ttl,
 	    .o_set  = surv0_sock_set_max_ttl,
 	},
-	{
-	    .o_name = NNG_OPT_RECVFD,
-	    .o_get  = surv0_sock_get_recv_fd,
-	},
-	{
-	    .o_name = NNG_OPT_SENDFD,
-	    .o_get  = surv0_sock_get_send_fd,
-	},
 	// terminate list
 	{
 	    .o_name = NULL,
@@ -613,14 +595,16 @@ static nni_option surv0_sock_options[] = {
 };
 
 static nni_proto_sock_ops surv0_sock_ops = {
-	.sock_size    = sizeof(surv0_sock),
-	.sock_init    = surv0_sock_init,
-	.sock_fini    = surv0_sock_fini,
-	.sock_open    = surv0_sock_open,
-	.sock_close   = surv0_sock_close,
-	.sock_send    = surv0_sock_send,
-	.sock_recv    = surv0_sock_recv,
-	.sock_options = surv0_sock_options,
+	.sock_size         = sizeof(surv0_sock),
+	.sock_init         = surv0_sock_init,
+	.sock_fini         = surv0_sock_fini,
+	.sock_open         = surv0_sock_open,
+	.sock_close        = surv0_sock_close,
+	.sock_send         = surv0_sock_send,
+	.sock_recv         = surv0_sock_recv,
+	.sock_send_poll_fd = surv0_sock_get_send_fd,
+	.sock_recv_poll_fd = surv0_sock_get_recv_fd,
+	.sock_options      = surv0_sock_options,
 };
 
 static nni_proto surv0_proto = {

--- a/src/sp/protocol/survey0/survey_test.c
+++ b/src/sp/protocol/survey0/survey_test.c
@@ -8,6 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -313,7 +314,7 @@ test_surv_poll_writeable(void)
 
 	NUTS_PASS(nng_surveyor0_open(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_socket_get_int(surv, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(surv, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Survey is broadcast, so we can always write.
@@ -338,7 +339,7 @@ test_surv_poll_readable(void)
 
 	NUTS_PASS(nng_surveyor0_open(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_socket_get_int(surv, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(surv, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!
@@ -369,21 +370,6 @@ test_surv_poll_readable(void)
 
 	NUTS_CLOSE(surv);
 	NUTS_CLOSE(resp);
-}
-
-static void
-test_surv_ctx_no_poll(void)
-{
-	int        fd;
-	nng_socket surv;
-	nng_ctx    ctx;
-
-	NUTS_PASS(nng_surveyor0_open(&surv));
-	NUTS_PASS(nng_ctx_open(&ctx, surv));
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_SENDFD, &fd), NNG_ENOTSUP);
-	NUTS_FAIL(nng_ctx_get_int(ctx, NNG_OPT_RECVFD, &fd), NNG_ENOTSUP);
-	NUTS_PASS(nng_ctx_close(ctx));
-	NUTS_CLOSE(surv);
 }
 
 static void
@@ -639,7 +625,6 @@ TEST_LIST = {
 	{ "survey cancel post recv", test_surv_cancel_post_recv },
 	{ "survey poll writable", test_surv_poll_writeable },
 	{ "survey poll readable", test_surv_poll_readable },
-	{ "survey context does not poll", test_surv_ctx_no_poll },
 	{ "survey context recv close socket",
 	    test_surv_ctx_recv_close_socket },
 	{ "survey context recv nonblock", test_surv_ctx_recv_nonblock },

--- a/src/sp/protocol/survey0/xrespond_test.c
+++ b/src/sp/protocol/survey0/xrespond_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -63,7 +64,7 @@ test_xresp_poll_writeable(void)
 
 	NUTS_PASS(nng_respondent0_open_raw(&resp));
 	NUTS_PASS(nng_surveyor0_open(&surv));
-	NUTS_PASS(nng_socket_get_int(resp, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(resp, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// We are always writeable, even before connect.  This is so that
@@ -91,7 +92,7 @@ test_xresp_poll_readable(void)
 
 	NUTS_PASS(nng_surveyor0_open(&surv));
 	NUTS_PASS(nng_respondent0_open_raw(&resp));
-	NUTS_PASS(nng_socket_get_int(resp, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(resp, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Not readable if not connected!

--- a/src/sp/protocol/survey0/xsurvey_test.c
+++ b/src/sp/protocol/survey0/xsurvey_test.c
@@ -7,6 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "nng/nng.h"
 #include <nuts.h>
 
 static void
@@ -62,7 +63,7 @@ test_xsurvey_poll_writeable(void)
 
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_socket_get_int(surv, NNG_OPT_SENDFD, &fd));
+	NUTS_PASS(nng_socket_get_send_poll_fd(surv, &fd));
 	NUTS_TRUE(fd >= 0);
 
 	// Survey is broadcast, so we can always write.
@@ -87,7 +88,7 @@ test_xsurvey_poll_readable(void)
 
 	NUTS_PASS(nng_surveyor0_open_raw(&surv));
 	NUTS_PASS(nng_respondent0_open(&resp));
-	NUTS_PASS(nng_socket_get_int(surv, NNG_OPT_RECVFD, &fd));
+	NUTS_PASS(nng_socket_get_recv_poll_fd(surv, &fd));
 	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(surv, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(resp, NNG_OPT_SENDTIMEO, 1000));

--- a/tests/nonblock.c
+++ b/tests/nonblock.c
@@ -35,7 +35,7 @@ repthr(void *arg)
 
 	nng_listen(rep, addr, &l, NNG_FLAG_NONBLOCK);
 
-	nng_socket_get_int(rep, NNG_OPT_RECVFD, &ifd);
+	nng_socket_get_recv_poll_fd(rep, &ifd);
 	fd = ifd;
 
 	for (;;) {

--- a/tests/pollfd.c
+++ b/tests/pollfd.c
@@ -53,18 +53,14 @@ TestMain("Poll FDs", {
 		nng_msleep(50);
 
 		Convey("We can get a recv FD", {
-			int    fd;
-			size_t sz;
+			int fd;
 
-			sz = sizeof(fd);
-			So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
+			So(nng_socket_get_recv_poll_fd(s1, &fd) == 0);
 			So(fd != (int) INVALID_SOCKET);
 
 			Convey("And it is always the same fd", {
 				int fd2;
-				sz = sizeof(fd2);
-				So(nng_socket_get(
-				       s1, NNG_OPT_RECVFD, &fd2, &sz) == 0);
+				So(nng_socket_get_recv_poll_fd(s1, &fd2) == 0);
 				So(fd2 == fd);
 			});
 
@@ -91,24 +87,11 @@ TestMain("Poll FDs", {
 		});
 
 		Convey("We can get a send FD", {
-			int    fd;
-			size_t sz;
+			int fd;
 
-			sz = sizeof(fd);
-			So(nng_socket_get(s1, NNG_OPT_SENDFD, &fd, &sz) == 0);
+			So(nng_socket_get_send_poll_fd(s1, &fd) == 0);
 			So(fd != (int) INVALID_SOCKET);
 			So(nng_send(s1, "oops", 4, 0) == 0);
-		});
-
-		Convey("Must have a big enough size", {
-			int    fd;
-			size_t sz;
-			sz = 1;
-			So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd, &sz) ==
-			    NNG_EINVAL);
-			sz = 128;
-			So(nng_socket_get(s1, NNG_OPT_RECVFD, &fd, &sz) == 0);
-			So(sz == sizeof(fd));
 		});
 	});
 
@@ -117,7 +100,7 @@ TestMain("Poll FDs", {
 		int        fd;
 		So(nng_pull0_open(&s3) == 0);
 		Reset({ nng_close(s3); });
-		So(nng_socket_get_int(s3, NNG_OPT_SENDFD, &fd) == NNG_ENOTSUP);
+		So(nng_socket_get_send_poll_fd(s3, &fd) == NNG_ENOTSUP);
 	});
 
 	Convey("We cannot get a recv FD for PUSH", {
@@ -125,6 +108,6 @@ TestMain("Poll FDs", {
 		int        fd;
 		So(nng_push0_open(&s3) == 0);
 		Reset({ nng_close(s3); });
-		So(nng_socket_get_int(s3, NNG_OPT_RECVFD, &fd) == NNG_ENOTSUP);
+		So(nng_socket_get_recv_poll_fd(s3, &fd) == NNG_ENOTSUP);
 	});
 })


### PR DESCRIPTION
These options are removed entirely, and their functionality is now available via special functions, `nng_socket_get_send_poll_fd` and `nng_socket_get_recv_poll_fd`, making these first class methods on the socket.

This eliminates a bit of wasteful code, and provides type safety for these methods.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
