### PR TITLE
* FIX [HTTP] fix a blocking case when freeing http client

### DIFF
--- a/src/supplemental/http/http_client.c
+++ b/src/supplemental/http/http_client.c
@@ -168,12 +168,10 @@ http_dial_cancel(nni_aio *aio, void *arg, int rv)
 {
 	nni_http_client *c = arg;
 	nni_mtx_lock(&c->mtx);
+	nni_aio_abort(c->aio, rv);
 	if (nni_aio_list_active(aio)) {
 		nni_aio_list_remove(aio);
 		nni_aio_finish_error(aio, rv);
-	}
-	if (nni_list_empty(&c->aios)) {
-		nni_aio_abort(c->aio, rv);
 	}
 	nni_mtx_unlock(&c->mtx);
 }


### PR DESCRIPTION
This is a bug I found in the past 2 days. Easily reproduce with low number of taskq_threads and set small timeout duration to http connect aio.
basically when aio timeout before the connaio of dialer, and users try to free the http_client obj will end in infinite blocking at `nni_http_client_fini`. Possibly at `nni_aio_free(c->aio);` or `nng_stream_dialer_free(c->dialer);` Both racing case is due to the ingnored aio aborting here. Because the aio_begin is called before it is put into the nni_list. I assume you shall abort it no matter if it is in the dialing list.
