### PR TITLE
syslog: test for existence

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -15,6 +15,7 @@ nng_check_sym(strnlen string.h NNG_HAVE_STRNLEN)
 nng_check_sym(strcasecmp string.h NNG_HAVE_STRCASECMP)
 nng_check_sym(strncasecmp string.h NNG_HAVE_STRNCASECMP)
 nng_check_sym(localtime_r time.h NNG_HAVE_LOCALTIME_R)
+nng_check_sym(syslog syslog.h NNG_HAVE_SYSLOG)
 
 nng_sources(
         defs.h

--- a/src/core/log.c
+++ b/src/core/log.c
@@ -16,7 +16,7 @@
 #ifdef NNG_PLATFORM_WINDOWS
 #include <io.h>
 #endif
-#ifdef NNG_PLATFORM_POSIX
+#ifdef NNG_HAVE_SYSLOG
 #include <syslog.h>
 #include <unistd.h>
 #endif
@@ -90,7 +90,7 @@ stderr_logger(nng_log_level level, nng_log_facility facility,
 #ifdef NNG_PLATFORM_WINDOWS
 	// NB: We are blithely assuming the user has a modern console.
 	colors = _isatty(_fileno(stderr));
-#elif defined(NNG_PLATFORM_POSIX)
+#elif defined(NNG_HAVE_SYSLOG)
 	// Only assuming we can use colors (and attributes) if stderr is a tty
 	// and $TERM is reasonable. We assume the terminal supports ECMA-48,
 	// which is true on every reasonable system these days.
@@ -186,7 +186,7 @@ void
 nng_system_logger(nng_log_level level, nng_log_facility facility,
     const char *msgid, const char *msg)
 {
-#ifdef NNG_PLATFORM_POSIX
+#ifdef NNG_HAVE_SYSLOG
 	int pri;
 	switch (level) {
 	case NNG_LOG_ERR:


### PR DESCRIPTION
Some POSIX emulations may lack a reasonable syslog function (although syslog is required per the Open Group).  For now we just check for it, and don't use it if it isn't present.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
