### PR TITLE
Integer sign extension bug in socket.c.

### DIFF
--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1485,8 +1485,8 @@ dialer_timer_start_locked(nni_dialer *d)
 	// This algorithm may lead to slight biases because we don't
 	// have a statistically perfect distribution with the modulo of
 	// the random number, but this really doesn't matter.
-	nni_sleep_aio(
-	    back_off ? (int) nni_random() % back_off : 0, &d->d_tmo_aio);
+	nni_sleep_aio(back_off ? (nng_duration) (nni_random() % back_off) : 0,
+	    &d->d_tmo_aio);
 }
 
 void


### PR DESCRIPTION
It turns out that for now this results in early wakeups, due to another bug in the aio framework.  But when that bug is fixed, this bug will lead to hangs when redialing.

(cherry picked from commit 2dfb99506142f2d59bcc0e0fa7db6b19a3c75d43)

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
