### PR TITLE
nni_aio_defer does not use nni_aio_begin first

### DIFF
--- a/src/core/aio_test.c
+++ b/src/core/aio_test.c
@@ -130,8 +130,7 @@ test_provider_cancel(void)
 	int      rv = 0;
 	// We fake an empty provider that does not do anything.
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
-	NUTS_TRUE(nng_aio_begin(aio) == true);
-	nng_aio_defer(aio, cancel, &rv);
+	NUTS_TRUE(nng_aio_defer(aio, cancel, &rv));
 	nng_aio_cancel(aio);
 	nng_aio_wait(aio);
 	NUTS_TRUE(rv == NNG_ECANCELED);

--- a/src/core/device.c
+++ b/src/core/device.c
@@ -219,13 +219,12 @@ nni_device(nni_aio *aio, nni_sock *s1, nni_sock *s2)
 	device_data *d;
 	int          rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&device_mtx);
 	if ((rv = device_init(&d, s1, s2)) != 0) {
 		nni_mtx_unlock(&device_mtx);
-		nni_aio_finish_error(aio, rv);
+		if (nni_aio_defer(aio, NULL, NULL)) {
+			nni_aio_finish_error(aio, rv);
+		}
 		return;
 	}
 	if (!nni_aio_defer(aio, device_cancel, d)) {

--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -466,7 +466,7 @@ nni_dialer_start(nni_dialer *d, unsigned flags)
 			nni_atomic_flag_reset(&d->d_started);
 			return (rv);
 		}
-		nni_aio_begin(aio);
+		nni_aio_defer(aio, NULL, NULL);
 	}
 
 	nni_mtx_lock(&d->d_mtx);

--- a/src/core/msgqueue.c
+++ b/src/core/msgqueue.c
@@ -213,9 +213,6 @@ nni_msgq_cancel(nni_aio *aio, void *arg, int rv)
 void
 nni_msgq_aio_put(nni_msgq *mq, nni_aio *aio)
 {
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&mq->mq_lock);
 
 	// If this is an instantaneous poll operation, and the queue has
@@ -234,9 +231,6 @@ nni_msgq_aio_put(nni_msgq *mq, nni_aio *aio)
 void
 nni_msgq_aio_get(nni_msgq *mq, nni_aio *aio)
 {
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&mq->mq_lock);
 	if (!nni_aio_defer(aio, nni_msgq_cancel, mq)) {
 		nni_mtx_unlock(&mq->mq_lock);

--- a/src/nng.c
+++ b/src/nng.c
@@ -213,7 +213,7 @@ nng_recv_aio(nng_socket s, nng_aio *aio)
 	int       rv;
 
 	if ((rv = nni_sock_find(&sock, s.id)) != 0) {
-		if (nni_aio_begin(aio) == 0) {
+		if (nni_aio_defer(aio, NULL, NULL)) {
 			nni_aio_finish_error(aio, rv);
 		}
 		return;
@@ -229,13 +229,13 @@ nng_send_aio(nng_socket s, nng_aio *aio)
 	int       rv;
 
 	if (nni_aio_get_msg(aio) == NULL) {
-		if (nni_aio_begin(aio) == 0) {
+		if (nni_aio_defer(aio, NULL, NULL)) {
 			nni_aio_finish_error(aio, NNG_EINVAL);
 		}
 		return;
 	}
 	if ((rv = nni_sock_find(&sock, s.id)) != 0) {
-		if (nni_aio_begin(aio) == 0) {
+		if (nni_aio_defer(aio, NULL, NULL)) {
 			nni_aio_finish_error(aio, rv);
 		}
 		return;
@@ -327,7 +327,7 @@ nng_ctx_recv(nng_ctx cid, nng_aio *aio)
 	nni_ctx *ctx;
 
 	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
-		if (nni_aio_begin(aio) == 0) {
+		if (nni_aio_defer(aio, NULL, NULL)) {
 			nni_aio_finish_error(aio, rv);
 		}
 		return;
@@ -343,13 +343,13 @@ nng_ctx_send(nng_ctx cid, nng_aio *aio)
 	nni_ctx *ctx;
 
 	if (nni_aio_get_msg(aio) == NULL) {
-		if (nni_aio_begin(aio) == 0) {
+		if (nni_aio_defer(aio, NULL, NULL)) {
 			nni_aio_finish_error(aio, NNG_EINVAL);
 		}
 		return;
 	}
 	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
-		if (nni_aio_begin(aio) == 0) {
+		if (nni_aio_defer(aio, NULL, NULL)) {
 			nni_aio_finish_error(aio, rv);
 		}
 		return;
@@ -1281,7 +1281,7 @@ nng_device_aio(nng_aio *aio, nng_socket s1, nng_socket s2)
 
 	if ((s1.id > 0) && (s1.id != (uint32_t) -1)) {
 		if ((rv = nni_sock_find(&sock1, s1.id)) != 0) {
-			if (nni_aio_begin(aio) == 0) {
+			if (nni_aio_defer(aio, NULL, NULL)) {
 				nni_aio_finish_error(aio, rv);
 			}
 			return;
@@ -1290,7 +1290,7 @@ nng_device_aio(nng_aio *aio, nng_socket s1, nng_socket s2)
 	if (((s2.id > 0) && (s2.id != (uint32_t) -1)) && (s2.id != s1.id)) {
 		if ((rv = nni_sock_find(&sock2, s2.id)) != 0) {
 			nni_sock_rele(sock1);
-			if (nni_aio_begin(aio) == 0) {
+			if (nni_aio_defer(aio, NULL, NULL)) {
 				nni_aio_finish_error(aio, rv);
 			}
 			return;

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -247,9 +247,6 @@ ipc_send(void *arg, nni_aio *aio)
 {
 	ipc_conn *c = arg;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&c->mtx);
 
 	if (!nni_aio_defer(aio, ipc_cancel, c)) {
@@ -274,16 +271,11 @@ static void
 ipc_recv(void *arg, nni_aio *aio)
 {
 	ipc_conn *c = arg;
-	int       rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&c->mtx);
 
-	if ((rv = nni_aio_schedule(aio, ipc_cancel, c)) != 0) {
+	if (!nni_aio_defer(aio, ipc_cancel, c)) {
 		nni_mtx_unlock(&c->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&c->readq, aio);

--- a/src/platform/posix/posix_ipclisten.c
+++ b/src/platform/posix/posix_ipclisten.c
@@ -415,16 +415,16 @@ static void
 ipc_listener_accept(void *arg, nni_aio *aio)
 {
 	ipc_listener *l = arg;
-	int           rv;
 
 	// Accept is simpler than the connect case.  With accept we just
 	// need to wait for the socket to be readable to indicate an incoming
 	// connection is ready for us.  There isn't anything else for us to
 	// do really, as that will have been done in listen.
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&l->mtx);
+	if (!nni_aio_defer(aio, ipc_listener_cancel, l)) {
+		nni_mtx_unlock(&l->mtx);
 		return;
 	}
-	nni_mtx_lock(&l->mtx);
 
 	if (!l->started) {
 		nni_mtx_unlock(&l->mtx);
@@ -434,11 +434,6 @@ ipc_listener_accept(void *arg, nni_aio *aio)
 	if (l->closed) {
 		nni_mtx_unlock(&l->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, ipc_listener_cancel, l)) != 0) {
-		nni_mtx_unlock(&l->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&l->acceptq, aio);

--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -231,9 +231,6 @@ nni_resolv_ip(const char *host, uint16_t port, int af, bool passive,
 	resolv_item *item;
 	sa_family_t  fam;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	if (host != NULL) {
 		if ((strlen(host) >= sizeof(item->host)) ||
 		    (strcmp(host, "*") == 0)) {

--- a/src/platform/posix/posix_sockfd.c
+++ b/src/platform/posix/posix_sockfd.c
@@ -275,16 +275,11 @@ static void
 sfd_send(void *arg, nni_aio *aio)
 {
 	nni_sfd_conn *c = arg;
-	int           rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&c->mtx);
 
-	if ((rv = nni_aio_schedule(aio, sfd_cancel, c)) != 0) {
+	if (!nni_aio_defer(aio, sfd_cancel, c)) {
 		nni_mtx_unlock(&c->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&c->writeq, aio);
@@ -305,16 +300,11 @@ static void
 sfd_recv(void *arg, nni_aio *aio)
 {
 	nni_sfd_conn *c = arg;
-	int           rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&c->mtx);
 
-	if ((rv = nni_aio_schedule(aio, sfd_cancel, c)) != 0) {
+	if (!nni_aio_defer(aio, sfd_cancel, c)) {
 		nni_mtx_unlock(&c->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&c->readq, aio);

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -283,16 +283,11 @@ static void
 tcp_send(void *arg, nni_aio *aio)
 {
 	nni_tcp_conn *c = arg;
-	int           rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&c->mtx);
 
-	if ((rv = nni_aio_schedule(aio, tcp_cancel, c)) != 0) {
+	if (!nni_aio_defer(aio, tcp_cancel, c)) {
 		nni_mtx_unlock(&c->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&c->writeq, aio);
@@ -313,16 +308,11 @@ static void
 tcp_recv(void *arg, nni_aio *aio)
 {
 	nni_tcp_conn *c = arg;
-	int           rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&c->mtx);
 
-	if ((rv = nni_aio_schedule(aio, tcp_cancel, c)) != 0) {
+	if (!nni_aio_defer(aio, tcp_cancel, c)) {
 		nni_mtx_unlock(&c->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&c->readq, aio);

--- a/src/platform/posix/posix_tcplisten.c
+++ b/src/platform/posix/posix_tcplisten.c
@@ -283,16 +283,15 @@ nni_tcp_listener_fini(nni_tcp_listener *l)
 void
 nni_tcp_listener_accept(nni_tcp_listener *l, nni_aio *aio)
 {
-	int rv;
-
 	// Accept is simpler than the connect case.  With accept we just
 	// need to wait for the socket to be readable to indicate an incoming
 	// connection is ready for us.  There isn't anything else for us to
 	// do really, as that will have been done in listen.
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&l->mtx);
+	if (!nni_aio_defer(aio, tcp_listener_cancel, l)) {
+		nni_mtx_unlock(&l->mtx);
 		return;
 	}
-	nni_mtx_lock(&l->mtx);
 
 	if (!l->started) {
 		nni_mtx_unlock(&l->mtx);
@@ -302,11 +301,6 @@ nni_tcp_listener_accept(nni_tcp_listener *l, nni_aio *aio)
 	if (l->closed) {
 		nni_mtx_unlock(&l->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, tcp_listener_cancel, l)) != 0) {
-		nni_mtx_unlock(&l->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_aio_list_append(&l->acceptq, aio);

--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -297,18 +297,14 @@ nni_plat_udp_cancel(nni_aio *aio, void *arg, int rv)
 void
 nni_plat_udp_recv(nni_plat_udp *udp, nni_aio *aio)
 {
-	int rv;
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&udp->udp_mtx);
-	if ((rv = nni_aio_schedule(aio, nni_plat_udp_cancel, udp)) != 0) {
+	if (!nni_aio_defer(aio, nni_plat_udp_cancel, udp)) {
 		nni_mtx_unlock(&udp->udp_mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&udp->udp_recvq, aio);
 	if (nni_list_first(&udp->udp_recvq) == aio) {
+		int rv;
 		if ((rv = nni_posix_pfd_arm(&udp->udp_pfd, NNI_POLL_IN)) !=
 		    0) {
 			nni_aio_list_remove(aio);
@@ -321,18 +317,14 @@ nni_plat_udp_recv(nni_plat_udp *udp, nni_aio *aio)
 void
 nni_plat_udp_send(nni_plat_udp *udp, nni_aio *aio)
 {
-	int rv;
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&udp->udp_mtx);
-	if ((rv = nni_aio_schedule(aio, nni_plat_udp_cancel, udp)) != 0) {
+	if (!nni_aio_defer(aio, nni_plat_udp_cancel, udp)) {
 		nni_mtx_unlock(&udp->udp_mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&udp->udp_sendq, aio);
 	if (nni_list_first(&udp->udp_sendq) == aio) {
+		int rv;
 		if ((rv = nni_posix_pfd_arm(&udp->udp_pfd, NNI_POLL_OUT)) !=
 		    0) {
 			nni_aio_list_remove(aio);

--- a/src/sp/protocol/bus0/bus_test.c
+++ b/src/sp/protocol/bus0/bus_test.c
@@ -189,12 +189,12 @@ test_bus_aio_stopped(void)
 
 	nng_recv_aio(s1, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 
 	nng_aio_set_msg(aio, msg);
 	nng_send_aio(s1, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 
 	nng_aio_free(aio);
 	nng_msg_free(msg);

--- a/src/sp/protocol/pair0/pair0_test.c
+++ b/src/sp/protocol/pair0/pair0_test.c
@@ -212,7 +212,7 @@ test_pair0_send_closed_aio(void)
 	nng_aio_stop(aio);
 	nng_send_aio(s1, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	nng_msg_free(msg);
 	nng_aio_free(aio);
 	NUTS_PASS(nng_close(s1));

--- a/src/sp/protocol/pair1/pair1_test.c
+++ b/src/sp/protocol/pair1/pair1_test.c
@@ -278,7 +278,7 @@ test_pair1_send_closed_aio(void)
 	nng_aio_stop(aio);
 	nng_send_aio(s1, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	nng_msg_free(msg);
 	nng_aio_free(aio);
 	NUTS_PASS(nng_close(s1));

--- a/src/sp/protocol/pipeline0/pull.c
+++ b/src/sp/protocol/pipeline0/pull.c
@@ -223,20 +223,12 @@ pull0_sock_recv(void *arg, nni_aio *aio)
 	pull0_sock *s = arg;
 	pull0_pipe *p;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&s->m);
+	if (!nni_aio_defer(aio, pull0_cancel, s)) {
+		nni_mtx_unlock(&s->m);
 		return;
 	}
-
-	nni_mtx_lock(&s->m);
 	if ((p = nni_list_first(&s->pl)) == NULL) {
-
-		int rv;
-		if ((rv = nni_aio_schedule(aio, pull0_cancel, s)) != 0) {
-			nni_mtx_unlock(&s->m);
-			nni_aio_finish_error(aio, rv);
-			return;
-		}
-
 		nni_aio_list_append(&s->rq, aio);
 		nni_mtx_unlock(&s->m);
 		return;

--- a/src/sp/protocol/pipeline0/pull_test.c
+++ b/src/sp/protocol/pipeline0/pull_test.c
@@ -175,7 +175,7 @@ test_pull_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_recv_aio(s, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_CLOSE(s);
 	nng_aio_free(aio);
 }

--- a/src/sp/protocol/pipeline0/push.c
+++ b/src/sp/protocol/pipeline0/push.c
@@ -269,16 +269,15 @@ push0_sock_send(void *arg, nni_aio *aio)
 	push0_pipe *p;
 	nni_msg    *m;
 	size_t      l;
-	int         rv;
-
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 
 	m = nni_aio_get_msg(aio);
 	l = nni_msg_len(m);
 
 	nni_mtx_lock(&s->m);
+	if (!nni_aio_defer(aio, push0_cancel, s)) {
+		nni_mtx_unlock(&s->m);
+		return;
+	}
 
 	// First we want to see if we can send it right now.
 	// Note that we don't block the sender until the read is complete,
@@ -312,11 +311,6 @@ push0_sock_send(void *arg, nni_aio *aio)
 		return;
 	}
 
-	if ((rv = nni_aio_schedule(aio, push0_cancel, s)) != 0) {
-		nni_aio_finish_error(aio, rv);
-		nni_mtx_unlock(&s->m);
-		return;
-	}
 	nni_aio_list_append(&s->aq, aio);
 	nni_mtx_unlock(&s->m);
 }

--- a/src/sp/protocol/pipeline0/push_test.c
+++ b/src/sp/protocol/pipeline0/push_test.c
@@ -252,7 +252,7 @@ test_push_send_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_send_aio(s, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_CLOSE(s);
 	nng_aio_free(aio);
 	nng_msg_free(m);

--- a/src/sp/protocol/pubsub0/pub_test.c
+++ b/src/sp/protocol/pubsub0/pub_test.c
@@ -191,7 +191,7 @@ test_sub_ctx_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_ctx_recv(ctx, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_PASS(nng_ctx_close(ctx));
 	NUTS_CLOSE(sub);
 	nng_aio_free(aio);

--- a/src/sp/protocol/pubsub0/sub_test.c
+++ b/src/sp/protocol/pubsub0/sub_test.c
@@ -223,7 +223,7 @@ test_sub_ctx_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_ctx_recv(ctx, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_PASS(nng_ctx_close(ctx));
 	NUTS_CLOSE(sub);
 	nng_aio_free(aio);

--- a/src/sp/protocol/pubsub0/xsub_test.c
+++ b/src/sp/protocol/pubsub0/xsub_test.c
@@ -337,7 +337,7 @@ test_xsub_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_recv_aio(sub, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_CLOSE(sub);
 	nng_aio_free(aio);
 }

--- a/src/sp/protocol/reqrep0/rep.c
+++ b/src/sp/protocol/reqrep0/rep.c
@@ -139,11 +139,12 @@ rep0_ctx_send(void *arg, nni_aio *aio)
 	msg = nni_aio_get_msg(aio);
 	nni_msg_header_clear(msg);
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&s->lk);
+	if (!nni_aio_defer(aio, rep0_ctx_cancel_send, ctx)) {
+		nni_mtx_unlock(&s->lk);
 		return;
 	}
 
-	nni_mtx_lock(&s->lk);
 	len  = ctx->btrace_len;
 	p_id = ctx->pipe_id;
 
@@ -188,12 +189,6 @@ rep0_ctx_send(void *arg, nni_aio *aio)
 
 		nni_aio_set_msg(aio, NULL);
 		nni_aio_finish(aio, 0, len);
-		return;
-	}
-
-	if ((rv = nni_aio_schedule(aio, rep0_ctx_cancel_send, ctx)) != 0) {
-		nni_mtx_unlock(&s->lk);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 
@@ -424,17 +419,12 @@ rep0_ctx_recv(void *arg, nni_aio *aio)
 	size_t     len;
 	nni_msg   *msg;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&s->lk);
+	if (!nni_aio_defer(aio, rep0_cancel_recv, ctx)) {
+		nni_mtx_unlock(&s->lk);
 		return;
 	}
-	nni_mtx_lock(&s->lk);
 	if ((p = nni_list_first(&s->recvpipes)) == NULL) {
-		int rv;
-		if ((rv = nni_aio_schedule(aio, rep0_cancel_recv, ctx)) != 0) {
-			nni_mtx_unlock(&s->lk);
-			nni_aio_finish_error(aio, rv);
-			return;
-		}
 		if (ctx->raio != NULL) {
 			// Cannot have a second receive operation pending.
 			// This could be ESTATE, or we could cancel the first

--- a/src/sp/protocol/reqrep0/req.c
+++ b/src/sp/protocol/reqrep0/req.c
@@ -610,7 +610,6 @@ req0_ctx_recv(void *arg, nni_aio *aio)
 
 	nni_mtx_lock(&s->mtx);
 	if (!nni_aio_defer(aio, req0_ctx_cancel_recv, ctx)) {
-		;
 		nni_mtx_unlock(&s->mtx);
 		return;
 	}

--- a/src/sp/protocol/reqrep0/xrep_test.c
+++ b/src/sp/protocol/reqrep0/xrep_test.c
@@ -262,6 +262,23 @@ test_xrep_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_recv_aio(rep, aio);
 	nng_aio_wait(aio);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
+	NUTS_CLOSE(rep);
+	nng_aio_free(aio);
+}
+
+static void
+test_xrep_recv_aio_aborted(void)
+{
+	nng_socket rep;
+	nng_aio   *aio;
+
+	NUTS_PASS(nng_rep0_open_raw(&rep));
+	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
+
+	nng_recv_aio(rep, aio);
+	nng_aio_cancel(aio);
+	nng_aio_wait(aio);
 	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
 	NUTS_CLOSE(rep);
 	nng_aio_free(aio);
@@ -415,6 +432,7 @@ NUTS_TESTS = {
 	{ "xrep close pipe during send", test_xrep_close_pipe_during_send },
 	{ "xrep close during recv", test_xrep_close_during_recv },
 	{ "xrep recv aio stopped", test_xrep_recv_aio_stopped },
+	{ "xrep recv aio aborted", test_xrep_recv_aio_aborted },
 	{ "xrep send no header", test_xrep_send_no_header },
 	{ "xrep recv garbage", test_xrep_recv_garbage },
 	{ "xrep ttl option", test_xrep_ttl_option },

--- a/src/sp/protocol/reqrep0/xreq_test.c
+++ b/src/sp/protocol/reqrep0/xreq_test.c
@@ -168,7 +168,7 @@ test_xreq_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_recv_aio(req, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_CLOSE(req);
 	nng_aio_free(aio);
 }

--- a/src/sp/protocol/survey0/respond_test.c
+++ b/src/sp/protocol/survey0/respond_test.c
@@ -257,7 +257,7 @@ test_resp_ctx_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_ctx_recv(ctx, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_PASS(nng_ctx_close(ctx));
 	NUTS_CLOSE(resp);
 	nng_aio_free(aio);

--- a/src/sp/protocol/survey0/survey_test.c
+++ b/src/sp/protocol/survey0/survey_test.c
@@ -240,7 +240,7 @@ test_surv_cancel_abort_recv(void)
 
 	// Our pending I/O should have been canceled.
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 
 	// Receive the first request (should be abc) on the respondent.
 	NUTS_RECV(resp, "abc");

--- a/src/sp/protocol/survey0/xrespond_test.c
+++ b/src/sp/protocol/survey0/xrespond_test.c
@@ -262,6 +262,23 @@ test_xresp_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_recv_aio(resp, aio);
 	nng_aio_wait(aio);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
+	NUTS_CLOSE(resp);
+	nng_aio_free(aio);
+}
+
+static void
+test_xresp_recv_aio_canceled(void)
+{
+	nng_socket resp;
+	nng_aio   *aio;
+
+	NUTS_PASS(nng_respondent0_open_raw(&resp));
+	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
+
+	nng_recv_aio(resp, aio);
+	nng_aio_cancel(aio);
+	nng_aio_wait(aio);
 	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
 	NUTS_CLOSE(resp);
 	nng_aio_free(aio);
@@ -418,6 +435,7 @@ NUTS_TESTS = {
 	    test_xresp_close_pipe_during_send },
 	{ "xrespond close during recv", test_xresp_close_during_recv },
 	{ "xrespond recv aio stopped", test_xresp_recv_aio_stopped },
+	{ "xrespond recv aio canceled", test_xresp_recv_aio_canceled },
 	{ "xrespond send no header", test_xresp_send_no_header },
 	{ "xrespond recv garbage", test_xresp_recv_garbage },
 	{ "xrespond ttl option", test_xresp_ttl_option },

--- a/src/sp/protocol/survey0/xsurvey_test.c
+++ b/src/sp/protocol/survey0/xsurvey_test.c
@@ -167,7 +167,7 @@ test_xsurvey_recv_aio_stopped(void)
 	nng_aio_stop(aio);
 	nng_recv_aio(surv, aio);
 	nng_aio_wait(aio);
-	NUTS_FAIL(nng_aio_result(aio), NNG_ECANCELED);
+	NUTS_FAIL(nng_aio_result(aio), NNG_ECLOSED);
 	NUTS_CLOSE(surv);
 	nng_aio_free(aio);
 }

--- a/src/sp/transport/ipc/ipc.c
+++ b/src/sp/transport/ipc/ipc.c
@@ -481,19 +481,10 @@ static void
 ipc_pipe_send(void *arg, nni_aio *aio)
 {
 	ipc_pipe *p = arg;
-	int       rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		// No way to give the message back to the protocol, so
-		// we just discard it silently to prevent it from leaking.
-		nni_msg_free(nni_aio_get_msg(aio));
-		nni_aio_set_msg(aio, NULL);
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, ipc_pipe_send_cancel, p)) != 0) {
+	if (!nni_aio_defer(aio, ipc_pipe_send_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&p->send_q, aio);
@@ -556,20 +547,15 @@ static void
 ipc_pipe_recv(void *arg, nni_aio *aio)
 {
 	ipc_pipe *p = arg;
-	int       rv;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&p->mtx);
+	if (!nni_aio_defer(aio, ipc_pipe_recv_cancel, p)) {
+		nni_mtx_unlock(&p->mtx);
 		return;
 	}
-	nni_mtx_lock(&p->mtx);
 	if (p->closed) {
 		nni_mtx_unlock(&p->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, ipc_pipe_recv_cancel, p)) != 0) {
-		nni_mtx_unlock(&p->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 
@@ -857,12 +843,12 @@ static void
 ipc_ep_connect(void *arg, nni_aio *aio)
 {
 	ipc_ep *ep = arg;
-	int     rv;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&ep->mtx);
+	if (!nni_aio_defer(aio, ipc_ep_cancel, ep)) {
+		nni_mtx_unlock(&ep->mtx);
 		return;
 	}
-	nni_mtx_lock(&ep->mtx);
 	if (ep->closed) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
@@ -874,11 +860,6 @@ ipc_ep_connect(void *arg, nni_aio *aio)
 		return;
 	}
 
-	if ((rv = nni_aio_schedule(aio, ipc_ep_cancel, ep)) != 0) {
-		nni_mtx_unlock(&ep->mtx);
-		nni_aio_finish_error(aio, rv);
-		return;
-	}
 	ep->user_aio = aio;
 	nng_stream_dialer_dial(ep->dialer, &ep->conn_aio);
 	nni_mtx_unlock(&ep->mtx);
@@ -930,12 +911,12 @@ static void
 ipc_ep_accept(void *arg, nni_aio *aio)
 {
 	ipc_ep *ep = arg;
-	int     rv;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&ep->mtx);
+	if (!nni_aio_defer(aio, ipc_ep_cancel, ep)) {
+		nni_mtx_unlock(&ep->mtx);
 		return;
 	}
-	nni_mtx_lock(&ep->mtx);
 	if (ep->closed) {
 		nni_aio_finish_error(aio, NNG_ECLOSED);
 		nni_mtx_unlock(&ep->mtx);
@@ -944,11 +925,6 @@ ipc_ep_accept(void *arg, nni_aio *aio)
 	if (ep->user_aio != NULL) {
 		nni_aio_finish_error(aio, NNG_EBUSY);
 		nni_mtx_unlock(&ep->mtx);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, ipc_ep_cancel, ep)) != 0) {
-		nni_mtx_unlock(&ep->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	ep->user_aio = aio;

--- a/src/sp/transport/socket/sockfd.c
+++ b/src/sp/transport/socket/sockfd.c
@@ -453,19 +453,10 @@ static void
 sfd_tran_pipe_send(void *arg, nni_aio *aio)
 {
 	sfd_tran_pipe *p = arg;
-	int            rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		// No way to give the message back to the protocol, so
-		// we just discard it silently to prevent it from leaking.
-		nni_msg_free(nni_aio_get_msg(aio));
-		nni_aio_set_msg(aio, NULL);
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, sfd_tran_pipe_send_cancel, p)) != 0) {
+	if (!nni_aio_defer(aio, sfd_tran_pipe_send_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&p->sendq, aio);
@@ -530,15 +521,10 @@ static void
 sfd_tran_pipe_recv(void *arg, nni_aio *aio)
 {
 	sfd_tran_pipe *p = arg;
-	int            rv;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, sfd_tran_pipe_recv_cancel, p)) != 0) {
+	if (!nni_aio_defer(aio, sfd_tran_pipe_recv_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 
@@ -791,12 +777,12 @@ static void
 sfd_tran_ep_accept(void *arg, nni_aio *aio)
 {
 	sfd_tran_ep *ep = arg;
-	int          rv;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&ep->mtx);
+	if (!nni_aio_defer(aio, sfd_tran_ep_cancel, ep)) {
+		nni_mtx_unlock(&ep->mtx);
 		return;
 	}
-	nni_mtx_lock(&ep->mtx);
 	if (ep->closed) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
@@ -805,11 +791,6 @@ sfd_tran_ep_accept(void *arg, nni_aio *aio)
 	if (ep->useraio != NULL) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_EBUSY);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, sfd_tran_ep_cancel, ep)) != 0) {
-		nni_mtx_unlock(&ep->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	ep->useraio = aio;

--- a/src/sp/transport/tls/tls.c
+++ b/src/sp/transport/tls/tls.c
@@ -458,19 +458,9 @@ static void
 tlstran_pipe_send(void *arg, nni_aio *aio)
 {
 	tlstran_pipe *p = arg;
-	int           rv;
-
-	if (nni_aio_begin(aio) != 0) {
-		// No way to give the message back to the protocol, so
-		// we just discard it silently to prevent it from leaking.
-		nni_msg_free(nni_aio_get_msg(aio));
-		nni_aio_set_msg(aio, NULL);
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, tlstran_pipe_send_cancel, p)) != 0) {
+	if (!nni_aio_defer(aio, tlstran_pipe_send_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	nni_list_append(&p->sendq, aio);
@@ -523,15 +513,9 @@ static void
 tlstran_pipe_recv(void *arg, nni_aio *aio)
 {
 	tlstran_pipe *p = arg;
-	int           rv;
-
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
-	if ((rv = nni_aio_schedule(aio, tlstran_pipe_recv_cancel, p)) != 0) {
+	if (!nni_aio_defer(aio, tlstran_pipe_recv_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 
@@ -837,13 +821,12 @@ static void
 tlstran_ep_connect(void *arg, nni_aio *aio)
 {
 	tlstran_ep *ep = arg;
-	int         rv;
-
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 
 	nni_mtx_lock(&ep->mtx);
+	if (!nni_aio_defer(aio, tlstran_ep_cancel, ep)) {
+		nni_mtx_unlock(&ep->mtx);
+		return;
+	}
 	if (ep->closed) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
@@ -852,11 +835,6 @@ tlstran_ep_connect(void *arg, nni_aio *aio)
 	if (ep->useraio != NULL) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_EBUSY);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, tlstran_ep_cancel, ep)) != 0) {
-		nni_mtx_unlock(&ep->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	ep->useraio = aio;
@@ -888,12 +866,12 @@ static void
 tlstran_ep_accept(void *arg, nni_aio *aio)
 {
 	tlstran_ep *ep = arg;
-	int         rv;
 
-	if (nni_aio_begin(aio) != 0) {
+	nni_mtx_lock(&ep->mtx);
+	if (!nni_aio_defer(aio, tlstran_ep_cancel, ep)) {
+		nni_mtx_unlock(&ep->mtx);
 		return;
 	}
-	nni_mtx_lock(&ep->mtx);
 	if (ep->closed) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_ECLOSED);
@@ -902,11 +880,6 @@ tlstran_ep_accept(void *arg, nni_aio *aio)
 	if (ep->useraio != NULL) {
 		nni_mtx_unlock(&ep->mtx);
 		nni_aio_finish_error(aio, NNG_EBUSY);
-		return;
-	}
-	if ((rv = nni_aio_schedule(aio, tlstran_ep_cancel, ep)) != 0) {
-		nni_mtx_unlock(&ep->mtx);
-		nni_aio_finish_error(aio, rv);
 		return;
 	}
 	ep->useraio = aio;

--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -127,9 +127,6 @@ wstran_pipe_recv(void *arg, nni_aio *aio)
 {
 	ws_pipe *p = arg;
 
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_defer(aio, wstran_pipe_recv_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
@@ -160,13 +157,6 @@ wstran_pipe_send(void *arg, nni_aio *aio)
 {
 	ws_pipe *p = arg;
 
-	if (nni_aio_begin(aio) != 0) {
-		// No way to give the message back to the protocol, so
-		// we just discard it silently to prevent it from leaking.
-		nni_msg_free(nni_aio_get_msg(aio));
-		nni_aio_set_msg(aio, NULL);
-		return;
-	}
 	nni_mtx_lock(&p->mtx);
 	if (!nni_aio_defer(aio, wstran_pipe_send_cancel, p)) {
 		nni_mtx_unlock(&p->mtx);
@@ -271,9 +261,6 @@ wstran_listener_accept(void *arg, nni_aio *aio)
 	// We already bound, so we just need to look for an available
 	// pipe (created by the handler), and match it.
 	// Otherwise we stick the AIO in the accept list.
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 	nni_mtx_lock(&l->mtx);
 	if (!nni_aio_defer(aio, wstran_listener_cancel, l)) {
 		nni_mtx_unlock(&l->mtx);
@@ -305,10 +292,6 @@ static void
 wstran_dialer_connect(void *arg, nni_aio *aio)
 {
 	ws_dialer *d = arg;
-
-	if (nni_aio_begin(aio) != 0) {
-		return;
-	}
 
 	nni_mtx_lock(&d->mtx);
 	if (!nni_aio_defer(aio, wstran_dialer_cancel, d)) {

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -363,14 +363,11 @@ http_rd_cancel(nni_aio *aio, void *arg, int rv)
 static void
 http_rd_submit(nni_http_conn *conn, nni_aio *aio, enum read_flavor flavor)
 {
-	if (nni_aio_begin(aio) != 0) {
+	if (!nni_aio_defer(aio, http_rd_cancel, conn)) {
 		return;
 	}
 	if (conn->closed) {
 		nni_aio_finish_error(aio, NNG_ECLOSED);
-		return;
-	}
-	if (!nni_aio_defer(aio, http_rd_cancel, conn)) {
 		return;
 	}
 	conn->rd_flavor = flavor;
@@ -480,14 +477,11 @@ http_wr_cancel(nni_aio *aio, void *arg, int rv)
 static void
 http_wr_submit(nni_http_conn *conn, nni_aio *aio, enum write_flavor flavor)
 {
-	if (nni_aio_begin(aio) != 0) {
+	if (!nni_aio_defer(aio, http_wr_cancel, conn)) {
 		return;
 	}
 	if (conn->closed) {
 		nni_aio_finish_error(aio, NNG_ECLOSED);
-		return;
-	}
-	if (!nni_aio_defer(aio, http_wr_cancel, conn)) {
 		return;
 	}
 	conn->wr_flavor = flavor;

--- a/src/testing/streams.c
+++ b/src/testing/streams.c
@@ -95,7 +95,7 @@ stream_xfr_alloc(nng_stream *s, void (*submit)(nng_stream *, nng_aio *),
 	nng_aio_set_timeout(x->upper_aio, 30000);
 	nng_aio_set_timeout(x->lower_aio, 5000);
 
-	nng_aio_begin(x->upper_aio);
+	nng_aio_defer(x->upper_aio, NULL, NULL);
 
 	x->s      = s;
 	x->rem    = size;


### PR DESCRIPTION
This reduces the number of locking calls and reduces contention on the hot eq mutex, by implicitly doing the begin first.

Note that it is vital that nni_aio_begin *not* be called first, and that this function (or nni_aio_begin) be called before doing nni_aio_finish (any variant) to prevent nni_aio_wait returning early.

Also while here, if an operation is stopped with nni_aio_close or nni_aio_stop, it should return NNG_ECLOSED, all the time. (We might later introduce a different error for this.)

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
