### PR TITLE
Stable branch: fix for clang 19 compiler warnings

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -72,7 +72,7 @@ static int                nni_aio_expire_q_cnt;
 
 static nni_reap_list aio_reap_list = {
 	.rl_offset = offsetof(nni_aio, a_reap_node),
-	.rl_func   = (nni_cb) nni_aio_free,
+	.rl_func   = nni_aio_free_cb,
 };
 
 static void nni_aio_expire_add(nni_aio *);
@@ -141,6 +141,12 @@ nni_aio_free(nni_aio *aio)
 		nni_aio_fini(aio);
 		NNI_FREE_STRUCT(aio);
 	}
+}
+
+void
+nni_aio_free_cb(void *aio)
+{
+  nni_aio_free((nni_aio *) aio);
 }
 
 void

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -146,7 +146,7 @@ nni_aio_free(nni_aio *aio)
 void
 nni_aio_free_cb(void *aio)
 {
-  nni_aio_free((nni_aio *) aio);
+	nni_aio_free((nni_aio *) aio);
 }
 
 void

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -44,6 +44,7 @@ extern int nni_aio_alloc(nni_aio **, nni_cb, void *arg);
 // This must only be called on an object that was allocated
 // with nni_aio_allocate.
 extern void nni_aio_free(nni_aio *aio);
+extern void nni_aio_free_cb(void *aio);
 
 // nni_aio_stop cancels any unfinished I/O, running completion callbacks,
 // but also prevents any new operations from starting (nni_aio_start will

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -1580,7 +1580,8 @@ http_handle_dir(nni_aio *aio)
 
 	rv = 0;
 	if (nni_file_is_dir(pn)) {
-		sprintf(dst, "%s%s", NNG_PLATFORM_DIR_SEP, "index.html");
+		snprintf(dst, pnsz - strlen(pn), "%s%s", NNG_PLATFORM_DIR_SEP,
+		    "index.html");
 		if (!nni_file_is_file(pn)) {
 			pn[strlen(pn) - 1] = '\0'; // index.html -> index.htm
 			if (!nni_file_is_file(pn)) {


### PR DESCRIPTION
Fixes #2103 [Warnings with recent compilers clang 19](https://github.com/nanomsg/nng/issues/2103)

(1) First commit just cherry-picks your fix from main.
(2) Provides a simple wrapper for `nni_aio_free()` for use in a reap list to silence UBSAN.

Note these target the stable branch. Do feel free to cherry pick the second commit back to main.

Thanks!
