### PR TITLE
Replace NNG_OPT_SUB_SUBSCRIBE/UNSUBSCRIBE with functions.

### DIFF
--- a/docs/ref/migrate/nanomsg.md
+++ b/docs/ref/migrate/nanomsg.md
@@ -84,6 +84,8 @@ The following options are changed.
 | `NN_IPV4ONLY`          | None                          | Use URL such as `tcp4://` to obtain this functionality. |
 | `NN_SOCKET_NAME`       | `NNG_OPT_SOCKNAME`            |
 | `NN_MAXTTL`            | `NNG_OPT_MAXTTL`              |
+| `NN_SUB_SUBSCRIBE`     | `nng_sub0_socket_subscribe`   | No longer an option, use a function call.               |
+| `NN_SUB_UNSUBSCRIBE`   | `nng_sub0_socket_unsubscribe` | No longer an option, use a function call.               |
 
 ## Error Codes
 

--- a/docs/ref/migrate/nng1.md
+++ b/docs/ref/migrate/nng1.md
@@ -80,6 +80,13 @@ matching the actual wire protocol values, instead of `int`.
 
 The `NNG_OPT_RAW` option has aso been replaced by a function, `nng_socket_raw`.
 
+## Subscriptions
+
+The `NNG_OPT_SUB_SUBSCRIBE` and `NNG_OPT_SUB_UNSUBCRIBE` options have been replaced by
+the following functions: `nng_sub0_socket_subscribe`, `nng_sub0_socket_unsubscribe`,
+`nng_sub0_ctx_subscribe` and `nng_sub0_ctx_unsubscribe`. These functions, like the options
+they replace, are only applicable to SUB sockets.
+
 ## Statistics Use Constified Pointers
 
 A number of the statistics functions take, or return, `const nng_stat *` instead

--- a/include/nng/protocol/pubsub0/sub.h
+++ b/include/nng/protocol/pubsub0/sub.h
@@ -11,6 +11,8 @@
 #ifndef NNG_PROTOCOL_PUBSUB0_SUB_H
 #define NNG_PROTOCOL_PUBSUB0_SUB_H
 
+#include <nng/nng.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -19,6 +21,13 @@ NNG_DECL int nng_sub0_open(nng_socket *);
 
 NNG_DECL int nng_sub0_open_raw(nng_socket *);
 
+NNG_DECL int nng_sub0_socket_subscribe(
+    nng_socket id, const void *buf, size_t sz);
+NNG_DECL int nng_sub0_socket_unsubscribe(
+    nng_socket id, const void *buf, size_t sz);
+NNG_DECL int nng_sub0_ctx_subscribe(nng_ctx id, const void *buf, size_t sz);
+NNG_DECL int nng_sub0_ctx_unsubscribe(nng_ctx id, const void *buf, size_t sz);
+
 #ifndef nng_sub_open
 #define nng_sub_open nng_sub0_open
 #endif
@@ -26,9 +35,6 @@ NNG_DECL int nng_sub0_open_raw(nng_socket *);
 #ifndef nng_sub_open_raw
 #define nng_sub_open_raw nng_sub0_open_raw
 #endif
-
-#define NNG_OPT_SUB_SUBSCRIBE "sub:subscribe"
-#define NNG_OPT_SUB_UNSUBSCRIBE "sub:unsubscribe"
 
 #define NNG_OPT_SUB_PREFNEW "sub:prefnew"
 

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -824,6 +824,18 @@ nni_sock_proto_pipe_ops(nni_sock *sock)
 	return (&sock->s_pipe_ops);
 }
 
+struct nni_proto_sock_ops *
+nni_sock_proto_ops(nni_sock *sock)
+{
+	return (&sock->s_sock_ops);
+}
+
+struct nni_proto_ctx_ops *
+nni_ctx_proto_ops(nni_ctx *ctx)
+{
+	return (&ctx->c_ops);
+}
+
 void *
 nni_sock_proto_data(nni_sock *sock)
 {
@@ -1140,6 +1152,12 @@ nni_ctx_find(nni_ctx **cp, uint32_t id, bool closing)
 	nni_mtx_unlock(&sock_lk);
 
 	return (rv);
+}
+
+void *
+nni_ctx_proto_data(nni_ctx *ctx)
+{
+	return (ctx->c_data);
 }
 
 static void

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -26,7 +26,9 @@ extern bool        nni_sock_raw(nni_sock *);
 extern void       *nni_sock_proto_data(nni_sock *);
 extern void        nni_sock_add_stat(nni_sock *, nni_stat_item *);
 
+extern struct nni_proto_sock_ops *nni_sock_proto_ops(nni_sock *);
 extern struct nni_proto_pipe_ops *nni_sock_proto_pipe_ops(nni_sock *);
+extern struct nni_proto_ctx_ops  *nni_ctx_proto_ops(nni_ctx *);
 
 extern int nni_sock_setopt(
     nni_sock *, const char *, const void *, size_t, nni_opt_type);
@@ -76,6 +78,8 @@ extern int nni_ctx_open(nni_ctx **, nni_sock *);
 // (If the socket for the context is being closed, then this will return
 // NNG_ECLOSED unless the final argument is true.)
 extern int nni_ctx_find(nni_ctx **, uint32_t, bool);
+
+extern void *nni_ctx_proto_data(nni_ctx *);
 
 // nni_ctx_rele is called to release a hold on the context.  These holds
 // are acquired by either nni_ctx_open or nni_ctx_find.  If the context

--- a/src/sp/protocol/pubsub0/pub_test.c
+++ b/src/sp/protocol/pubsub0/pub_test.c
@@ -141,7 +141,7 @@ test_pub_send_queued(void)
 	// test to be really meaningful.
 	NUTS_PASS(nng_pub0_open(&pub));
 	NUTS_PASS(nng_sub0_open(&sub));
-	NUTS_PASS(nng_socket_set(sub, NNG_OPT_SUB_SUBSCRIBE, "", 0));
+	NUTS_PASS(nng_sub0_socket_subscribe(sub, "", 0));
 	NUTS_PASS(nng_socket_set_int(pub, NNG_OPT_SENDBUF, 10));
 	NUTS_PASS(nng_socket_set_int(sub, NNG_OPT_RECVBUF, 10));
 	NUTS_PASS(nng_socket_set_ms(pub, NNG_OPT_SENDTIMEO, 1000));

--- a/src/sp/protocol/pubsub0/xsub_test.c
+++ b/src/sp/protocol/pubsub0/xsub_test.c
@@ -7,7 +7,8 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
+#include <nng/nng.h>
+#include <nng/protocol/pubsub0/sub.h>
 #include <nuts.h>
 
 static void
@@ -257,22 +258,20 @@ test_xsub_recv_buf_option(void)
 static void
 test_xsub_subscribe_option(void)
 {
-	nng_socket  sub;
-	const char *opt = NNG_OPT_SUB_SUBSCRIBE;
+	nng_socket sub;
 
 	NUTS_PASS(nng_sub0_open_raw(&sub));
-	NUTS_FAIL(nng_socket_set(sub, opt, "abc", 3), NNG_ENOTSUP);
+	NUTS_FAIL(nng_sub0_socket_subscribe(sub, "abc", 3), NNG_ENOTSUP);
 	NUTS_CLOSE(sub);
 }
 
 static void
 test_xsub_unsubscribe_option(void)
 {
-	nng_socket  sub;
-	const char *opt = NNG_OPT_SUB_UNSUBSCRIBE;
+	nng_socket sub;
 
 	NUTS_PASS(nng_sub0_open_raw(&sub));
-	NUTS_FAIL(nng_socket_set(sub, opt, "abc", 3), NNG_ENOTSUP);
+	NUTS_FAIL(nng_sub0_socket_unsubscribe(sub, "abc", 3), NNG_ENOTSUP);
 	NUTS_CLOSE(sub);
 }
 

--- a/src/tools/nngcat/nngcat.c
+++ b/src/tools/nngcat/nngcat.c
@@ -1065,8 +1065,7 @@ main(int ac, char **av)
 	}
 
 	for (struct topic *t = topics; t != NULL; t = t->next) {
-		rv = nng_socket_set(
-		    sock, NNG_OPT_SUB_SUBSCRIBE, t->val, strlen(t->val));
+		rv = nng_sub0_socket_subscribe(sock, t->val, strlen(t->val));
 		if (rv != 0) {
 			fatal("Unable to subscribe to topic %s: %s", t->val,
 			    nng_strerror(rv));

--- a/src/tools/perf/pubdrop.c
+++ b/src/tools/perf/pubdrop.c
@@ -206,7 +206,7 @@ sub_client(void *arg)
 	if ((rv = nng_socket_set_ms(sock, NNG_OPT_RECONNMINT, 51)) != 0) {
 		die("setopt: %s", nng_strerror(rv));
 	}
-	if ((rv = nng_socket_set(sock, NNG_OPT_SUB_SUBSCRIBE, "", 0)) != 0) {
+	if ((rv = nng_sub0_socket_subscribe(sock, "", 0)) != 0) {
 		die("setopt: %s", nng_strerror(rv));
 	}
 	if ((rv = nng_socket_set_ms(sock, NNG_OPT_RECVTIMEO, 10000)) != 0) {

--- a/tests/multistress.c
+++ b/tests/multistress.c
@@ -581,7 +581,7 @@ pubsub0_test(int ntests)
 		if ((rv = nng_aio_alloc(&cli->recd, sub0_recd, cli)) != 0) {
 			fatal("nng_aio_alloc", rv);
 		}
-		rv = nng_socket_set(cli->sock, NNG_OPT_SUB_SUBSCRIBE, "", 0);
+		rv = nng_sub0_socket_subscribe(cli->sock, "", 0);
 		if (rv != 0) {
 			fatal("subscribe", rv);
 		}


### PR DESCRIPTION
The main purpose is to eliminate the NNI_TYPE_OPAQUE options, by putting these into their own first class, protocol-specific, functions.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
