### PR TITLE
tcp/tls: Remove support for local interface address in dialer URLs

### DIFF
--- a/docs/ref/migrate/nanomsg.md
+++ b/docs/ref/migrate/nanomsg.md
@@ -121,4 +121,11 @@ There are some exceptions. Be aware that the numeric values are _not_ the same.
 | `EMFILE`       | [`NNG_ENOFILES`]                                                                         |
 | `ENOSPC`       | [`NNG_ENOSPC`]                                                                           |
 
+## Local Addresses for Dialing
+
+The ability to specify the source address in the UROL,to use when
+using `nn_dial` inside the URL is not present in NNG. The correct
+way to specify the local address is using the `NNG_OPT_LOCADDR` option on the
+dialer before starting to dial.
+
 {{#include ../xref.md}}

--- a/docs/ref/migrate/nng1.md
+++ b/docs/ref/migrate/nng1.md
@@ -60,6 +60,14 @@ Support for very old TLS versions 1.0 and 1.1 is removed.
 Further, the `NNG_TLS_1_0` and `NNG_TLS_1_1` constants are also removed.
 Applications should use `NNG_TLS_1_2` or even `NNG_TLS_1_3` instead.
 
+## Support for Local Addresses in Dial URLs Removed
+
+NNG 1.x had an undocumented ability to specify the local address to bind
+to when dialing, by using the local address in front of the destination
+address separated by a semicolon. This was provided for legacy libnanomsg
+compatilibility, and is no longer offered. The correct way to specify a
+local address is by setting `NNG_OPT_LOCADDR` on the dialer.
+
 ## Option Functions
 
 The previously deprecated `nng_pipe_getopt_xxx` family of functions is removed.

--- a/src/sp/transport/tcp/tcp_test.c
+++ b/src/sp/transport/tcp/tcp_test.c
@@ -47,27 +47,6 @@ test_tcp_wild_card_bind(void)
 }
 
 void
-test_tcp_local_address_connect(void)
-{
-
-	nng_socket s1;
-	nng_socket s2;
-	char       addr[NNG_MAXADDRLEN];
-	uint16_t   port;
-
-	NUTS_OPEN(s1);
-	NUTS_OPEN(s2);
-	port = nuts_next_port();
-	(void) snprintf(addr, sizeof(addr), "tcp://127.0.0.1:%u", port);
-	NUTS_PASS(nng_listen(s1, addr, NULL, 0));
-	(void) snprintf(
-	    addr, sizeof(addr), "tcp://127.0.0.1;127.0.0.1:%u", port);
-	NUTS_PASS(nng_dial(s2, addr, NULL, 0));
-	NUTS_CLOSE(s2);
-	NUTS_CLOSE(s1);
-}
-
-void
 test_tcp_port_zero_bind(void)
 {
 	nng_socket   s1;
@@ -88,19 +67,6 @@ test_tcp_port_zero_bind(void)
 	NUTS_PASS(nng_dial(s2, addr, NULL, 0));
 	nng_strfree(addr);
 	NUTS_CLOSE(s2);
-	NUTS_CLOSE(s1);
-}
-
-void
-test_tcp_bad_local_interface(void)
-{
-	nng_socket s1;
-	int        rv;
-
-	NUTS_OPEN(s1);
-	rv = nng_dial(s1, "tcp://bogus1;127.0.0.1:80", NULL, 0),
-	NUTS_TRUE(rv != 0);
-	NUTS_TRUE(rv != NNG_ECONNREFUSED);
 	NUTS_CLOSE(s1);
 }
 
@@ -244,8 +210,6 @@ NUTS_TESTS = {
 	{ "tcp wild card connect fail", test_tcp_wild_card_connect_fail },
 	{ "tcp wild card bind", test_tcp_wild_card_bind },
 	{ "tcp port zero bind", test_tcp_port_zero_bind },
-	{ "tcp local address connect", test_tcp_local_address_connect },
-	{ "tcp bad local interface", test_tcp_bad_local_interface },
 	{ "tcp non-local address", test_tcp_non_local_address },
 	{ "tcp malformed address", test_tcp_malformed_address },
 	{ "tcp no delay option", test_tcp_no_delay_option },

--- a/src/sp/transport/tls/tls_tran_test.c
+++ b/src/sp/transport/tls/tls_tran_test.c
@@ -133,38 +133,6 @@ test_tls_port_zero_bind(void)
 }
 
 void
-test_tls_local_address_connect(void)
-{
-
-	nng_socket      s1;
-	nng_socket      s2;
-	nng_tls_config *c1, *c2;
-	nng_dialer      d;
-	nng_listener    l;
-	char            addr[NNG_MAXADDRLEN];
-	uint16_t        port;
-
-	c1 = tls_server_config();
-	c2 = tls_client_config();
-	NUTS_OPEN(s1);
-	NUTS_OPEN(s2);
-	port = nuts_next_port();
-	(void) snprintf(addr, sizeof(addr), "tls+tcp://127.0.0.1:%u", port);
-	NUTS_PASS(nng_listener_create(&l, s1, addr));
-	NUTS_PASS(nng_listener_set_tls(l, c1));
-	NUTS_PASS(nng_listener_start(l, 0));
-	(void) snprintf(
-	    addr, sizeof(addr), "tls+tcp://127.0.0.1;127.0.0.1:%u", port);
-	NUTS_PASS(nng_dialer_create(&d, s2, addr));
-	NUTS_PASS(nng_dialer_set_tls(d, c2));
-	NUTS_PASS(nng_dialer_start(d, 0));
-	NUTS_CLOSE(s2);
-	NUTS_CLOSE(s1);
-	nng_tls_config_free(c1);
-	nng_tls_config_free(c2);
-}
-
-void
 test_tls_malformed_address(void)
 {
 	nng_socket s1;
@@ -364,7 +332,6 @@ NUTS_TESTS = {
 	{ "tls wild card connect fail", test_tls_wild_card_connect_fail },
 	{ "tls wild card bind", test_tls_wild_card_bind },
 	{ "tls port zero bind", test_tls_port_zero_bind },
-	{ "tls local address connect", test_tls_local_address_connect },
 	{ "tls malformed address", test_tls_malformed_address },
 	{ "tls no delay option", test_tls_no_delay_option },
 	{ "tls keep alive option", test_tls_keep_alive_option },


### PR DESCRIPTION
This was an undocumented capability provided for libnanomsg.  The correct way to obtain the same functionality is to use `NNG_OPT_LOCADDR`.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
