### PR TITLE
Fix for clang 19 compiler warnings (main branch)

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -74,7 +74,7 @@ static int                nni_aio_expire_q_cnt;
 
 static nni_reap_list aio_reap_list = {
 	.rl_offset = offsetof(nni_aio, a_reap_node),
-	.rl_func   = (nni_cb) nni_aio_free,
+	.rl_func   = nni_aio_free_cb,
 };
 
 static void nni_aio_expire_add(nni_aio *);
@@ -144,6 +144,12 @@ nni_aio_free(nni_aio *aio)
 		nni_aio_fini(aio);
 		NNI_FREE_STRUCT(aio);
 	}
+}
+
+void
+nni_aio_free_cb(void *aio)
+{
+	nni_aio_free((nni_aio *) aio);
 }
 
 void

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -44,6 +44,7 @@ extern nng_err nni_aio_alloc(nni_aio **, nni_cb, void *arg);
 // This must only be called on an object that was allocated
 // with nni_aio_allocate.
 extern void nni_aio_free(nni_aio *aio);
+extern void nni_aio_free_cb(void *aio);
 
 // nni_aio_stop cancels any unfinished I/O, running completion callbacks,
 // but also prevents any new operations from starting (nni_aio_start will


### PR DESCRIPTION
This just ports #2104 to the main branch for NNG v2.

The commit is identical to [768bcf0](https://github.com/nanomsg/nng/pull/2104/commits/768bcf0a6f6fa065b12b70314e2980a452197e24) (but correctly-formatted for indentation).