### PR TITLE
remaps EAI_AGAIN to NNG_EADDRINVAL

### DIFF
--- a/src/platform/posix/posix_resolv_gai.c
+++ b/src/platform/posix/posix_resolv_gai.c
@@ -117,7 +117,13 @@ posix_gai_errno(int rv)
 
 #ifdef EAI_AGAIN
 	case EAI_AGAIN:
-		return (NNG_EAGAIN);
+		// EAE_AGAIN means a temporary failure in name resolution.
+		// While that doesn't mean the address is invalid, it's the
+		// closest error code we currently have. This was previously
+		// mapped to NNG_EAGAIN, but that error code is used to
+		// indicate that non-blocking operations would block, so would
+		// be confusing to callers.
+		return (NNG_EADDRINVAL);
 #endif
 
 	default:


### PR DESCRIPTION
When running nng tests in CI under nix on Linux, I would see `nng_dialer_start` fail with `NNG_EAGAIN` when invoked with `flags = 0` and a URL of `tcp://999.888.777.666:8080` (this is in a test that is supposed to check that dialing that gives you `NNG_EINVAL` or `NNG_EADDRINVAL`).

This can happen if `nni_resolv_ip` in `posix_resolv_gai.c` gets `EAI_AGAIN` from `getaddrinfo`, which the man pages suggest _can_ happen due to "a temporary failure in name resolution". In the nix case, this is due to the nix build sandbox, but it can also arise simply due to DNS overload or misconfiguration.

In either case, nng should not bubble up `EAI_AGAIN` `as `NNG_EAGAIN` from `nng_dialer_start`, as `NNG_EAGAIN` has a different semantic meaning. `NNG_EAGAIN` is more equivalent to "would block", and should only be generated through calls with the `NONBLOCK` flag. We don't have a perfect mapping for `EAI_AGAIN`, but the closest is probably `NNG_ADDRINVAL` to indicate that we failed to resolve the given address (even if it's temporary). Another option would be to introduce another error variant like `NNG_ENAMELOOKUP`, but that felt excessive to cover this case.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
