### PR TITLE
fixes #1408 Reference count as a first class type

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -57,6 +57,8 @@ nng_sources(
         protocol.h
         reap.c
         reap.h
+        refcnt.c
+        refcnt.h
         sockaddr.c
         socket.c
         socket.h

--- a/src/core/nng_impl.h
+++ b/src/core/nng_impl.h
@@ -40,6 +40,7 @@
 #include "core/pollable.h"
 #include "core/protocol.h"
 #include "core/reap.h"
+#include "core/refcnt.h"
 #include "core/stats.h"
 #include "core/stream.h"
 #include "core/strs.h"

--- a/src/core/refcnt.c
+++ b/src/core/refcnt.c
@@ -1,0 +1,33 @@
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include <core/refcnt.h>
+
+void
+nni_refcnt_init(
+    nni_refcnt *rc, unsigned value, void *data, void (*fini)(void *))
+{
+	nni_atomic_init(&rc->rc_cnt);
+	nni_atomic_set(&rc->rc_cnt, value);
+	rc->rc_data = data;
+	rc->rc_fini = fini;
+}
+
+void
+nni_refcnt_hold(nni_refcnt *rc)
+{
+	nni_atomic_inc(&rc->rc_cnt);
+}
+
+void
+nni_refcnt_rele(nni_refcnt *rc)
+{
+	if (nni_atomic_dec_nv(&rc->rc_cnt) == 0) {
+		rc->rc_fini(rc->rc_data);
+	}
+}

--- a/src/core/refcnt.h
+++ b/src/core/refcnt.h
@@ -1,0 +1,28 @@
+// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef CORE_REFCNT_H
+#define CORE_REFCNT_H
+
+#include <nng/nng.h>
+
+#include <core/nng_impl.h>
+#include <core/platform.h>
+
+typedef struct {
+	nni_atomic_int rc_cnt;
+	void (*rc_fini)(void *);
+	void *rc_data;
+} nni_refcnt;
+
+extern void nni_refcnt_init(
+    nni_refcnt *rc, unsigned value, void *v, void (*fini)(void *));
+extern void nni_refcnt_hold(nni_refcnt *rc);
+extern void nni_refcnt_rele(nni_refcnt *rc);
+
+#endif // CORE_REFCNT_H

--- a/src/core/sockimpl.h
+++ b/src/core/sockimpl.h
@@ -105,9 +105,8 @@ struct nni_pipe {
 	nni_atomic_bool    p_closed;
 	nni_atomic_flag    p_stop;
 	bool               p_cbs;
-	int                p_ref;
-	nni_cv             p_cv;
 	nni_reap_node      p_reap;
+	nni_refcnt         p_refcnt;
 
 #ifdef NNG_ENABLE_STATS
 	nni_stat_item st_root;


### PR DESCRIPTION
This starts by using this for the nni_pipe, but we will use it for the other primary objects as well.  This should simplify the tear down and hopefully eliminate some races.

It does mean that pipe destruction goes through an additional context switch, for now at least.  This shouldn't be on the hot data path anyway.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
