### PR TITLE
Add EPOLLHUP flag in nni_epoll_thr

### DIFF
--- a/src/platform/posix/posix_pollq_epoll.c
+++ b/src/platform/posix/posix_pollq_epoll.c
@@ -225,7 +225,7 @@ nni_epoll_thr(void *arg)
 
 				mask = ev->events &
 				    ((unsigned) (EPOLLIN | EPOLLOUT |
-				        EPOLLERR));
+				        EPOLLERR | EPOLLHUP));
 
 				nni_atomic_and(&pfd->events, (int) ~mask);
 


### PR DESCRIPTION
posix_pollq_epoll.c:add EPOLLHUP flag to aovid code error continues executing in tcp_cb



fixes #<issue number> <issue synopsis>

the reason of the modification refers to https://github.com/nanomsg/nng/issues/2100

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
