### PR TITLE
ipc test: add a case for IPC that never connects

### DIFF
--- a/src/platform/posix/posix_ipc.h
+++ b/src/platform/posix/posix_ipc.h
@@ -40,6 +40,9 @@ struct nni_ipc_dialer {
 	nni_mtx           mtx;
 	nng_sockaddr      sa;
 	nni_refcnt        ref;
+#ifdef NNG_TEST_LIB
+	bool no_connect; // don't actually connect, for testing cancellation,
+#endif
 };
 
 extern int nni_posix_ipc_alloc(


### PR DESCRIPTION
This involved test-specific hacks, since connect() for UNIX domain sockets always completes synchronously one way or the other, even though it is documented that it might not.  This found a bug, with an uninitialized poll FD as well!

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
