### PR TITLE
device: fixes for socket holds and leaking aio data

### DIFF
--- a/src/core/device.c
+++ b/src/core/device.c
@@ -51,6 +51,11 @@ device_fini(void *arg)
 	for (int i = 0; i < d->num_paths; i++) {
 		nni_aio_stop(&d->paths[i].aio);
 	}
+	for (int i = 0; i < d->num_paths; i++) {
+		nni_aio_fini(&d->paths[i].aio);
+	}
+	nni_sock_rele(d->paths[0].src);
+	nni_sock_rele(d->paths[0].dst);
 	NNI_FREE_STRUCT(d);
 }
 
@@ -97,8 +102,6 @@ device_cb(void *arg)
 				nni_aio_finish_error(d->user, d->rv);
 				d->user = NULL;
 			}
-			nni_sock_rele(d->paths[0].src);
-			nni_sock_rele(d->paths[0].dst);
 
 			nni_reap(&device_reap, d);
 		}


### PR DESCRIPTION
The aio structures need to be finalized, and the sockets should be held until the device is totally finalized to prevent any possible use after free.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
