### PR TITLE
Req protocol: free msg early if no retries

### DIFF
--- a/src/sp/protocol/reqrep0/req.c
+++ b/src/sp/protocol/reqrep0/req.c
@@ -359,7 +359,10 @@ req0_recv_cb(void *arg)
 	nni_id_remove(&s->requests, id);
 	ctx->request_id = 0;
 	if (ctx->req_msg != NULL) {
-		nni_msg_free(ctx->req_msg);
+	  // Only free msg if we originally cloned it (for retries)
+	  if (ctx->retry > 0) {
+	    nni_msg_free(ctx->req_msg);
+	  }
 		ctx->req_msg = NULL;
 	}
 
@@ -533,7 +536,10 @@ req0_run_send_queue(req0_sock *s, nni_aio_completions *sent_list)
 		// At this point, we will never give this message back to
 		// the user, so we don't have to worry about making it
 		// unique.  We can freely clone it.
-		nni_msg_clone(ctx->req_msg);
+		// But only do so if we need to hang onto it (for potential retries)
+		if (ctx->retry > 0) {
+		  nni_msg_clone(ctx->req_msg);
+		}
 		nni_aio_set_msg(&p->aio_send, ctx->req_msg);
 		nni_pipe_send(p->pipe, &p->aio_send);
 	}
@@ -553,7 +559,10 @@ req0_ctx_reset(req0_ctx *ctx)
 		ctx->request_id = 0;
 	}
 	if (ctx->req_msg != NULL) {
-		nni_msg_free(ctx->req_msg);
+	  // Only free msg if we originally cloned it (for retries)
+	  if (ctx->retry > 0) {
+	    nni_msg_free(ctx->req_msg);
+	  }
 		ctx->req_msg = NULL;
 	}
 	if (ctx->rep_msg != NULL) {


### PR DESCRIPTION
Fixes #2106 Req Protocol: Free Msg Early if Resends Disabled

From a previous discussion, where you were supportive of the idea: https://github.com/nanomsg/nng/discussions/1781#discussioncomment-8585336.

This PR has been tested for my intended use cases.

Targets `main`, but I'm hoping you're also fine to cherry pick the commit to `stable` / I'm happy to open another PR if you're in agreement.