### PR TITLE
fixes #2148 Old id_reg_map seems not be freed

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2021 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitoar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -67,7 +67,7 @@ typedef int32_t  nni_duration; // Rel. time (ms).
 typedef void (*nni_cb)(void *);
 
 // Some default timing things.
-#define NNI_TIME_NEVER ((nni_time) -1)
+#define NNI_TIME_NEVER ((nni_time) - 1)
 #define NNI_TIME_ZERO ((nni_time) 0)
 #define NNI_SECOND (1000)
 
@@ -238,5 +238,24 @@ typedef nni_type nni_opt_type;
 #error "Unknown endian: specify -DNNG_BIG_ENDIAN=1 or -DNNG_LITTLE_ENDIAN=1"
 #endif // defined(__BYTE_ORDER)
 #endif // defined() endianness
+
+// nni_alloc allocates memory.  In most cases this can just be malloc().
+// However, you may provide a different allocator, for example it is
+// possible to use a slab allocator or somesuch.  It is permissible for this
+// to return NULL if memory cannot be allocated.
+extern void *nni_alloc(size_t);
+
+// nni_zalloc is just like nni_alloc, but ensures that memory is
+// initialized to zero.  It is a separate function because some platforms
+// can use a more efficient zero-based allocation.
+extern void *nni_zalloc(size_t);
+
+// nni_free frees memory allocated with nni_alloc or nni_zalloc. It takes
+// a size because some allocators do not track size, or can operate more
+// efficiently if the size is provided with the free call.  Examples of this
+// are slab allocators like this found in Solaris/illumos (see libumem).
+// This routine does nothing if supplied with a NULL pointer and zero size.
+// Most implementations can just call free() here.
+extern void nni_free(void *, size_t);
 
 #endif // CORE_DEFS_H

--- a/src/core/dialer.c
+++ b/src/core/dialer.c
@@ -22,7 +22,7 @@ static void dialer_connect_start(nni_dialer *);
 static void dialer_connect_cb(void *);
 static void dialer_timer_cb(void *);
 
-static nni_id_map dialers    = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, 0);
+static nni_id_map dialers    = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, false);
 static nni_mtx    dialers_lk = NNI_MTX_INITIALIZER;
 
 uint32_t

--- a/src/core/idhash.h
+++ b/src/core/idhash.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -11,7 +11,7 @@
 #ifndef CORE_IDHASH_H
 #define CORE_IDHASH_H
 
-#include "core/defs.h"
+#include "defs.h"
 
 // We find that we often want to have a list of things listed by a
 // numeric ID, which is generally monotonically increasing.  This is
@@ -30,12 +30,14 @@ typedef struct nni_id_entry nni_id_entry;
 // They are provided here to facilitate inlining in structures.
 // We can support at most 2^32 ~ 4 billion ~ entries.
 struct nni_id_map {
-	uint32_t      id_flags;
 	uint32_t      id_cap;
 	uint32_t      id_count;
 	uint32_t      id_load;
 	uint32_t      id_min_load; // considers placeholders
 	uint32_t      id_max_load;
+	bool          id_static;
+	bool          id_registered;
+	bool          id_random;
 	uint64_t      id_min_val;
 	uint64_t      id_max_val;
 	uint64_t      id_dyn_val;
@@ -57,10 +59,13 @@ extern void     nni_id_map_sys_fini(void);
 extern bool     nni_id_visit(nni_id_map *, uint64_t *, void **, uint32_t *);
 extern uint32_t nni_id_count(const nni_id_map *);
 
-#define NNI_ID_MAP_INITIALIZER(min, max, flags)            \
-	{                                                  \
-		.id_min_val = (min), .id_max_val = (max),  \
-		.id_flags = ((flags) | NNI_ID_FLAG_STATIC) \
+#define NNI_ID_MAP_INITIALIZER(min, max, random) \
+	{                                        \
+		.id_min_val    = (min),          \
+		.id_max_val    = (max),          \
+		.id_static     = true,           \
+		.id_registered = false,          \
+		.id_random     = random,         \
 	}
 
 #endif // CORE_IDHASH_H

--- a/src/core/listener.c
+++ b/src/core/listener.c
@@ -24,7 +24,7 @@ static void listener_accept_start(nni_listener *);
 static void listener_accept_cb(void *);
 static void listener_timer_cb(void *);
 
-static nni_id_map listeners    = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, 0);
+static nni_id_map listeners    = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, false);
 static nni_mtx    listeners_lk = NNI_MTX_INITIALIZER;
 
 uint32_t

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -9,8 +9,8 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "core/nng_impl.h"
 #include "nng/nng.h"
+#include "nng_impl.h"
 #include "sockimpl.h"
 
 #include <stdio.h>
@@ -20,9 +20,8 @@
 // Operations on pipes (to the transport) are generally blocking operations,
 // performed in the context of the protocol.
 
-static nni_id_map pipes =
-    NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, NNI_ID_FLAG_RANDOM);
-static nni_mtx pipes_lk = NNI_MTX_INITIALIZER;
+static nni_id_map pipes    = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, true);
+static nni_mtx    pipes_lk = NNI_MTX_INITIALIZER;
 
 static void pipe_destroy(void *);
 static void pipe_reap(void *);

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -123,8 +123,8 @@ struct nni_socket {
 
 static nni_list sock_list  = NNI_LIST_INITIALIZER(sock_list, nni_sock, s_node);
 static nni_mtx  sock_lk    = NNI_MTX_INITIALIZER;
-static nni_id_map sock_ids = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, 0);
-static nni_id_map ctx_ids  = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, 0);
+static nni_id_map sock_ids = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, false);
+static nni_id_map ctx_ids  = NNI_ID_MAP_INITIALIZER(1, 0x7fffffff, false);
 
 static void nni_ctx_destroy(nni_ctx *);
 


### PR DESCRIPTION
This simplifies the code to just use a precompiled static list. This should be lighter weight, and provably free from leaks.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
