### PR TITLE
fixes #2165 nng_http_handler_alloc_static crashes if content type is …

### DIFF
--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -1571,6 +1571,9 @@ nni_http_handler_init_static(nni_http_handler **hpp, const char *uri,
 	if ((hs = NNI_ALLOC_STRUCT(hs)) == NULL) {
 		return (NNG_ENOMEM);
 	}
+	if (ctype == NULL) {
+		ctype = "application/octet-stream";
+	}
 	if (((hs->ctype = nni_strdup(ctype)) == NULL) ||
 	    ((size > 0) && ((hs->data = nni_alloc(size)) == NULL))) {
 		http_static_free(hs);


### PR DESCRIPTION
…null

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
