### PR TITLE
remove NNG_OPT_SOCKNAME (and socket names altogether)

### DIFF
--- a/docs/man/nng_options.5.adoc
+++ b/docs/man/nng_options.5.adoc
@@ -20,16 +20,8 @@ nng_options - socket, dialer, listener, and pipe options
 ----
 #include <nng/nng.h>
 
-#define NNG_OPT_SOCKNAME      "socket-name"
-#define NNG_OPT_RAW           "raw"
-#define NNG_OPT_PROTO         "protocol"
-#define NNG_OPT_PROTONAME     "protocol-name"
-#define NNG_OPT_PEER          "peer"
-#define NNG_OPT_PEERNAME      "peer-name"
 #define NNG_OPT_RECVBUF       "recv-buffer"
 #define NNG_OPT_SENDBUF       "send-buffer"
-#define NNG_OPT_RECVFD        "recv-fd"
-#define NNG_OPT_SENDFD        "send-fd"
 #define NNG_OPT_RECVTIMEO     "recv-timeout"
 #define NNG_OPT_SENDTIMEO     "send-timeout"
 #define NNG_OPT_LOCADDR       "local-address"
@@ -153,36 +145,6 @@ This value must be an integer between 0 and 8192, inclusive.
 NOTE: Not all protocols support buffering received messages.
 For example xref:nng_req.7.adoc[_req_] can only deal with a single reply at a time.
 
-[[NNG_OPT_RECVFD]]
-((`NNG_OPT_RECVFD`))::
-(((poll)))
-(((select)))
-(((receive, polling)))
-(`int`)
-This read-only option is used to obtain an integer file descriptor suitable
-for use with
-http://pubs.opengroup.org/onlinepubs/7908799/xsh/poll.html[`poll()`],
-http://pubs.opengroup.org/onlinepubs/7908799/xsh/select.html[`select()`],
-(or on Windows systems
-https://msdn.microsoft.com/en-us/library/windows/desktop/ms741669(v=vs.85).aspx[`WSAPoll()`])
-and similar functions.
-This descriptor will be *readable* when a message is available for receiving
-on the socket.
-When no message is ready for receiving, then this file descriptor will *not*
-be readable.
-+
-IMPORTANT: Applications should never attempt to read or write to the
-returned file descriptor.
-+
-IMPORTANT: This option is incompatible with
-xref:nng_ctx.5.adoc[`nng_ctx`] contexts and should not be used on a socket
-where they are in use.
-+
-TIP: While this option may help applications integrate into existing polling
-loops, it is more efficient, and often easier, to use the asynchronous I/O
-objects instead.
-See xref:nng_aio_alloc.3.adoc[`nng_aio_alloc()`].
-
 [[NNG_OPT_RECVMAXSZ]]
 ((`NNG_OPT_RECVMAXSZ`))::
 (((receive, maximum size)))
@@ -240,37 +202,6 @@ NOTE: Not all protocols support buffering sent messages.
 For example, xref:nng_req.7.adoc[_req_] can only have a single request
 outstanding at a time (per context).
 
-[[NNG_OPT_SENDFD]]
-((`NNG_OPT_SENDFD`))::
-(((poll)))
-(((select)))
-(((send, polling)))
-(`int`)
-This read-only option is used to obtain an integer file descriptor suitable
-for use with
-http://pubs.opengroup.org/onlinepubs/7908799/xsh/poll.html[`poll()`],
-http://pubs.opengroup.org/onlinepubs/7908799/xsh/select.html[`select()`],
-(or on Windows systems
-https://msdn.microsoft.com/en-us/library/windows/desktop/ms741669(v=vs.85).aspx[`WSAPoll()`])
-and similar functions.
-+
-This descriptor will be *readable* when the socket is able to accept a
-message for sending without blocking.
-When the socket is no longer able to accept such messages without blocking,
-the descriptor will *not* be readable.
-+
-IMPORTANT: Applications should never attempt to read or write to the
-returned file descriptor; use should be limited to polling system calls only.
-+
-IMPORTANT: This option is incompatible with
-xref:nng_ctx.5.adoc[`nng_ctx`] contexts and should not be used on a socket
-where they are in use.
-+
-TIP: While this option may help applications integrate into existing polling
-loops, it is more efficient, and often easier, to use the asynchronous I/O
-objects instead.
-See xref:nng_aio_alloc.3.adoc[`nng_aio_alloc()`].
-
 [[NNG_OPT_SENDTIMEO]]
 ((`NNG_OPT_SENDTIMEO`))::
 (((send, timeout)))
@@ -280,17 +211,6 @@ This is the socket send timeout in milliseconds.
 When a message cannot be queued for delivery by the socket for this period of
 time (such as if send buffers are full), the operation will fail with a
 return value of `NNG_ETIMEDOUT`.
-
-[[NNG_OPT_SOCKNAME]]
-((`NNG_OPT_SOCKNAME`))::
-(((name, socket)))
-(string)
-This the socket name.
-By default, this is a string corresponding to the value of the socket.
-The string must fit within 64-bytes, including the terminating
-`NUL` byte.
-The value is intended for application use, and is not used for anything
-in the library itself.
 
 [[NNG_OPT_MAXTTL]]
 ((`NNG_OPT_MAXTTL`))::
@@ -320,17 +240,6 @@ Accordingly it can only be used with dialers, listeners, and pipes.
 +
 NOTE: Some transports will canonify URLs before returning them to the
 application.
-
-[[NNG_OPT_PROTO]]
-((`NNG_OPT_PROTO`))::
-(`int`)
-This read-only option is used to obtain the 16-bit number for the socket's protocol.
-
-[[NNG_OPT_PEER]]
-((`NNG_OPT_PEER`))::
-(`int`)
-This read-only option is used to obtain the 16-bit number of the
-peer protocol for the socket.
 
 [[NNG_OPT_PEER_GID]]
 ((`NNG_OPT_PEER_GID`))::
@@ -364,16 +273,6 @@ This option is generally only available on POSIX systems, on certain transports.
 (`uint64_t`)
 This read-only option provides a connected peer's the zone id.
 Zones (and this option) are only supported on Solaris and illumos systems, on select transports.
-
-[[NNG_OPT_PEERNAME]]
-((`NNG_OPT_PEERNAME`))::
-(string)
-This read-only option is used to obtain the name of the peer protocol for the socket.
-
-[[NNG_OPT_PROTONAME]]
-((`NNG_OPT_PROTONAME`))::
-(string)
-This read-only option is used to obtain the name of the socket's protocol.
 
 == SEE ALSO
 

--- a/docs/ref/migrate/nanomsg.md
+++ b/docs/ref/migrate/nanomsg.md
@@ -87,7 +87,7 @@ The following options are changed.
 | `NN_DOMAIN`            | None                            | NNG options are not divided by domain or protocol.      |
 | `NN_PROTOCOL`          | [`nng_socket_proto_id`]         | No longer an option. See also `nng_socket_proto_name`.  |
 | `NN_IPV4ONLY`          | None                            | Use URL such as `tcp4://` to obtain this functionality. |
-| `NN_SOCKET_NAME`       | `NNG_OPT_SOCKNAME`              |
+| `NN_SOCKET_NAME`       | None                            | Removed from NNG.                                       |
 | `NN_MAXTTL`            | `NNG_OPT_MAXTTL`                |
 | `NN_SUB_SUBSCRIBE`     | [`nng_sub0_socket_subscribe`]   | No longer an option, use a function call.               |
 | `NN_SUB_UNSUBSCRIBE`   | [`nng_sub0_socket_unsubscribe`] | No longer an option, use a function call.               |

--- a/docs/ref/migrate/nng1.md
+++ b/docs/ref/migrate/nng1.md
@@ -136,6 +136,9 @@ The `NNG_OPT_RAW` option has aso been replaced by a function, [`nng_socket_raw`]
 The `NNG_OPT_SENDFD` and `NNG_OPT_RECVFD` options have been replaced by
 [`nng_socket_get_send_poll_fd`] and [`nng_socket_get_recv_poll_fd`] respectively.
 
+The `NNG_OPT_SOCKNAME` function is removed. This was provided for application use, and never used internally by NNG.
+Applications should keep track of this information separately.
+
 ## Subscriptions
 
 The `NNG_OPT_SUB_SUBSCRIBE` and `NNG_OPT_SUB_UNSUBCRIBE` options have been replaced by

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -713,7 +713,6 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 #define NNG_FLAG_NONBLOCK 2u // Non-blocking operations
 
 // Options.
-#define NNG_OPT_SOCKNAME "socket-name"
 #define NNG_OPT_RECVBUF "recv-buffer"
 #define NNG_OPT_SENDBUF "send-buffer"
 #define NNG_OPT_RECVTIMEO "recv-timeout"

--- a/src/core/stats_test.c
+++ b/src/core/stats_test.c
@@ -25,7 +25,6 @@ test_stats_socket(void)
 
 	NUTS_OPEN(s1);
 	NUTS_OPEN(s2);
-	nng_socket_set_string(s2, NNG_OPT_SOCKNAME, "second");
 	NUTS_MARRY(s1, s2);
 	NUTS_SEND(s1, "ping");
 	NUTS_RECV(s2, "ping");
@@ -37,14 +36,6 @@ test_stats_socket(void)
 	NUTS_ASSERT(st1 != NULL);
 	NUTS_ASSERT(st2 != NULL);
 	NUTS_ASSERT(st1 != st2);
-	item = nng_stat_find(st1, "name");
-	NUTS_ASSERT(item != NULL);
-	NUTS_ASSERT(nng_stat_string(item) != NULL);
-	NUTS_MATCH(nng_stat_string(item), "1");
-	item = nng_stat_find(st2, "name");
-	NUTS_ASSERT(item != NULL);
-	NUTS_ASSERT(nng_stat_string(item) != NULL);
-	NUTS_MATCH(nng_stat_string(item), "second");
 	item = nng_stat_find(st1, "tx_msgs");
 	NUTS_ASSERT(item != NULL);
 	NUTS_ASSERT(nng_stat_value(item) == 1);
@@ -71,7 +62,6 @@ test_stats_dump(void)
 
 	NUTS_OPEN(s1);
 	NUTS_OPEN(s2);
-	nng_socket_set_string(s2, NNG_OPT_SOCKNAME, "second");
 	NUTS_MARRY(s1, s2);
 	NUTS_SEND(s1, "ping");
 	NUTS_RECV(s2, "ping");


### PR DESCRIPTION
This functionality was provided principally for libnanomsg compatibility. This saves some memory and eliminates some pointless functionality.

While here, updated the socket options documentation to remove references to options already removed.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
