### PR TITLE
windows ipc: check the return value of nni_aio_schedule

### DIFF
--- a/src/platform/windows/win_ipclisten.c
+++ b/src/platform/windows/win_ipclisten.c
@@ -257,6 +257,7 @@ static void
 ipc_listener_accept(void *arg, nni_aio *aio)
 {
 	ipc_listener *l = arg;
+	int           rv;
 	if (nni_aio_begin(aio) != 0) {
 		return;
 	}
@@ -266,10 +267,13 @@ ipc_listener_accept(void *arg, nni_aio *aio)
 		nni_aio_finish_error(aio, NNG_ESTATE);
 		return;
 	}
-	nni_aio_schedule(aio, ipc_accept_cancel, l);
-	nni_list_append(&l->aios, aio);
-	if (nni_list_first(&l->aios) == aio) {
-		ipc_accept_start(l);
+	if ((rv = nni_aio_schedule(aio, ipc_accept_cancel, l)) != 0) {
+		nni_aio_finish_error(aio, rv);
+	} else {
+		nni_list_append(&l->aios, aio);
+		if (nni_list_first(&l->aios) == aio) {
+			ipc_accept_start(l);
+		}
 	}
 	nni_mtx_unlock(&l->mtx);
 }


### PR DESCRIPTION
This hopefully addresses a long standing bug with Windows IPC sometimes hanging on shut down.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
