### PR TITLE
Reference counting changes

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -88,32 +88,14 @@ nni_aio_init(nni_aio *aio, nni_cb cb, void *arg)
 	aio->a_timeout = NNG_DURATION_INFINITE;
 	aio->a_expire_q =
 	    nni_aio_expire_q_list[nni_random() % nni_aio_expire_q_cnt];
-#ifndef NDEBUG
-	nni_atomic_init_bool(&aio->a_started);
-#endif
-	nni_atomic_init_bool(&aio->a_stopped);
 	aio->a_init = true;
-}
-
-#ifndef NDEBUG
-static bool
-aio_started(nni_aio *aio)
-{
-	return (nni_atomic_get_bool(&aio->a_started));
-}
-#endif
-
-static bool
-aio_stopped(nni_aio *aio)
-{
-	return (nni_atomic_get_bool(&aio->a_stopped));
 }
 
 void
 nni_aio_fini(nni_aio *aio)
 {
 	if (aio != NULL && aio->a_init) {
-		NNI_ASSERT(aio_stopped(aio) || !aio_started(aio));
+		NNI_ASSERT(!nni_aio_busy(aio));
 		nni_task_fini(&aio->a_task);
 	}
 }
@@ -177,7 +159,7 @@ nni_aio_set_iov(nni_aio *aio, unsigned nio, const nni_iov *iov)
 void
 nni_aio_stop(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_init && !aio_stopped(aio)) {
+	if (aio != NULL && aio->a_init) {
 		nni_aio_cancel_fn fn;
 		void             *arg;
 		nni_aio_expire_q *eq = aio->a_expire_q;
@@ -196,20 +178,17 @@ nni_aio_stop(nni_aio *aio)
 
 		if (fn != NULL) {
 			fn(aio, arg, NNG_ECANCELED);
-		} else {
-			nni_task_abort(&aio->a_task);
 		}
 
 		nni_aio_wait(aio);
-
-		nni_atomic_set_bool(&aio->a_stopped, true);
+		NNI_ASSERT(!nni_aio_busy(aio));
 	}
 }
 
 void
 nni_aio_close(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_init && !aio_stopped(aio)) {
+	if (aio != NULL && aio->a_init) {
 		nni_aio_cancel_fn fn;
 		void             *arg;
 		nni_aio_expire_q *eq = aio->a_expire_q;
@@ -225,8 +204,6 @@ nni_aio_close(nni_aio *aio)
 
 		if (fn != NULL) {
 			fn(aio, arg, NNG_ECLOSED);
-		} else {
-			nni_task_abort(&aio->a_task);
 		}
 	}
 }
@@ -312,7 +289,7 @@ nni_aio_count(nni_aio *aio)
 void
 nni_aio_wait(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_init && !aio_stopped(aio)) {
+	if (aio != NULL && aio->a_init) {
 		nni_task_wait(&aio->a_task);
 	}
 }
@@ -326,35 +303,21 @@ nni_aio_busy(nni_aio *aio)
 int
 nni_aio_begin(nni_aio *aio)
 {
-	// If any of these triggers then the caller has a defect because
-	// it means that the aio is already in use.  This is always
-	// a bug in the caller.  These checks are not technically thread
-	// safe in the event that they are false.  Users of race detectors
-	// checks may wish ignore or suppress these checks.
 	nni_aio_expire_q *eq = aio->a_expire_q;
 
-	if (aio_stopped(aio)) {
-		NNI_ASSERT(!nni_list_node_active(&aio->a_expire_node));
-		aio->a_result    = NNG_ECANCELED;
-		aio->a_cancel_fn = NULL;
-		return (NNG_ECANCELED);
-	}
-#ifndef NDEBUG
-	nni_atomic_set_bool(&aio->a_started, true);
-#endif
 	nni_mtx_lock(&eq->eq_mtx);
 	NNI_ASSERT(!nni_aio_list_active(aio));
 	NNI_ASSERT(aio->a_cancel_fn == NULL);
 	NNI_ASSERT(!nni_list_node_active(&aio->a_expire_node));
 
-	// Some initialization can be done outside the lock, because
-	// we must have exclusive access to the aio.
 	for (unsigned i = 0; i < NNI_NUM_ELEMENTS(aio->a_outputs); i++) {
 		aio->a_outputs[i] = NULL;
 	}
-	aio->a_result    = 0;
-	aio->a_count     = 0;
-	aio->a_cancel_fn = NULL;
+	aio->a_result       = 0;
+	aio->a_count        = 0;
+	aio->a_cancel_fn    = NULL;
+	aio->a_abort        = false;
+	aio->a_abort_result = 0;
 
 	// We should not reschedule anything at this point.
 	if (aio->a_stop || eq->eq_stop) {
@@ -363,7 +326,6 @@ nni_aio_begin(nni_aio *aio)
 		aio->a_expire    = NNI_TIME_NEVER;
 		aio->a_sleep     = false;
 		aio->a_expire_ok = false;
-		nni_atomic_set_bool(&aio->a_stopped, true);
 		nni_mtx_unlock(&eq->eq_mtx);
 
 		return (NNG_ECANCELED);
@@ -382,7 +344,6 @@ nni_aio_schedule(nni_aio *aio, nni_aio_cancel_fn cancel, void *data)
 		// Convert the relative timeout to an absolute timeout.
 		switch (aio->a_timeout) {
 		case NNG_DURATION_ZERO:
-			nni_task_abort(&aio->a_task);
 			return (NNG_ETIMEDOUT);
 		case NNG_DURATION_INFINITE:
 		case NNG_DURATION_DEFAULT:
@@ -396,9 +357,15 @@ nni_aio_schedule(nni_aio *aio, nni_aio_cancel_fn cancel, void *data)
 
 	nni_mtx_lock(&eq->eq_mtx);
 	if (aio->a_stop || eq->eq_stop) {
-		nni_task_abort(&aio->a_task);
 		nni_mtx_unlock(&eq->eq_mtx);
 		return (NNG_ECLOSED);
+	}
+	if (aio->a_abort) {
+		int rv              = aio->a_abort_result;
+		aio->a_abort        = false;
+		aio->a_abort_result = 0;
+		nni_mtx_unlock(&eq->eq_mtx);
+		return (rv);
 	}
 
 	NNI_ASSERT(aio->a_cancel_fn == NULL);
@@ -423,19 +390,26 @@ nni_aio_abort(nni_aio *aio, int rv)
 	void             *arg;
 	nni_aio_expire_q *eq = aio->a_expire_q;
 
+	NNI_ASSERT(rv > 0);
 	nni_mtx_lock(&eq->eq_mtx);
 	nni_aio_expire_rm(aio);
 	fn                = aio->a_cancel_fn;
 	arg               = aio->a_cancel_arg;
 	aio->a_cancel_fn  = NULL;
 	aio->a_cancel_arg = NULL;
+	if (fn != NULL) {
+		aio->a_abort        = true;
+		aio->a_abort_result = rv;
+	}
 	nni_mtx_unlock(&eq->eq_mtx);
 
 	// Stop any I/O at the provider level.
+	// If this doesn't catch it, it will be reported
+	// at nni_aio_schedule (if this is to be scheduled),
+	// or else we have proceeded to far to cancel this operation.
+	// (In which case it should complete shortly.)
 	if (fn != NULL) {
 		fn(aio, arg, rv);
-	} else {
-		nni_task_abort(&aio->a_task);
 	}
 }
 
@@ -446,13 +420,6 @@ nni_aio_finish_impl(
     nni_aio *aio, int rv, size_t count, nni_msg *msg, bool sync)
 {
 	nni_aio_expire_q *eq = aio->a_expire_q;
-
-	if (eq == NULL) {
-		// This happens if we have stopped I/O
-		// and some caller has not noticed yet.
-		// (The caller should own the aio.)
-		return;
-	}
 
 	nni_mtx_lock(&eq->eq_mtx);
 
@@ -465,9 +432,11 @@ nni_aio_finish_impl(
 		aio->a_msg = msg;
 	}
 
-	aio->a_expire     = NNI_TIME_NEVER;
-	aio->a_sleep      = false;
-	aio->a_use_expire = false;
+	aio->a_expire       = NNI_TIME_NEVER;
+	aio->a_sleep        = false;
+	aio->a_use_expire   = false;
+	aio->a_abort        = false;
+	aio->a_abort_result = 0;
 	nni_mtx_unlock(&eq->eq_mtx);
 
 	if (sync) {

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -9,7 +9,6 @@
 //
 
 #include "core/nng_impl.h"
-#include "core/taskq.h"
 #include <string.h>
 
 struct nni_aio_expire_q {
@@ -89,38 +88,32 @@ nni_aio_init(nni_aio *aio, nni_cb cb, void *arg)
 	aio->a_timeout = NNG_DURATION_INFINITE;
 	aio->a_expire_q =
 	    nni_aio_expire_q_list[nni_random() % nni_aio_expire_q_cnt];
+#ifndef NDEBUG
+	nni_atomic_init_bool(&aio->a_started);
+#endif
+	nni_atomic_init_bool(&aio->a_stopped);
+	aio->a_init = true;
+}
+
+#ifndef NDEBUG
+static bool
+aio_started(nni_aio *aio)
+{
+	return (nni_atomic_get_bool(&aio->a_started));
+}
+#endif
+
+static bool
+aio_stopped(nni_aio *aio)
+{
+	return (nni_atomic_get_bool(&aio->a_stopped));
 }
 
 void
 nni_aio_fini(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_expire_q != NULL) {
-		nni_aio_cancel_fn fn;
-		void             *arg;
-		nni_aio_expire_q *eq = aio->a_expire_q;
-
-		// This is like aio_close, but we don't want to dispatch
-		// the task.  And unlike aio_stop, we don't want to wait
-		// for the task.  (Because we implicitly do task_fini.)
-		// We also wait if the aio is being expired.
-		nni_mtx_lock(&eq->eq_mtx);
-		aio->a_stop = true;
-		while (aio->a_expiring) {
-			nni_cv_wait(&eq->eq_cv);
-		}
-		nni_aio_expire_rm(aio);
-		fn                = aio->a_cancel_fn;
-		arg               = aio->a_cancel_arg;
-		aio->a_cancel_fn  = NULL;
-		aio->a_cancel_arg = NULL;
-		nni_mtx_unlock(&eq->eq_mtx);
-
-		if (fn != NULL) {
-			fn(aio, arg, NNG_ECLOSED);
-		} else {
-			nni_task_abort(&aio->a_task);
-		}
-
+	if (aio != NULL && aio->a_init) {
+		NNI_ASSERT(aio_stopped(aio) || !aio_started(aio));
 		nni_task_fini(&aio->a_task);
 	}
 }
@@ -141,7 +134,8 @@ nni_aio_alloc(nni_aio **aio_p, nni_cb cb, void *arg)
 void
 nni_aio_free(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_expire_q != NULL) {
+	if (aio != NULL) {
+		nni_aio_stop(aio);
 		nni_aio_fini(aio);
 		NNI_FREE_STRUCT(aio);
 	}
@@ -150,7 +144,7 @@ nni_aio_free(nni_aio *aio)
 void
 nni_aio_reap(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_expire_q != NULL) {
+	if (aio != NULL && aio->a_init) {
 		nni_reap(&aio_reap_list, aio);
 	}
 }
@@ -183,13 +177,13 @@ nni_aio_set_iov(nni_aio *aio, unsigned nio, const nni_iov *iov)
 void
 nni_aio_stop(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_expire_q != NULL) {
+	if (aio != NULL && aio->a_init && !aio_stopped(aio)) {
 		nni_aio_cancel_fn fn;
 		void             *arg;
 		nni_aio_expire_q *eq = aio->a_expire_q;
 
 		nni_mtx_lock(&eq->eq_mtx);
-		aio->a_stop       = true;
+		aio->a_stop = true;
 		while (aio->a_expiring) {
 			nni_cv_wait(&eq->eq_cv);
 		}
@@ -207,13 +201,15 @@ nni_aio_stop(nni_aio *aio)
 		}
 
 		nni_aio_wait(aio);
+
+		nni_atomic_set_bool(&aio->a_stopped, true);
 	}
 }
 
 void
 nni_aio_close(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_expire_q != NULL) {
+	if (aio != NULL && aio->a_init && !aio_stopped(aio)) {
 		nni_aio_cancel_fn fn;
 		void             *arg;
 		nni_aio_expire_q *eq = aio->a_expire_q;
@@ -316,7 +312,7 @@ nni_aio_count(nni_aio *aio)
 void
 nni_aio_wait(nni_aio *aio)
 {
-	if (aio != NULL && aio->a_expire_q != NULL) {
+	if (aio != NULL && aio->a_init && !aio_stopped(aio)) {
 		nni_task_wait(&aio->a_task);
 	}
 }
@@ -337,6 +333,15 @@ nni_aio_begin(nni_aio *aio)
 	// checks may wish ignore or suppress these checks.
 	nni_aio_expire_q *eq = aio->a_expire_q;
 
+	if (aio_stopped(aio)) {
+		NNI_ASSERT(!nni_list_node_active(&aio->a_expire_node));
+		aio->a_result    = NNG_ECANCELED;
+		aio->a_cancel_fn = NULL;
+		return (NNG_ECANCELED);
+	}
+#ifndef NDEBUG
+	nni_atomic_set_bool(&aio->a_started, true);
+#endif
 	nni_mtx_lock(&eq->eq_mtx);
 	NNI_ASSERT(!nni_aio_list_active(aio));
 	NNI_ASSERT(aio->a_cancel_fn == NULL);
@@ -358,6 +363,7 @@ nni_aio_begin(nni_aio *aio)
 		aio->a_expire    = NNI_TIME_NEVER;
 		aio->a_sleep     = false;
 		aio->a_expire_ok = false;
+		nni_atomic_set_bool(&aio->a_stopped, true);
 		nni_mtx_unlock(&eq->eq_mtx);
 
 		return (NNG_ECANCELED);
@@ -440,6 +446,13 @@ nni_aio_finish_impl(
     nni_aio *aio, int rv, size_t count, nni_msg *msg, bool sync)
 {
 	nni_aio_expire_q *eq = aio->a_expire_q;
+
+	if (eq == NULL) {
+		// This happens if we have stopped I/O
+		// and some caller has not noticed yet.
+		// (The caller should own the aio.)
+		return;
+	}
 
 	nni_mtx_lock(&eq->eq_mtx);
 

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -94,33 +94,35 @@ nni_aio_init(nni_aio *aio, nni_cb cb, void *arg)
 void
 nni_aio_fini(nni_aio *aio)
 {
-	nni_aio_cancel_fn fn;
-	void             *arg;
-	nni_aio_expire_q *eq = aio->a_expire_q;
+	if (aio != NULL && aio->a_expire_q != NULL) {
+		nni_aio_cancel_fn fn;
+		void             *arg;
+		nni_aio_expire_q *eq = aio->a_expire_q;
 
-	// This is like aio_close, but we don't want to dispatch
-	// the task.  And unlike aio_stop, we don't want to wait
-	// for the task.  (Because we implicitly do task_fini.)
-	// We also wait if the aio is being expired.
-	nni_mtx_lock(&eq->eq_mtx);
-	aio->a_stop = true;
-	while (aio->a_expiring) {
-		nni_cv_wait(&eq->eq_cv);
+		// This is like aio_close, but we don't want to dispatch
+		// the task.  And unlike aio_stop, we don't want to wait
+		// for the task.  (Because we implicitly do task_fini.)
+		// We also wait if the aio is being expired.
+		nni_mtx_lock(&eq->eq_mtx);
+		aio->a_stop = true;
+		while (aio->a_expiring) {
+			nni_cv_wait(&eq->eq_cv);
+		}
+		nni_aio_expire_rm(aio);
+		fn                = aio->a_cancel_fn;
+		arg               = aio->a_cancel_arg;
+		aio->a_cancel_fn  = NULL;
+		aio->a_cancel_arg = NULL;
+		nni_mtx_unlock(&eq->eq_mtx);
+
+		if (fn != NULL) {
+			fn(aio, arg, NNG_ECLOSED);
+		} else {
+			nni_task_abort(&aio->a_task);
+		}
+
+		nni_task_fini(&aio->a_task);
 	}
-	nni_aio_expire_rm(aio);
-	fn                = aio->a_cancel_fn;
-	arg               = aio->a_cancel_arg;
-	aio->a_cancel_fn  = NULL;
-	aio->a_cancel_arg = NULL;
-	nni_mtx_unlock(&eq->eq_mtx);
-
-	if (fn != NULL) {
-		fn(aio, arg, NNG_ECLOSED);
-	} else {
-		nni_task_abort(&aio->a_task);
-	}
-
-	nni_task_fini(&aio->a_task);
 }
 
 int
@@ -139,7 +141,7 @@ nni_aio_alloc(nni_aio **aio_p, nni_cb cb, void *arg)
 void
 nni_aio_free(nni_aio *aio)
 {
-	if (aio != NULL) {
+	if (aio != NULL && aio->a_expire_q != NULL) {
 		nni_aio_fini(aio);
 		NNI_FREE_STRUCT(aio);
 	}
@@ -148,7 +150,7 @@ nni_aio_free(nni_aio *aio)
 void
 nni_aio_reap(nni_aio *aio)
 {
-	if (aio != NULL) {
+	if (aio != NULL && aio->a_expire_q != NULL) {
 		nni_reap(&aio_reap_list, aio);
 	}
 }
@@ -181,7 +183,7 @@ nni_aio_set_iov(nni_aio *aio, unsigned nio, const nni_iov *iov)
 void
 nni_aio_stop(nni_aio *aio)
 {
-	if (aio != NULL) {
+	if (aio != NULL && aio->a_expire_q != NULL) {
 		nni_aio_cancel_fn fn;
 		void             *arg;
 		nni_aio_expire_q *eq = aio->a_expire_q;
@@ -211,7 +213,7 @@ nni_aio_stop(nni_aio *aio)
 void
 nni_aio_close(nni_aio *aio)
 {
-	if (aio != NULL) {
+	if (aio != NULL && aio->a_expire_q != NULL) {
 		nni_aio_cancel_fn fn;
 		void             *arg;
 		nni_aio_expire_q *eq = aio->a_expire_q;
@@ -314,7 +316,9 @@ nni_aio_count(nni_aio *aio)
 void
 nni_aio_wait(nni_aio *aio)
 {
-	nni_task_wait(&aio->a_task);
+	if (aio != NULL && aio->a_expire_q != NULL) {
+		nni_task_wait(&aio->a_task);
+	}
 }
 
 bool

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -393,14 +393,12 @@ nni_aio_abort(nni_aio *aio, int rv)
 	NNI_ASSERT(rv > 0);
 	nni_mtx_lock(&eq->eq_mtx);
 	nni_aio_expire_rm(aio);
-	fn                = aio->a_cancel_fn;
-	arg               = aio->a_cancel_arg;
-	aio->a_cancel_fn  = NULL;
-	aio->a_cancel_arg = NULL;
-	if (fn != NULL) {
-		aio->a_abort        = true;
-		aio->a_abort_result = rv;
-	}
+	fn                  = aio->a_cancel_fn;
+	arg                 = aio->a_cancel_arg;
+	aio->a_cancel_fn    = NULL;
+	aio->a_cancel_arg   = NULL;
+	aio->a_abort        = true;
+	aio->a_abort_result = rv;
 	nni_mtx_unlock(&eq->eq_mtx);
 
 	// Stop any I/O at the provider level.

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -211,16 +211,18 @@ typedef struct nni_aio_expire_q nni_aio_expire_q;
 // any of these members -- the definition is provided here to facilitate
 // inlining, but that should be the only use.
 struct nng_aio {
-	size_t       a_count;      // Bytes transferred (I/O only)
-	nni_time     a_expire;     // Absolute timeout
-	nni_duration a_timeout;    // Relative timeout
-	int          a_result;     // Result code (nng_errno)
-	bool         a_stop;       // Shutting down (no new operations)
-	bool         a_sleep;      // Sleeping with no action
-	bool         a_expire_ok;  // Expire from sleep is ok
-	bool         a_expiring;   // Expiration in progress
-	bool         a_use_expire; // Use expire instead of timeout
-	bool         a_init;       // This is initialized
+	size_t       a_count;        // Bytes transferred (I/O only)
+	nni_time     a_expire;       // Absolute timeout
+	nni_duration a_timeout;      // Relative timeout
+	int          a_result;       // Result code (nng_errno)
+	int          a_abort_result; // Reason for abort (result code)
+	bool         a_stop;         // Shutting down (no new operations)
+	bool         a_abort;        // Aborted (after begin, before schedule)
+	bool         a_sleep;        // Sleeping with no action
+	bool         a_expire_ok;    // Expire from sleep is ok
+	bool         a_expiring;     // Expiration in progress
+	bool         a_use_expire;   // Use expire instead of timeout
+	bool         a_init;         // This is initialized
 
 	nni_task a_task;
 
@@ -237,11 +239,6 @@ struct nng_aio {
 	void *a_inputs[4];
 	void *a_outputs[4];
 
-#ifndef NDEBUG
-	nni_atomic_bool a_started; // Used only in NNI_ASSERT
-#endif
-
-	nni_atomic_bool   a_stopped;
 	nni_aio_expire_q *a_expire_q;
 	nni_list_node     a_expire_node; // Expiration node
 	nni_reap_node     a_reap_node;

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -13,6 +13,7 @@
 
 #include "core/defs.h"
 #include "core/list.h"
+#include "core/platform.h"
 #include "core/reap.h"
 #include "core/taskq.h"
 #include "core/thread.h"
@@ -26,11 +27,14 @@ typedef void (*nni_aio_cancel_fn)(nni_aio *, void *, int);
 extern void nni_aio_init(nni_aio *, nni_cb, void *arg);
 
 // nni_aio_fini finalizes an aio object, releasing associated resources.
-// It waits for the callback to complete.
+// It does NOT wait for the callback to complete, so it is mandatory
+// that nni_aio_stop be called first.
 extern void nni_aio_fini(nni_aio *);
 
 // nni_aio_reap is used to asynchronously reap the aio.  It can
 // be called even from the callback of the aio itself.
+// Note that this only works with aio objects created
+// with nni_aio_alloc.
 extern void nni_aio_reap(nni_aio *);
 
 // nni_aio_alloc allocates an aio object and initializes it.  The callback
@@ -42,17 +46,19 @@ extern int nni_aio_alloc(nni_aio **, nni_cb, void *arg);
 // nni_aio_free frees the aio, releasing resources (locks)
 // associated with it. This is safe to call on zeroed memory.
 // This must only be called on an object that was allocated
-// with nni_aio_allocate.
+// with nni_aio_alloc.
 extern void nni_aio_free(nni_aio *aio);
 
 // nni_aio_stop cancels any unfinished I/O, running completion callbacks,
 // but also prevents any new operations from starting (nni_aio_start will
-// return NNG_ESTATE).  This should be called before nni_aio_free().  The
-// best pattern is to call nni_aio_stop on all linked aio objects, before
-// calling nni_aio_free on any of them.  This function will block until any
-// callbacks are executed, and therefore it should never be executed
-// from a callback itself.  (To abort operations without blocking
-// use nni_aio_cancel instead.)
+// return NNG_ESTATE).  This should be called before nni_aio_free(), and MUST
+// be called before nni_aio_fini().
+//
+// The best pattern is to call nni_aio_stop on all linked aio objects, before
+// calling nni_aio_free or nni_aio_fini on any of them.  This function will
+// block until any callbacks are executed, and therefore it should never be
+// executed from a callback itself.  (To abort operations without blocking use
+// nni_aio_cancel instead.)
 extern void nni_aio_stop(nni_aio *);
 
 // nni_aio_close closes the aio for further activity. It aborts any in-progress
@@ -214,7 +220,9 @@ struct nng_aio {
 	bool         a_expire_ok;  // Expire from sleep is ok
 	bool         a_expiring;   // Expiration in progress
 	bool         a_use_expire; // Use expire instead of timeout
-	nni_task     a_task;
+	bool         a_init;       // This is initialized
+
+	nni_task a_task;
 
 	// Read/write operations.
 	nni_iov  a_iov[8];
@@ -229,14 +237,20 @@ struct nng_aio {
 	void *a_inputs[4];
 	void *a_outputs[4];
 
+#ifndef NDEBUG
+	nni_atomic_bool a_started; // Used only in NNI_ASSERT
+#endif
+
+	nni_atomic_bool   a_stopped;
+	nni_aio_expire_q *a_expire_q;
+	nni_list_node     a_expire_node; // Expiration node
+	nni_reap_node     a_reap_node;
+
 	// Provider-use fields.
 	nni_aio_cancel_fn a_cancel_fn;
 	void             *a_cancel_arg;
 	void             *a_prov_data;
 	nni_list_node     a_prov_node; // Linkage on provider list.
-	nni_aio_expire_q *a_expire_q;
-	nni_list_node     a_expire_node; // Expiration node
-	nni_reap_node     a_reap_node;
 };
 
 #endif // CORE_AIO_H

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -51,6 +51,8 @@ device_fini(void *arg)
 	for (int i = 0; i < d->num_paths; i++) {
 		nni_aio_stop(&d->paths[i].aio);
 	}
+	nni_sock_rele(d->paths[0].src);
+	nni_sock_rele(d->paths[0].dst);
 	NNI_FREE_STRUCT(d);
 }
 
@@ -97,8 +99,6 @@ device_cb(void *arg)
 				nni_aio_finish_error(d->user, d->rv);
 				d->user = NULL;
 			}
-			nni_sock_rele(d->paths[0].src);
-			nni_sock_rele(d->paths[0].dst);
 
 			nni_reap(&device_reap, d);
 		}

--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -233,6 +233,8 @@ nni_dialer_init(nni_dialer *d, nni_sock *s, nni_sp_tran *tran)
 	rv = nni_id_alloc32(&dialers, &d->d_id, d);
 	nni_mtx_unlock(&dialers_lk);
 
+	nni_sock_hold(s);
+
 #ifdef NNG_ENABLE_STATS
 	dialer_stats_init(d);
 #endif

--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -36,12 +36,14 @@ dialer_destroy(void *arg)
 {
 	nni_dialer *d = arg;
 
-	nni_aio_fini(&d->d_con_aio);
-	nni_aio_fini(&d->d_tmo_aio);
-
 	if (d->d_data != NULL) {
 		d->d_ops.d_fini(d->d_data);
 	}
+	nni_aio_fini(&d->d_con_aio);
+	nni_aio_fini(&d->d_tmo_aio);
+
+	nni_sock_rele(d->d_sock);
+
 	nni_mtx_fini(&d->d_mtx);
 	nni_url_fini(&d->d_url);
 	NNI_FREE_STRUCT(d);

--- a/src/core/dialer.h
+++ b/src/core/dialer.h
@@ -13,7 +13,7 @@
 #define CORE_DIALER_H
 
 extern int      nni_dialer_find(nni_dialer **, uint32_t);
-extern int      nni_dialer_hold(nni_dialer *);
+extern void     nni_dialer_hold(nni_dialer *);
 extern void     nni_dialer_rele(nni_dialer *);
 extern uint32_t nni_dialer_id(nni_dialer *);
 extern int      nni_dialer_create(nni_dialer **, nni_sock *, const char *);

--- a/src/core/init_test.c
+++ b/src/core/init_test.c
@@ -192,6 +192,15 @@ test_init_concurrent(void)
 	nng_fini();
 }
 
+void
+test_fini_closes_socket(void)
+{
+	nng_socket s;
+	NUTS_OPEN(s);
+	nng_fini();
+	NUTS_FAIL(nng_close(s), NNG_ECLOSED);
+}
+
 NUTS_TESTS = {
 	{ "init parameter", test_init_param },
 	{ "init zero resolvers", test_init_zero_resolvers },
@@ -203,6 +212,7 @@ NUTS_TESTS = {
 	{ "init too many poller threads", test_init_too_many_poller_threads },
 	{ "init repeated", test_init_repeated },
 	{ "init concurrent", test_init_concurrent },
+	{ "fini closes socket", test_fini_closes_socket },
 
 	{ NULL, NULL },
 };

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -39,12 +39,14 @@ listener_destroy(void *arg)
 {
 	nni_listener *l = arg;
 
-	nni_aio_fini(&l->l_acc_aio);
-	nni_aio_fini(&l->l_tmo_aio);
-
 	if (l->l_data != NULL) {
 		l->l_ops.l_fini(l->l_data);
 	}
+	nni_aio_fini(&l->l_acc_aio);
+	nni_aio_fini(&l->l_tmo_aio);
+
+	nni_sock_rele(l->l_sock);
+
 	nni_url_fini(&l->l_url);
 	NNI_FREE_STRUCT(l);
 }

--- a/src/core/listener.h
+++ b/src/core/listener.h
@@ -13,7 +13,7 @@
 #define CORE_LISTENER_H
 
 extern int      nni_listener_find(nni_listener **, uint32_t);
-extern int      nni_listener_hold(nni_listener *);
+extern void     nni_listener_hold(nni_listener *);
 extern void     nni_listener_rele(nni_listener *);
 extern uint32_t nni_listener_id(nni_listener *);
 extern int      nni_listener_create(nni_listener **, nni_sock *, const char *);

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -41,7 +41,10 @@ static nni_reap_list pipe_reap_list = {
 static void
 pipe_destroy(void *arg)
 {
-	nni_pipe *p = arg;
+	nni_pipe     *p = arg;
+	nni_sock     *s = p->p_sock;
+	nni_dialer   *d = p->p_dialer;
+	nni_listener *l = p->p_listener;
 
 	if (p->p_proto_data != NULL) {
 		p->p_proto_ops.pipe_fini(p->p_proto_data);
@@ -49,16 +52,20 @@ pipe_destroy(void *arg)
 	if (p->p_tran_data != NULL) {
 		p->p_tran_ops.p_fini(p->p_tran_data);
 	}
+	if (l != NULL) {
+		nni_listener_rele(l);
+	}
+	if (d != NULL) {
+		nni_dialer_rele(d);
+	}
+	nni_sock_rele(s);
 	nni_free(p, p->p_size);
 }
 
 void
 pipe_reap(void *arg)
 {
-	nni_pipe     *p = arg;
-	nni_sock     *s = p->p_sock;
-	nni_dialer   *d = p->p_dialer;
-	nni_listener *l = p->p_listener;
+	nni_pipe *p = arg;
 
 	nni_pipe_run_cb(p, NNG_PIPE_EV_REM_POST);
 
@@ -83,13 +90,6 @@ pipe_reap(void *arg)
 	}
 
 	nni_pipe_rele(p);
-	if (l != NULL) {
-		nni_listener_rele(l);
-	}
-	if (d != NULL) {
-		nni_dialer_rele(d);
-	}
-	nni_sock_rele(s);
 }
 
 int

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -48,6 +48,7 @@ void
 pipe_reap(void *arg)
 {
 	nni_pipe *p = arg;
+	nni_sock *s = p->p_sock;
 
 	nni_pipe_run_cb(p, NNG_PIPE_EV_REM_POST);
 
@@ -70,6 +71,7 @@ pipe_reap(void *arg)
 	}
 
 	nni_pipe_rele(p);
+	nni_sock_rele(s);
 }
 
 int
@@ -255,6 +257,8 @@ pipe_create(nni_pipe **pp, nni_sock *sock, nni_sp_tran *tran, void *tran_data)
 #ifdef NNG_ENABLE_STATS
 	pipe_stats_init(p);
 #endif
+
+	nni_sock_hold(sock);
 
 	if ((rv != 0) || ((rv = p->p_tran_ops.p_init(tran_data, p)) != 0) ||
 	    ((rv = pops->pipe_init(p->p_proto_data, p, sock_data)) != 0)) {

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -15,9 +15,10 @@
 // OUTSIDE of the core is STRICTLY VERBOTEN.  NO DIRECT ACCESS BY PROTOCOLS OR
 // TRANSPORTS.
 
+#include "nng/nng.h"
+
 #include "core/defs.h"
 #include "core/thread.h"
-#include "nng/nng.h"
 #include "sp/transport.h"
 
 // AIO
@@ -62,5 +63,6 @@ extern void nni_pipe_bump_tx(nni_pipe *, size_t);
 extern void nni_pipe_bump_error(nni_pipe *, int);
 
 extern char *nni_pipe_peer_addr(nni_pipe *p, char buf[NNG_MAXADDRSTRLEN]);
+extern void *nni_pipe_tran_data(nni_pipe *);
 
 #endif // CORE_PIPE_H

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -63,6 +63,8 @@ extern void nni_pipe_bump_tx(nni_pipe *, size_t);
 extern void nni_pipe_bump_error(nni_pipe *, int);
 
 extern char *nni_pipe_peer_addr(nni_pipe *p, char buf[NNG_MAXADDRSTRLEN]);
-extern void *nni_pipe_tran_data(nni_pipe *);
+
+extern int nni_pipe_alloc_dialer(void **, nni_dialer *);
+extern int nni_pipe_alloc_listener(void **, nni_listener *);
 
 #endif // CORE_PIPE_H

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -197,8 +197,6 @@ extern void     nni_atomic_sub64(nni_atomic_u64 *, uint64_t);
 extern uint64_t nni_atomic_get64(nni_atomic_u64 *);
 extern void     nni_atomic_set64(nni_atomic_u64 *, uint64_t);
 extern uint64_t nni_atomic_swap64(nni_atomic_u64 *, uint64_t);
-extern uint64_t nni_atomic_dec64_nv(nni_atomic_u64 *);
-extern void     nni_atomic_inc64(nni_atomic_u64 *);
 
 // nni_atomic_cas64 is a compare and swap.  The second argument is the
 // value to compare against, and the third is the new value. Returns
@@ -218,6 +216,11 @@ extern void nni_atomic_sub(nni_atomic_int *, int);
 extern int  nni_atomic_get(nni_atomic_int *);
 extern void nni_atomic_set(nni_atomic_int *, int);
 extern int  nni_atomic_swap(nni_atomic_int *, int);
+
+// These versions are tuned for use as reference
+// counters. Relaxed order when possible to increase
+// reference count, acquire-release order for dropping
+// it (where we need to check the value).
 extern int  nni_atomic_dec_nv(nni_atomic_int *);
 extern void nni_atomic_dec(nni_atomic_int *);
 extern void nni_atomic_inc(nni_atomic_int *);

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1272,9 +1272,13 @@ nni_listener_add_pipe(nni_listener *l, void *tpipe)
 	nni_pipe *p;
 
 	nni_mtx_lock(&s->s_mx);
-	if (nni_pipe_create_listener(&p, l, tpipe) != 0) {
-		nni_mtx_unlock(&s->s_mx);
-		return;
+	if (l->l_tran->tran_pipe->p_size != 0) {
+		p = tpipe;
+	} else {
+		if (nni_pipe_create_listener(&p, l, tpipe) != 0) {
+			nni_mtx_unlock(&s->s_mx);
+			return;
+		}
 	}
 
 	nni_list_append(&l->l_pipes, p);

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1030,7 +1030,7 @@ nni_sock_set_pipe_cb(nni_sock *s, int ev, nng_pipe_cb cb, void *arg)
 }
 
 int
-nni_ctx_find(nni_ctx **cp, uint32_t id, bool closing)
+nni_ctx_find(nni_ctx **cp, uint32_t id)
 {
 	int      rv = 0;
 	nni_ctx *ctx;
@@ -1043,7 +1043,7 @@ nni_ctx_find(nni_ctx **cp, uint32_t id, bool closing)
 		// we can close it, then we still allow.  In the case
 		// the only valid operation will be to close the
 		// socket.)
-		if (ctx->c_closed || ((!closing) && ctx->c_sock->s_closed)) {
+		if (ctx->c_closed || ctx->c_sock->s_closed) {
 			rv = NNG_ECLOSED;
 		} else {
 			ctx->c_ref++;

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -706,19 +706,9 @@ nni_sock_closeall(void)
 	nni_sock *s;
 	uint32_t  next = 0;
 
-	nni_mtx_lock(&sock_lk);
 	while (nni_id_visit(&sock_ids, NULL, (void **) &s, &next)) {
-		if (nni_atomic_flag_test_and_set(&s->s_close_once)) {
-			continue;
-		}
-		s->s_closed = true;
-		nni_id_remove(&sock_ids, s->s_id);
-
-		sock_close_children(s);
-
-		nni_reap(&sock_reap_list, s);
+		nni_sock_close(s);
 	}
-	nni_mtx_unlock(&sock_lk);
 }
 
 void

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1262,7 +1262,6 @@ nni_dialer_shutdown(nni_dialer *d)
 #ifdef NNG_ENABLE_STATS
 	nni_stat_unregister(&d->st_root);
 #endif
-	nni_sock_rele(d->d_sock);
 }
 
 void
@@ -1339,7 +1338,6 @@ nni_listener_shutdown(nni_listener *l)
 #ifdef NNG_ENABLE_STATS
 	nni_stat_unregister(&l->st_root);
 #endif
-	nni_sock_rele(s);
 }
 
 void

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -73,11 +73,8 @@ extern void nni_sock_set_pipe_cb(nni_sock *sock, int, nng_pipe_cb, void *);
 // sockets (will also return NNG_ENOTSUP).
 extern int nni_ctx_open(nni_ctx **, nni_sock *);
 
-// nni_ctx_find finds a context given its id.  The last argument should
-// be true if the context is acquired merely to close it, false otherwise.
-// (If the socket for the context is being closed, then this will return
-// NNG_ECLOSED unless the final argument is true.)
-extern int nni_ctx_find(nni_ctx **, uint32_t, bool);
+// nni_ctx_find finds a context given its id.
+extern int nni_ctx_find(nni_ctx **, uint32_t);
 
 extern void *nni_ctx_proto_data(nni_ctx *);
 

--- a/src/core/socket.h
+++ b/src/core/socket.h
@@ -78,6 +78,8 @@ extern int nni_ctx_find(nni_ctx **, uint32_t);
 
 extern void *nni_ctx_proto_data(nni_ctx *);
 
+extern void nni_ctx_hold(nni_ctx *);
+
 // nni_ctx_rele is called to release a hold on the context.  These holds
 // are acquired by either nni_ctx_open or nni_ctx_find.  If the context
 // is being closed (nni_ctx_close was called), and this is the last reference,

--- a/src/core/sockimpl.h
+++ b/src/core/sockimpl.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -248,11 +248,6 @@ nni_task_init(nni_task *task, nni_taskq *tq, nni_cb cb, void *arg)
 void
 nni_task_fini(nni_task *task)
 {
-	nni_mtx_lock(&task->task_mtx);
-	while (task->task_busy) {
-		nni_cv_wait(&task->task_cv);
-	}
-	nni_mtx_unlock(&task->task_mtx);
 	nni_cv_fini(&task->task_cv);
 	nni_mtx_fini(&task->task_mtx);
 }

--- a/src/core/taskq.c
+++ b/src/core/taskq.c
@@ -41,6 +41,7 @@ nni_taskq_thread(void *self)
 	for (;;) {
 		if ((task = nni_list_first(&tq->tq_tasks)) != NULL) {
 
+			NNI_ASSERT(!task->task_dead);
 			nni_list_remove(&tq->tq_tasks, task);
 
 			nni_mtx_unlock(&tq->tq_mtx);
@@ -50,6 +51,7 @@ nni_taskq_thread(void *self)
 			nni_mtx_lock(&task->task_mtx);
 			task->task_busy--;
 			if (task->task_busy == 0) {
+				NNI_ASSERT(!task->task_prep);
 				nni_cv_wake(&task->task_cv);
 			}
 			nni_mtx_unlock(&task->task_mtx);
@@ -145,7 +147,9 @@ void
 nni_task_exec(nni_task *task)
 {
 	nni_mtx_lock(&task->task_mtx);
+	NNI_ASSERT(!task->task_dead);
 	if (task->task_prep) {
+		NNI_ASSERT(task->task_busy > 0);
 		task->task_prep = false;
 	} else {
 		task->task_busy++;
@@ -169,6 +173,7 @@ nni_task_dispatch(nni_task *task)
 {
 	nni_taskq *tq = task->task_tq;
 
+	NNI_ASSERT(!task->task_dead);
 	// If there is no callback to perform, then do nothing!
 	// The user will be none the wiser.
 	if (task->task_cb == NULL) {
@@ -177,6 +182,7 @@ nni_task_dispatch(nni_task *task)
 	}
 	nni_mtx_lock(&task->task_mtx);
 	if (task->task_prep) {
+		NNI_ASSERT(task->task_busy > 0);
 		task->task_prep = false;
 	} else {
 		task->task_busy++;
@@ -193,29 +199,17 @@ void
 nni_task_prep(nni_task *task)
 {
 	nni_mtx_lock(&task->task_mtx);
+	NNI_ASSERT(!task->task_dead);
 	task->task_busy++;
 	task->task_prep = true;
 	nni_mtx_unlock(&task->task_mtx);
 }
 
 void
-nni_task_abort(nni_task *task)
-{
-	// This is called when unscheduling the task.
-	nni_mtx_lock(&task->task_mtx);
-	if (task->task_prep) {
-		task->task_prep = false;
-		task->task_busy--;
-		if (task->task_busy == 0) {
-			nni_cv_wake(&task->task_cv);
-		}
-	}
-	nni_mtx_unlock(&task->task_mtx);
-}
-void
 nni_task_wait(nni_task *task)
 {
 	nni_mtx_lock(&task->task_mtx);
+	NNI_ASSERT(!task->task_dead);
 	while (task->task_busy) {
 		nni_cv_wait(&task->task_cv);
 	}
@@ -248,6 +242,8 @@ nni_task_init(nni_task *task, nni_taskq *tq, nni_cb cb, void *arg)
 void
 nni_task_fini(nni_task *task)
 {
+	task->task_dead = true;
+	NNI_ASSERT(!nni_list_node_active(&task->task_node));
 	nni_cv_fini(&task->task_cv);
 	nni_mtx_fini(&task->task_mtx);
 }

--- a/src/core/taskq.h
+++ b/src/core/taskq.h
@@ -40,11 +40,6 @@ extern void nni_task_exec(nni_task *);
 // nni_task_exec).
 extern void nni_task_prep(nni_task *);
 
-// nni_task_abort is called to undo the effect of nni_task_prep,
-// basically. The aio framework uses this when nni_aio_schedule()
-// returns an error.
-extern void nni_task_abort(nni_task *);
-
 // nni_task_busy checks to see if a task is still busy.
 // This is uses the same check that nni_task_wait uses.
 extern bool nni_task_busy(nni_task *);
@@ -53,6 +48,7 @@ extern bool nni_task_busy(nni_task *);
 // work is scheduled on the task then it will not return until that
 // work (or any other work subsequently scheduled) is complete.
 extern void nni_task_wait(nni_task *);
+extern void nni_task_stop(nni_task *);
 extern void nni_task_init(nni_task *, nni_taskq *, nni_cb, void *);
 
 // nni_task_fini destroys the task.  It will reap resources asynchronously
@@ -75,6 +71,7 @@ struct nni_task {
 	nni_taskq    *task_tq;
 	unsigned      task_busy;
 	bool          task_prep;
+	bool          task_dead;
 	nni_mtx       task_mtx;
 	nni_cv        task_cv;
 };

--- a/src/core/url.c
+++ b/src/core/url.c
@@ -703,6 +703,7 @@ nni_url_to_address(nng_sockaddr *sa, const nng_url *url)
 	nni_resolv_ip(h, url->u_port, af, true, sa, &aio);
 	nni_aio_wait(&aio);
 	rv = nni_aio_result(&aio);
+	nni_aio_stop(&aio);
 	nni_aio_fini(&aio);
 	return (rv);
 }

--- a/src/nng.c
+++ b/src/nng.c
@@ -36,8 +36,8 @@ nng_close(nng_socket s)
 	if ((rv = nni_sock_find(&sock, s.id)) != 0) {
 		return (rv);
 	}
-	// No release -- close releases it.
 	nni_sock_close(sock);
+	nni_sock_rele(sock);
 	return (0);
 }
 

--- a/src/nng.c
+++ b/src/nng.c
@@ -275,8 +275,8 @@ nng_ctx_close(nng_ctx c)
 	if ((rv = nni_ctx_find(&ctx, c.id)) != 0) {
 		return (rv);
 	}
-	// no release, close releases implicitly.
 	nni_ctx_close(ctx);
+	nni_ctx_rele(ctx);
 	return (0);
 }
 

--- a/src/nng.c
+++ b/src/nng.c
@@ -272,7 +272,7 @@ nng_ctx_close(nng_ctx c)
 	int      rv;
 	nni_ctx *ctx;
 
-	if ((rv = nni_ctx_find(&ctx, c.id, true)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, c.id)) != 0) {
 		return (rv);
 	}
 	// no release, close releases implicitly.
@@ -293,7 +293,7 @@ nng_ctx_recvmsg(nng_ctx cid, nng_msg **msgp, int flags)
 	nni_aio  aio;
 	nni_ctx *ctx;
 
-	if ((rv = nni_ctx_find(&ctx, cid.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
 		return (rv);
 	}
 
@@ -326,7 +326,7 @@ nng_ctx_recv(nng_ctx cid, nng_aio *aio)
 	int      rv;
 	nni_ctx *ctx;
 
-	if ((rv = nni_ctx_find(&ctx, cid.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
 		if (nni_aio_begin(aio) == 0) {
 			nni_aio_finish_error(aio, rv);
 		}
@@ -348,7 +348,7 @@ nng_ctx_send(nng_ctx cid, nng_aio *aio)
 		}
 		return;
 	}
-	if ((rv = nni_ctx_find(&ctx, cid.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
 		if (nni_aio_begin(aio) == 0) {
 			nni_aio_finish_error(aio, rv);
 		}
@@ -368,7 +368,7 @@ nng_ctx_sendmsg(nng_ctx cid, nng_msg *msg, int flags)
 	if (msg == NULL) {
 		return (NNG_EINVAL);
 	}
-	if ((rv = nni_ctx_find(&ctx, cid.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
 		return (rv);
 	}
 
@@ -403,7 +403,7 @@ ctx_get(nng_ctx id, const char *n, void *v, size_t *szp, nni_type t)
 	nni_ctx *ctx;
 	int      rv;
 
-	if ((rv = nni_ctx_find(&ctx, id.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, id.id)) != 0) {
 		return (rv);
 	}
 	rv = nni_ctx_getopt(ctx, n, v, szp, t);
@@ -447,7 +447,7 @@ ctx_set(nng_ctx id, const char *n, const void *v, size_t sz, nni_type t)
 	nni_ctx *ctx;
 	int      rv;
 
-	if ((rv = nni_ctx_find(&ctx, id.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&ctx, id.id)) != 0) {
 		return (rv);
 	}
 	rv = nni_ctx_setopt(ctx, n, v, sz, t);

--- a/src/nng.c
+++ b/src/nng.c
@@ -502,6 +502,7 @@ nng_dial(nng_socket sid, const char *addr, nng_dialer *dp, int flags)
 	if ((rv = nni_dialer_start(d, flags)) != 0) {
 		nni_dialer_close(d);
 		nni_dialer_rele(d);
+		nni_sock_rele(s);
 		return (rv);
 	}
 	if (dp != NULL) {
@@ -510,6 +511,7 @@ nng_dial(nng_socket sid, const char *addr, nng_dialer *dp, int flags)
 		*dp    = did;
 	}
 	nni_dialer_rele(d);
+	nni_sock_rele(s);
 	return (0);
 }
 
@@ -530,6 +532,7 @@ nng_dial_url(nng_socket sid, const nng_url *url, nng_dialer *dp, int flags)
 	if ((rv = nni_dialer_start(d, flags)) != 0) {
 		nni_dialer_close(d);
 		nni_dialer_rele(d);
+		nni_sock_rele(s);
 		return (rv);
 	}
 	if (dp != NULL) {
@@ -538,6 +541,7 @@ nng_dial_url(nng_socket sid, const nng_url *url, nng_dialer *dp, int flags)
 		*dp    = did;
 	}
 	nni_dialer_rele(d);
+	nni_sock_rele(s);
 	return (0);
 }
 
@@ -557,6 +561,7 @@ nng_listen(nng_socket sid, const char *addr, nng_listener *lp, int flags)
 	}
 	if ((rv = nni_listener_start(l, flags)) != 0) {
 		nni_listener_close(l);
+		nni_listener_rele(l);
 		nni_sock_rele(s);
 		return (rv);
 	}
@@ -587,6 +592,7 @@ nng_listen_url(nng_socket sid, const nng_url *url, nng_listener *lp, int flags)
 	}
 	if ((rv = nni_listener_start(l, flags)) != 0) {
 		nni_listener_close(l);
+		nni_listener_rele(l);
 		nni_sock_rele(s);
 		return (rv);
 	}
@@ -683,6 +689,7 @@ nng_dialer_create(nng_dialer *dp, nng_socket sid, const char *addr)
 	did.id = nni_dialer_id(d);
 	*dp    = did;
 	nni_dialer_rele(d);
+	nni_sock_rele(s);
 	return (0);
 }
 
@@ -704,6 +711,7 @@ nng_dialer_create_url(nng_dialer *dp, nng_socket sid, const nng_url *url)
 	did.id = nni_dialer_id(d);
 	*dp    = did;
 	nni_dialer_rele(d);
+	nni_sock_rele(s);
 	return (0);
 }
 

--- a/src/nng.c
+++ b/src/nng.c
@@ -1078,6 +1078,7 @@ nng_listener_close(nng_listener lid)
 		return (rv);
 	}
 	nni_listener_close(l);
+	nni_listener_rele(l);
 	return (0);
 }
 

--- a/src/nng.c
+++ b/src/nng.c
@@ -501,6 +501,7 @@ nng_dial(nng_socket sid, const char *addr, nng_dialer *dp, int flags)
 	}
 	if ((rv = nni_dialer_start(d, flags)) != 0) {
 		nni_dialer_close(d);
+		nni_dialer_rele(d);
 		return (rv);
 	}
 	if (dp != NULL) {
@@ -528,6 +529,7 @@ nng_dial_url(nng_socket sid, const nng_url *url, nng_dialer *dp, int flags)
 	}
 	if ((rv = nni_dialer_start(d, flags)) != 0) {
 		nni_dialer_close(d);
+		nni_dialer_rele(d);
 		return (rv);
 	}
 	if (dp != NULL) {
@@ -555,6 +557,7 @@ nng_listen(nng_socket sid, const char *addr, nng_listener *lp, int flags)
 	}
 	if ((rv = nni_listener_start(l, flags)) != 0) {
 		nni_listener_close(l);
+		nni_sock_rele(s);
 		return (rv);
 	}
 
@@ -564,6 +567,7 @@ nng_listen(nng_socket sid, const char *addr, nng_listener *lp, int flags)
 		*lp    = lid;
 	}
 	nni_listener_rele(l);
+	nni_sock_rele(s);
 	return (rv);
 }
 
@@ -583,6 +587,7 @@ nng_listen_url(nng_socket sid, const nng_url *url, nng_listener *lp, int flags)
 	}
 	if ((rv = nni_listener_start(l, flags)) != 0) {
 		nni_listener_close(l);
+		nni_sock_rele(s);
 		return (rv);
 	}
 
@@ -592,6 +597,7 @@ nng_listen_url(nng_socket sid, const nng_url *url, nng_listener *lp, int flags)
 		*lp    = lid;
 	}
 	nni_listener_rele(l);
+	nni_sock_rele(s);
 	return (rv);
 }
 
@@ -613,6 +619,7 @@ nng_listener_create(nng_listener *lp, nng_socket sid, const char *addr)
 	lid.id = nni_listener_id(l);
 	*lp    = lid;
 	nni_listener_rele(l);
+	nni_sock_rele(s);
 	return (0);
 }
 
@@ -634,6 +641,7 @@ nng_listener_create_url(nng_listener *lp, nng_socket sid, const nng_url *url)
 	lid.id = nni_listener_id(l);
 	*lp    = lid;
 	nni_listener_rele(l);
+	nni_sock_rele(s);
 	return (0);
 }
 
@@ -1048,6 +1056,7 @@ nng_dialer_close(nng_dialer did)
 		return (rv);
 	}
 	nni_dialer_close(d);
+	nni_dialer_rele(d);
 	return (0);
 }
 

--- a/src/nng.c
+++ b/src/nng.c
@@ -141,6 +141,7 @@ nng_recvmsg(nng_socket s, nng_msg **msgp, int flags)
 	    ((flags & NNG_FLAG_NONBLOCK) == NNG_FLAG_NONBLOCK)) {
 		rv = NNG_EAGAIN;
 	}
+	nni_aio_stop(&aio);
 	nni_aio_fini(&aio);
 
 	return (rv);
@@ -194,6 +195,7 @@ nng_sendmsg(nng_socket s, nng_msg *msg, int flags)
 
 	nni_aio_wait(&aio);
 	rv = nni_aio_result(&aio);
+	nni_aio_stop(&aio);
 	nni_aio_fini(&aio);
 
 	// Possibly massage nonblocking attempt.  Note that nonblocking is
@@ -315,6 +317,7 @@ nng_ctx_recvmsg(nng_ctx cid, nng_msg **msgp, int flags)
 	    ((flags & NNG_FLAG_NONBLOCK) == NNG_FLAG_NONBLOCK)) {
 		rv = NNG_EAGAIN;
 	}
+	nni_aio_stop(&aio);
 	nni_aio_fini(&aio);
 
 	return (rv);
@@ -385,6 +388,7 @@ nng_ctx_sendmsg(nng_ctx cid, nng_msg *msg, int flags)
 
 	nni_aio_wait(&aio);
 	rv = nni_aio_result(&aio);
+	nni_aio_stop(&aio);
 	nni_aio_fini(&aio);
 
 	// Possibly massage nonblocking attempt.  Note that nonblocking is
@@ -1333,6 +1337,7 @@ nng_device(nng_socket s1, nng_socket s2)
 	nng_device_aio(&aio, s1, s2);
 	nni_aio_wait(&aio);
 	rv = nni_aio_result(&aio);
+	nni_aio_stop(&aio);
 	nni_aio_fini(&aio);
 	return (rv);
 }

--- a/src/platform/posix/posix_atomic.c
+++ b/src/platform/posix/posix_atomic.c
@@ -105,7 +105,7 @@ nni_atomic_swap(nni_atomic_int *v, int i)
 void
 nni_atomic_inc(nni_atomic_int *v)
 {
-	atomic_fetch_add(&v->v, 1);
+	atomic_fetch_add_explicit(&v->v, 1, memory_order_relaxed);
 }
 
 void
@@ -117,7 +117,7 @@ nni_atomic_dec(nni_atomic_int *v)
 int
 nni_atomic_dec_nv(nni_atomic_int *v)
 {
-	return (atomic_fetch_sub(&v->v, 1) - 1);
+	return (atomic_fetch_sub_explicit(&v->v, 1, memory_order_acq_rel) - 1);
 }
 
 bool
@@ -319,10 +319,11 @@ nni_atomic_get(nni_atomic_int *v)
 {
 	return (__atomic_load_n(&v->v, __ATOMIC_SEQ_CST));
 }
+
 void
 nni_atomic_inc(nni_atomic_int *v)
 {
-	__atomic_add_fetch(&v->v, 1, __ATOMIC_SEQ_CST);
+	__atomic_add_fetch(&v->v, 1, __ATOMIC_RELAXED);
 }
 
 void

--- a/src/platform/posix/posix_ipc.h
+++ b/src/platform/posix/posix_ipc.h
@@ -22,12 +22,12 @@
 
 struct nni_ipc_conn {
 	nng_stream      stream;
-	nni_posix_pfd * pfd;
+	nni_posix_pfd  *pfd;
 	nni_list        readq;
 	nni_list        writeq;
 	bool            closed;
 	nni_mtx         mtx;
-	nni_aio *       dial_aio;
+	nni_aio        *dial_aio;
 	nni_ipc_dialer *dialer;
 	nng_sockaddr    sa;
 	nni_reap_node   reap;
@@ -39,7 +39,7 @@ struct nni_ipc_dialer {
 	bool              closed;
 	nni_mtx           mtx;
 	nng_sockaddr      sa;
-	nni_atomic_u64    ref;
+	nni_atomic_int    ref;
 	nni_atomic_bool   fini;
 };
 

--- a/src/platform/posix/posix_ipcdial.c
+++ b/src/platform/posix/posix_ipcdial.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2023 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -69,7 +69,7 @@ ipc_dialer_free(void *arg)
 void
 nni_posix_ipc_dialer_rele(ipc_dialer *d)
 {
-	if (((nni_atomic_dec64_nv(&d->ref)) != 0) ||
+	if (((nni_atomic_dec_nv(&d->ref)) != 0) ||
 	    (!nni_atomic_get_bool(&d->fini))) {
 		return;
 	}
@@ -176,7 +176,7 @@ ipc_dialer_dial(void *arg, nni_aio *aio)
 		return;
 	}
 
-	nni_atomic_inc64(&d->ref);
+	nni_atomic_inc(&d->ref);
 
 	if ((rv = nni_posix_ipc_alloc(&c, &d->sa, d)) != 0) {
 		(void) close(fd);
@@ -323,8 +323,8 @@ nni_ipc_dialer_alloc(nng_stream_dialer **dp, const nng_url *url)
 	d->sd.sd_get   = ipc_dialer_get;
 	d->sd.sd_set   = ipc_dialer_set;
 	nni_atomic_init_bool(&d->fini);
-	nni_atomic_init64(&d->ref);
-	nni_atomic_inc64(&d->ref);
+	nni_atomic_init(&d->ref);
+	nni_atomic_inc(&d->ref);
 
 	*dp = (void *) d;
 	return (0);

--- a/src/platform/posix/posix_tcp.h
+++ b/src/platform/posix/posix_tcp.h
@@ -18,12 +18,12 @@
 
 struct nni_tcp_conn {
 	nng_stream      stream;
-	nni_posix_pfd * pfd;
+	nni_posix_pfd  *pfd;
 	nni_list        readq;
 	nni_list        writeq;
 	bool            closed;
 	nni_mtx         mtx;
-	nni_aio *       dial_aio;
+	nni_aio        *dial_aio;
 	nni_tcp_dialer *dialer;
 	nni_reap_node   reap;
 };
@@ -36,7 +36,7 @@ struct nni_tcp_dialer {
 	struct sockaddr_storage src;
 	size_t                  srclen;
 	nni_mtx                 mtx;
-	nni_atomic_u64          ref;
+	nni_atomic_int          ref;
 	nni_atomic_bool         fini;
 };
 

--- a/src/platform/posix/posix_tcpdial.c
+++ b/src/platform/posix/posix_tcpdial.c
@@ -41,8 +41,8 @@ nni_tcp_dialer_init(nni_tcp_dialer **dp)
 	d->nodelay = true;
 	nni_aio_list_init(&d->connq);
 	nni_atomic_init_bool(&d->fini);
-	nni_atomic_init64(&d->ref);
-	nni_atomic_inc64(&d->ref);
+	nni_atomic_init(&d->ref);
+	nni_atomic_inc(&d->ref);
 	*dp = d;
 	return (0);
 }
@@ -87,7 +87,7 @@ nni_tcp_dialer_fini(nni_tcp_dialer *d)
 void
 nni_posix_tcp_dialer_rele(nni_tcp_dialer *d)
 {
-	if (((nni_atomic_dec64_nv(&d->ref) != 0)) ||
+	if (((nni_atomic_dec_nv(&d->ref) != 0)) ||
 	    (!nni_atomic_get_bool(&d->fini))) {
 		return;
 	}
@@ -200,7 +200,7 @@ nni_tcp_dial(nni_tcp_dialer *d, const nni_sockaddr *sa, nni_aio *aio)
 		return;
 	}
 
-	nni_atomic_inc64(&d->ref);
+	nni_atomic_inc(&d->ref);
 
 	if ((rv = nni_posix_tcp_alloc(&c, d)) != 0) {
 		nni_aio_finish_error(aio, rv);

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -22,6 +22,8 @@ static pfnSetThreadDescription set_thread_desc;
 // mingw does not define InterlockedAddNoFence64, use the mingw equivalent
 #if defined(__MINGW32__) || defined(__MINGW64__)
 #define InterlockedAddNoFence(a, b) __atomic_add_fetch(a, b, __ATOMIC_RELAXED)
+#define InterlockedIncrementNoFence(a) \
+	__atomic_add_fetch(a, 1, __ATOMIC_RELAXED)
 #define InterlockedAddNoFence64(a, b) \
 	__atomic_add_fetch(a, b, __ATOMIC_RELAXED)
 #define InterlockedIncrementAcquire64(a) \
@@ -326,7 +328,7 @@ nni_atomic_init(nni_atomic_int *v)
 void
 nni_atomic_inc(nni_atomic_int *v)
 {
-	(void) InterlockedIncrementAcquire(&v->v);
+	(void) InterlockedIncrementNoFence(&v->v);
 }
 
 int

--- a/src/sp/protocol.c
+++ b/src/sp/protocol.c
@@ -22,6 +22,7 @@ nni_proto_open(nng_socket *sip, const nni_proto *proto)
 		nng_socket s;
 		s.id = nni_sock_id(sock); // Keep socket held open.
 		*sip = s;
+		nni_sock_rele(sock);
 	}
 	return (rv);
 }

--- a/src/sp/protocol/pair1/pair.c
+++ b/src/sp/protocol/pair1/pair.c
@@ -199,6 +199,8 @@ pair1_pipe_stop(void *arg)
 	pair1_pipe *p = arg;
 	pair1_sock *s = p->pair;
 
+	nni_aio_close(&p->aio_send);
+	nni_aio_close(&p->aio_recv);
 	nni_mtx_lock(&s->mtx);
 	if (s->p == p) {
 		s->p = NULL;

--- a/src/sp/protocol/pair1/pair1_poly.c
+++ b/src/sp/protocol/pair1/pair1_poly.c
@@ -75,6 +75,7 @@ pair1poly_sock_fini(void *arg)
 {
 	pair1poly_sock *s = arg;
 
+	nni_aio_stop(&s->aio_get);
 	nni_aio_fini(&s->aio_get);
 	nni_id_map_fini(&s->pipes);
 	nni_mtx_fini(&s->mtx);

--- a/src/sp/protocol/pubsub0/sub.c
+++ b/src/sp/protocol/pubsub0/sub.c
@@ -753,7 +753,7 @@ nng_sub0_ctx_subscribe(nng_ctx id, const void *buf, size_t sz)
 	nni_ctx  *c;
 	sub0_ctx *ctx;
 
-	if ((rv = nni_ctx_find(&c, id.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&c, id.id)) != 0) {
 		return (rv);
 	}
 	// validate the socket type
@@ -774,7 +774,7 @@ nng_sub0_ctx_unsubscribe(nng_ctx id, const void *buf, size_t sz)
 	nni_ctx  *c;
 	sub0_ctx *ctx;
 
-	if ((rv = nni_ctx_find(&c, id.id, false)) != 0) {
+	if ((rv = nni_ctx_find(&c, id.id)) != 0) {
 		return (rv);
 	}
 	// validate the socket type

--- a/src/sp/protocol/reqrep0/xrep.c
+++ b/src/sp/protocol/reqrep0/xrep.c
@@ -53,6 +53,7 @@ xrep0_sock_fini(void *arg)
 {
 	xrep0_sock *s = arg;
 
+	nni_aio_stop(&s->aio_getq);
 	nni_aio_fini(&s->aio_getq);
 	nni_id_map_fini(&s->pipes);
 	nni_mtx_fini(&s->lk);

--- a/src/sp/protocol/survey0/xrespond.c
+++ b/src/sp/protocol/survey0/xrespond.c
@@ -62,6 +62,7 @@ xresp0_sock_fini(void *arg)
 {
 	xresp0_sock *s = arg;
 
+	nni_aio_stop(&s->aio_getq);
 	nni_aio_fini(&s->aio_getq);
 	nni_id_map_fini(&s->pipes);
 	nni_mtx_fini(&s->mtx);

--- a/src/sp/protocol/survey0/xsurvey.c
+++ b/src/sp/protocol/survey0/xsurvey.c
@@ -50,6 +50,7 @@ xsurv0_sock_fini(void *arg)
 {
 	xsurv0_sock *s = arg;
 
+	nni_aio_stop(&s->aio_getq);
 	nni_aio_fini(&s->aio_getq);
 	nni_mtx_fini(&s->mtx);
 }

--- a/src/sp/transport.h
+++ b/src/sp/transport.h
@@ -201,6 +201,4 @@ extern void         nni_sp_tran_sys_init(void);
 extern void         nni_sp_tran_sys_fini(void);
 extern void         nni_sp_tran_register(nni_sp_tran *);
 
-extern int nni_sp_pipe_alloc(void **datap, nni_dialer *d, nni_listener *l);
-
 #endif // PROTOCOL_SP_TRANSPORT_H

--- a/src/sp/transport/ipc/ipc_test.c
+++ b/src/sp/transport/ipc/ipc_test.c
@@ -237,8 +237,8 @@ test_ipc_huge_msg(void)
 void
 test_ipc_recv_max(void)
 {
-	char         msg[256];
-	char         rcvbuf[256];
+	char         msg[256]    = { 0 };
+	char         rcvbuf[256] = { 0 };
 	nng_socket   s0;
 	nng_socket   s1;
 	nng_listener l;

--- a/src/sp/transport/socket/sockfd.c
+++ b/src/sp/transport/socket/sockfd.c
@@ -841,7 +841,7 @@ sfd_tran_ep_accept(void *arg, nni_aio *aio)
 	nni_mtx_unlock(&ep->mtx);
 }
 
-static nni_sp_pipe_ops sfd_tran_pipe_ops = {
+static const nni_sp_pipe_ops sfd_tran_pipe_ops = {
 	.p_size   = sizeof(sfd_tran_pipe),
 	.p_init   = sfd_tran_pipe_init,
 	.p_fini   = sfd_tran_pipe_fini,
@@ -893,7 +893,7 @@ sfd_tran_listener_setopt(
 	return (rv);
 }
 
-static nni_sp_listener_ops sfd_tran_listener_ops = {
+static const nni_sp_listener_ops sfd_tran_listener_ops = {
 	.l_init   = sfd_tran_listener_init,
 	.l_fini   = sfd_tran_ep_fini,
 	.l_bind   = sfd_tran_ep_bind,

--- a/src/sp/transport/socket/sockfd_test.c
+++ b/src/sp/transport/socket/sockfd_test.c
@@ -157,8 +157,8 @@ void
 test_sfd_recv_max(void)
 {
 #ifdef NNG_HAVE_SOCKETPAIR
-	char         msg[256];
-	char         buf[256];
+	char         msg[256] = { 0 };
+	char         buf[256] = { 0 };
 	nng_socket   s0;
 	nng_socket   s1;
 	nng_listener l0;

--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -1146,10 +1146,10 @@ udp_ep_rele(udp_ep *ep)
 	}
 	nni_mtx_unlock(&ep->mtx);
 
-	nni_aio_close(&ep->timeaio);
-	nni_aio_close(&ep->resaio);
-	nni_aio_close(&ep->tx_aio);
-	nni_aio_close(&ep->rx_aio);
+	nni_aio_stop(&ep->timeaio);
+	nni_aio_stop(&ep->resaio);
+	nni_aio_stop(&ep->tx_aio);
+	nni_aio_stop(&ep->rx_aio);
 	if (ep->udp != NULL) {
 		nni_udp_close(ep->udp);
 	}

--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -26,7 +26,7 @@ struct ws_dialer {
 	uint16_t           peer; // remote protocol
 	nni_list           aios;
 	nni_mtx            mtx;
-	nni_aio           *connaio;
+	nni_aio            connaio;
 	nng_stream_dialer *dialer;
 	bool               started;
 };
@@ -35,7 +35,7 @@ struct ws_listener {
 	uint16_t             peer; // remote protocol
 	nni_list             aios;
 	nni_mtx              mtx;
-	nni_aio             *accaio;
+	nni_aio              accaio;
 	nng_stream_listener *listener;
 	bool                 started;
 };
@@ -46,20 +46,19 @@ struct ws_pipe {
 	uint16_t    peer;
 	nni_aio    *user_txaio;
 	nni_aio    *user_rxaio;
-	nni_aio    *txaio;
-	nni_aio    *rxaio;
+	nni_aio     txaio;
+	nni_aio     rxaio;
 	nng_stream *ws;
 };
 
 static void
 wstran_pipe_send_cb(void *arg)
 {
-	ws_pipe *p = arg;
-	nni_aio *taio;
+	ws_pipe *p    = arg;
+	nni_aio *taio = &p->txaio;
 	nni_aio *uaio;
 
 	nni_mtx_lock(&p->mtx);
-	taio          = p->txaio;
 	uaio          = p->user_txaio;
 	p->user_txaio = NULL;
 
@@ -78,7 +77,7 @@ static void
 wstran_pipe_recv_cb(void *arg)
 {
 	ws_pipe *p    = arg;
-	nni_aio *raio = p->rxaio;
+	nni_aio *raio = &p->rxaio;
 	nni_aio *uaio;
 	int      rv;
 
@@ -110,7 +109,7 @@ wstran_pipe_recv_cancel(nni_aio *aio, void *arg, int rv)
 		return;
 	}
 	p->user_rxaio = NULL;
-	nni_aio_abort(p->rxaio, rv);
+	nni_aio_abort(&p->rxaio, rv);
 	nni_aio_finish_error(aio, rv);
 	nni_mtx_unlock(&p->mtx);
 }
@@ -131,7 +130,7 @@ wstran_pipe_recv(void *arg, nni_aio *aio)
 		return;
 	}
 	p->user_rxaio = aio;
-	nng_stream_recv(p->ws, p->rxaio);
+	nng_stream_recv(p->ws, &p->rxaio);
 	nni_mtx_unlock(&p->mtx);
 }
 
@@ -145,7 +144,7 @@ wstran_pipe_send_cancel(nni_aio *aio, void *arg, int rv)
 		return;
 	}
 	p->user_txaio = NULL;
-	nni_aio_abort(p->txaio, rv);
+	nni_aio_abort(&p->txaio, rv);
 	nni_aio_finish_error(aio, rv);
 	nni_mtx_unlock(&p->mtx);
 }
@@ -170,10 +169,10 @@ wstran_pipe_send(void *arg, nni_aio *aio)
 		return;
 	}
 	p->user_txaio = aio;
-	nni_aio_set_msg(p->txaio, nni_aio_get_msg(aio));
+	nni_aio_set_msg(&p->txaio, nni_aio_get_msg(aio));
 	nni_aio_set_msg(aio, NULL);
 
-	nng_stream_send(p->ws, p->txaio);
+	nng_stream_send(p->ws, &p->txaio);
 	nni_mtx_unlock(&p->mtx);
 }
 
@@ -182,8 +181,8 @@ wstran_pipe_stop(void *arg)
 {
 	ws_pipe *p = arg;
 
-	nni_aio_stop(p->rxaio);
-	nni_aio_stop(p->txaio);
+	nni_aio_stop(&p->rxaio);
+	nni_aio_stop(&p->txaio);
 }
 
 static int
@@ -200,8 +199,8 @@ wstran_pipe_fini(void *arg)
 	ws_pipe *p = arg;
 
 	nng_stream_free(p->ws);
-	nni_aio_free(p->rxaio);
-	nni_aio_free(p->txaio);
+	nni_aio_fini(&p->rxaio);
+	nni_aio_fini(&p->txaio);
 
 	nni_mtx_fini(&p->mtx);
 	NNI_FREE_STRUCT(p);
@@ -212,8 +211,8 @@ wstran_pipe_close(void *arg)
 {
 	ws_pipe *p = arg;
 
-	nni_aio_close(p->rxaio);
-	nni_aio_close(p->txaio);
+	nni_aio_close(&p->rxaio);
+	nni_aio_close(&p->txaio);
 
 	nni_mtx_lock(&p->mtx);
 	nng_stream_close(p->ws);
@@ -224,20 +223,16 @@ static int
 wstran_pipe_alloc(ws_pipe **pipep, void *ws)
 {
 	ws_pipe *p;
-	int      rv;
 
 	if ((p = NNI_ALLOC_STRUCT(p)) == NULL) {
 		return (NNG_ENOMEM);
 	}
+	p->ws = ws;
 	nni_mtx_init(&p->mtx);
 
 	// Initialize AIOs.
-	if (((rv = nni_aio_alloc(&p->txaio, wstran_pipe_send_cb, p)) != 0) ||
-	    ((rv = nni_aio_alloc(&p->rxaio, wstran_pipe_recv_cb, p)) != 0)) {
-		wstran_pipe_fini(p);
-		return (rv);
-	}
-	p->ws = ws;
+	nni_aio_init(&p->txaio, wstran_pipe_send_cb, p);
+	nni_aio_init(&p->rxaio, wstran_pipe_recv_cb, p);
 
 	*pipep = p;
 	return (0);
@@ -300,7 +295,7 @@ wstran_listener_accept(void *arg, nni_aio *aio)
 	}
 	nni_list_append(&l->aios, aio);
 	if (aio == nni_list_first(&l->aios)) {
-		nng_stream_listener_accept(l->listener, l->accaio);
+		nng_stream_listener_accept(l->listener, &l->accaio);
 	}
 	nni_mtx_unlock(&l->mtx);
 }
@@ -337,7 +332,7 @@ wstran_dialer_connect(void *arg, nni_aio *aio)
 	NNI_ASSERT(nni_list_empty(&d->aios));
 	d->started = true;
 	nni_list_append(&d->aios, aio);
-	nng_stream_dialer_dial(d->dialer, d->connaio);
+	nng_stream_dialer_dial(d->dialer, &d->connaio);
 	nni_mtx_unlock(&d->mtx);
 }
 
@@ -377,9 +372,9 @@ wstran_dialer_fini(void *arg)
 {
 	ws_dialer *d = arg;
 
-	nni_aio_stop(d->connaio);
+	nni_aio_stop(&d->connaio);
 	nng_stream_dialer_free(d->dialer);
-	nni_aio_free(d->connaio);
+	nni_aio_fini(&d->connaio);
 	nni_mtx_fini(&d->mtx);
 	NNI_FREE_STRUCT(d);
 }
@@ -389,9 +384,9 @@ wstran_listener_fini(void *arg)
 {
 	ws_listener *l = arg;
 
-	nni_aio_stop(l->accaio);
+	nni_aio_stop(&l->accaio);
 	nng_stream_listener_free(l->listener);
-	nni_aio_free(l->accaio);
+	nni_aio_fini(&l->accaio);
 	nni_mtx_fini(&l->mtx);
 	NNI_FREE_STRUCT(l);
 }
@@ -401,7 +396,7 @@ wstran_connect_cb(void *arg)
 {
 	ws_dialer  *d = arg;
 	ws_pipe    *p;
-	nni_aio    *caio = d->connaio;
+	nni_aio    *caio = &d->connaio;
 	nni_aio    *uaio;
 	int         rv;
 	nng_stream *ws = NULL;
@@ -437,7 +432,7 @@ wstran_dialer_close(void *arg)
 {
 	ws_dialer *d = arg;
 
-	nni_aio_close(d->connaio);
+	nni_aio_close(&d->connaio);
 	nng_stream_dialer_close(d->dialer);
 }
 
@@ -446,7 +441,7 @@ wstran_listener_close(void *arg)
 {
 	ws_listener *l = arg;
 
-	nni_aio_close(l->accaio);
+	nni_aio_close(&l->accaio);
 	nng_stream_listener_close(l->listener);
 }
 
@@ -454,7 +449,7 @@ static void
 wstran_accept_cb(void *arg)
 {
 	ws_listener *l    = arg;
-	nni_aio     *aaio = l->accaio;
+	nni_aio     *aaio = &l->accaio;
 	nni_aio     *uaio;
 	int          rv;
 
@@ -502,6 +497,7 @@ wstran_dialer_init(void **dp, nng_url *url, nni_dialer *ndialer)
 	nni_mtx_init(&d->mtx);
 
 	nni_aio_list_init(&d->aios);
+	nni_aio_init(&d->connaio, wstran_connect_cb, d);
 
 	d->peer = nni_sock_peer_id(s);
 
@@ -509,7 +505,6 @@ wstran_dialer_init(void **dp, nng_url *url, nni_dialer *ndialer)
 	    name, sizeof(name), "%s.sp.nanomsg.org", nni_sock_peer_name(s));
 
 	if (((rv = nni_ws_dialer_alloc(&d->dialer, url)) != 0) ||
-	    ((rv = nni_aio_alloc(&d->connaio, wstran_connect_cb, d)) != 0) ||
 	    ((rv = nng_stream_dialer_set_bool(
 	          d->dialer, NNI_OPT_WS_MSGMODE, true)) != 0) ||
 	    ((rv = nng_stream_dialer_set_string(
@@ -536,6 +531,7 @@ wstran_listener_init(void **lp, nng_url *url, nni_listener *listener)
 	nni_mtx_init(&l->mtx);
 
 	nni_aio_list_init(&l->aios);
+	nni_aio_init(&l->accaio, wstran_accept_cb, l);
 
 	l->peer = nni_sock_peer_id(s);
 
@@ -543,7 +539,6 @@ wstran_listener_init(void **lp, nng_url *url, nni_listener *listener)
 	    name, sizeof(name), "%s.sp.nanomsg.org", nni_sock_proto_name(s));
 
 	if (((rv = nni_ws_listener_alloc(&l->listener, url)) != 0) ||
-	    ((rv = nni_aio_alloc(&l->accaio, wstran_accept_cb, l)) != 0) ||
 	    ((rv = nng_stream_listener_set_bool(
 	          l->listener, NNI_OPT_WS_MSGMODE, true)) != 0) ||
 	    ((rv = nng_stream_listener_set_string(

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -31,7 +31,7 @@ struct nng_http_handler {
 	bool            host_ip;
 	bool            tree;
 	bool            tree_exclusive;
-	nni_atomic_u64  ref;
+	nni_atomic_int  ref;
 	nni_atomic_bool busy;
 	size_t          maxbody;
 	bool            getbody;
@@ -107,8 +107,8 @@ nni_http_handler_init(
 	if ((h = NNI_ALLOC_STRUCT(h)) == NULL) {
 		return (NNG_ENOMEM);
 	}
-	nni_atomic_init64(&h->ref);
-	nni_atomic_inc64(&h->ref);
+	nni_atomic_init(&h->ref);
+	nni_atomic_inc(&h->ref);
 
 	// Default for HTTP is /.  But remap it to "" for ease of matching.
 	if ((uri == NULL) || (strlen(uri) == 0) || (strcmp(uri, "/") == 0)) {
@@ -137,7 +137,7 @@ nni_http_handler_init(
 void
 nni_http_handler_fini(nni_http_handler *h)
 {
-	if (nni_atomic_dec64_nv(&h->ref) != 0) {
+	if (nni_atomic_dec_nv(&h->ref) != 0) {
 		return;
 	}
 	if (h->dtor != NULL) {
@@ -735,7 +735,7 @@ finish:
 
 	// Set a reference -- this because the callback may be running
 	// asynchronously even after it gets removed from the server.
-	nni_atomic_inc64(&h->ref);
+	nni_atomic_inc(&h->ref);
 
 	// Documented that we call this on behalf of the callback.
 	if (nni_aio_begin(sc->cbaio) != 0) {


### PR DESCRIPTION
This converts the main part of NNG to use reference counting atomics efficiently, instead of some other hacky approaches using locks.   It should be safer, and faster both!