### PR TITLE
tls: remove support for TLS 1.0 and 1.1.

### DIFF
--- a/docs/man/nng_tls_config_version.3tls.adoc
+++ b/docs/man/nng_tls_config_version.3tls.adoc
@@ -1,6 +1,6 @@
 = nng_tls_config_version(3tls)
 //
-// Copyright 2020 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This document is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -20,8 +20,6 @@ nng_tls_config_version - configure TLS version
 #include <nng/supplemental/tls/tls.h>
 
 typedef enum nng_tls_version {
-    NNG_TLS_1_0 = 0x301,
-    NNG_TLS_1_1 = 0x302,
     NNG_TLS_1_2 = 0x303,
     NNG_TLS_1_3 = 0x304
 } nng_tls_version;
@@ -41,21 +39,9 @@ By default (if this function is not called), NNG will attempt to use both TLS v1
 
 Clients and servers will generally negotiate for the highest mutually supported TLS version.
 
-TIP: As of this writing, we recommend setting the minimum to
-`NNG_TLS_1_2` (TLS v1.2) and the maximum to `NNG_TLS_1_3` (TLS v1.3).
-This gives the best security, while ensuring good interoperability.
-Nearly all modern TLS implementations support TLS v1.2.
-
-TIP: Support for TLS v1.3 is available via external TLS engines.
-
-NOTE: The cipher-suites supported by TLS v1.3 are different from earlier versions.
-Therefore it may be necessary to generate different certificates.
-
 == CAVEATS
 
-* SSL v2.0 and v3.0 are insecure, and not supported in NNG.
-
-* TLS v1.3 is not supported by the default _Mbed TLS_ engine at this time.
+* SSL v2.0, SSL v3.0, TLS v1.0 and TLS v1.1 are insecure, and not supported in NNG.
 
 * Some TLS engines may not support limiting the maximum version.
 
@@ -63,7 +49,7 @@ Therefore it may be necessary to generate different certificates.
 
 * Session resumption is not supported in NNG (for any TLS version).
 
-* TLS PSK support is not supported in NNG. (This is a limitation planned to be addressed.)
+* TLS PSK support is dependent upon the engine.
 
 == RETURN VALUES
 

--- a/docs/ref/migrate/nng1.md
+++ b/docs/ref/migrate/nng1.md
@@ -54,6 +54,12 @@ Likewise, when using the streams API, use the [`nng_stream_listener_set_tls`] or
 Note that the declarations needed for TLS configuration are now available in `<nng/nng.h>`,
 rather than the supplemental header.
 
+## Old TLS Versions Removed
+
+Support for very old TLS versions 1.0 and 1.1 is removed.
+Further, the `NNG_TLS_1_0` and `NNG_TLS_1_1` constants are also removed.
+Applications should use `NNG_TLS_1_2` or even `NNG_TLS_1_3` instead.
+
 ## Option Functions
 
 The previously deprecated `nng_pipe_getopt_xxx` family of functions is removed.

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -1499,12 +1499,9 @@ typedef enum nng_tls_auth_mode {
 } nng_tls_auth_mode;
 
 // TLS version numbers.  We encode the major number and minor number
-// as separate byte fields.  No support for SSL 3.0 or earlier -- older
+// as separate byte fields.  No support for TLS 1.1 or earlier -- older
 // versions are known to be insecure and should not be used.
-// When possible applications should restrict themselves to TLS 1.2 or better.
 typedef enum nng_tls_version {
-	NNG_TLS_1_0 = 0x301,
-	NNG_TLS_1_1 = 0x302,
 	NNG_TLS_1_2 = 0x303,
 	NNG_TLS_1_3 = 0x304
 } nng_tls_version;

--- a/src/supplemental/tls/mbedtls/tls.c
+++ b/src/supplemental/tls/mbedtls/tls.c
@@ -467,9 +467,8 @@ config_init(nng_tls_engine_config *cfg, enum nng_tls_mode mode)
 
 	mbedtls_ssl_conf_authmode(&cfg->cfg_ctx, auth_mode);
 
-	// Default: we *require* TLS v1.2 or newer, which is also known as
-	// SSL v3.3. As of this writing, Mbed TLS still does not support
-	// version 1.3, and we would want to test it before enabling it here.
+	// We *require* TLS v1.2 or newer, which is also known as SSL
+	// v3.3.
 	cfg->min_ver = MBEDTLS_SSL_MINOR_VERSION_3;
 #ifdef MBEDTLS_SSL_PROTO_TLS1_3
 	cfg->max_ver = MBEDTLS_SSL_MINOR_VERSION_4;
@@ -689,16 +688,6 @@ config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 		return (NNG_ENOTSUP);
 	}
 	switch (min_ver) {
-#ifdef MBEDTLS_SSL_MINOR_VERSION_1
-	case NNG_TLS_1_0:
-		v1 = MBEDTLS_SSL_MINOR_VERSION_1;
-		break;
-#endif
-#ifdef MBEDTLS_SSL_MINOR_VERSION_2
-	case NNG_TLS_1_1:
-		v1 = MBEDTLS_SSL_MINOR_VERSION_2;
-		break;
-#endif
 #ifdef MBEDTLS_SSL_MINOR_VERSION_3
 	case NNG_TLS_1_2:
 		v1 = MBEDTLS_SSL_MINOR_VERSION_3;
@@ -716,16 +705,6 @@ config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 	}
 
 	switch (max_ver) {
-#ifdef MBEDTLS_SSL_MINOR_VERSION_1
-	case NNG_TLS_1_0:
-		v2 = MBEDTLS_SSL_MINOR_VERSION_1;
-		break;
-#endif
-#ifdef MBEDTLS_SSL_MINOR_VERSION_2
-	case NNG_TLS_1_1:
-		v2 = MBEDTLS_SSL_MINOR_VERSION_2;
-		break;
-#endif
 #ifdef MBEDTLS_SSL_MINOR_VERSION_3
 	case NNG_TLS_1_2:
 		v2 = MBEDTLS_SSL_MINOR_VERSION_3;

--- a/src/supplemental/tls/tls_test.c
+++ b/src/supplemental/tls/tls_test.c
@@ -20,29 +20,20 @@ test_tls_config_version(void)
 	NUTS_PASS(nng_tls_config_alloc(&cfg, NNG_TLS_MODE_SERVER));
 
 	// Verify that min ver < max ver
-	NUTS_FAIL(nng_tls_config_version(cfg, NNG_TLS_1_3, NNG_TLS_1_0),
+	NUTS_FAIL(nng_tls_config_version(cfg, NNG_TLS_1_3, NNG_TLS_1_2),
 	    NNG_ENOTSUP);
 
-	// Verify that we cannot configure SSL 3.0 or older.
-	NUTS_FAIL(nng_tls_config_version(cfg, NNG_TLS_1_0 - 1, NNG_TLS_1_0),
+	// Verify that we cannot configure TLS 1.1 or older.
+	NUTS_FAIL(
+	    nng_tls_config_version(cfg, NNG_TLS_1_2 - 1, NNG_TLS_1_2 - 1),
 	    NNG_ENOTSUP);
 
 	// Verify that we cannot configure TLS > 1.3.
-	NUTS_FAIL(nng_tls_config_version(cfg, NNG_TLS_1_0, NNG_TLS_1_3 + 1),
+	NUTS_FAIL(nng_tls_config_version(cfg, NNG_TLS_1_2, NNG_TLS_1_3 + 1),
 	    NNG_ENOTSUP);
 
 	// Verify that we *can* configure some various ranges starting with
-	// TLS v1.2.  Note that some libraries no longer support TLS 1.0
-	// and TLS 1.1, so we don't test for them.
-#if 0
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_0, NNG_TLS_1_0));
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_0, NNG_TLS_1_1));
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_0, NNG_TLS_1_2));
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_0, NNG_TLS_1_3));
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_1, NNG_TLS_1_1));
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_1, NNG_TLS_1_2));
-	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_1, NNG_TLS_1_3));
-#endif
+	// TLS v1.2.
 	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_2, NNG_TLS_1_2));
 	NUTS_PASS(nng_tls_config_version(cfg, NNG_TLS_1_2, NNG_TLS_1_3));
 

--- a/src/supplemental/tls/wolfssl/wolfssl.c
+++ b/src/supplemental/tls/wolfssl/wolfssl.c
@@ -602,12 +602,6 @@ wolf_config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
 		return (NNG_ENOTSUP);
 	}
 	switch (min_ver) {
-	case NNG_TLS_1_0:
-		rv = wolfSSL_CTX_SetMinVersion(cfg->ctx, WOLFSSL_TLSV1);
-		break;
-	case NNG_TLS_1_1:
-		rv = wolfSSL_CTX_SetMinVersion(cfg->ctx, WOLFSSL_TLSV1_1);
-		break;
 	case NNG_TLS_1_2:
 		rv = wolfSSL_CTX_SetMinVersion(cfg->ctx, WOLFSSL_TLSV1_2);
 		break;


### PR DESCRIPTION
Those old algorithms are not used anywhere, and are not recommended. TLS 1.2 support has been prevalent for over a decade.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
