### PR TITLE
tests: use zero port for performance test

### DIFF
--- a/src/testing/util.c
+++ b/src/testing/util.c
@@ -535,7 +535,7 @@ nuts_tran_perf(const char *scheme)
 	nuts_set_logger(NNG_LOG_NOTICE);
 	NUTS_OPEN(s1);
 	NUTS_OPEN(s2);
-	NUTS_ADDR(addr, scheme);
+	NUTS_ADDR_ZERO(addr, scheme);
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, 100));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 100));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 100));


### PR DESCRIPTION
This is another occasional test failure due to EADDRINUSE that we can avoid.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
