### PR TITLE
fixes #2158 Implement support for NNG_OPT_TLS_PEER_CN for WolfSSL

### DIFF
--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -73,7 +73,7 @@ extern "C" {
 // NNG_PROTOCOL_NUMBER is used by protocol headers to calculate their
 // protocol number from a major and minor number.  Applications should
 // probably not need to use this.
-#define NNG_PROTOCOL_NUMBER(maj, min) (((x) *16) + (y))
+#define NNG_PROTOCOL_NUMBER(maj, min) (((x) * 16) + (y))
 
 // Types common to nng.
 

--- a/src/sp/transport/tls/tls_tran_test.c
+++ b/src/sp/transport/tls/tls_tran_test.c
@@ -187,6 +187,60 @@ test_tls_cert_mutual(void)
 }
 
 void
+test_tls_pipe_details(void)
+{
+	nng_socket      s1;
+	nng_socket      s2;
+	nng_tls_config *c1, *c2;
+	nng_sockaddr    sa;
+	nng_listener    l;
+	nng_dialer      d;
+	nng_msg        *msg;
+	nng_pipe        p;
+	const nng_url  *url;
+
+	c1 = tls_server_config_ecdsa();
+	c2 = tls_client_config_ecdsa();
+
+	NUTS_ENABLE_LOG(NNG_LOG_DEBUG);
+	NUTS_OPEN(s1);
+	NUTS_OPEN(s2);
+	NUTS_PASS(nng_tls_config_auth_mode(c1, NNG_TLS_AUTH_MODE_REQUIRED));
+	NUTS_PASS(nng_tls_config_ca_chain(c1, nuts_ecdsa_server_crt, NULL));
+	NUTS_PASS(nng_tls_config_ca_chain(c2, nuts_ecdsa_server_crt, NULL));
+	NUTS_PASS(nng_listener_create(&l, s1, "tls+tcp://127.0.0.1:0"));
+	NUTS_PASS(nng_listener_set_tls(l, c1));
+	NUTS_PASS(nng_listener_start(l, 0));
+	NUTS_PASS(nng_listener_get_url(l, &url));
+	NUTS_MATCH(nng_url_scheme(url), "tls+tcp");
+	NUTS_PASS(nng_listener_get_addr(l, NNG_OPT_LOCADDR, &sa));
+	NUTS_TRUE(sa.s_in.sa_family == NNG_AF_INET);
+	NUTS_TRUE(sa.s_in.sa_port != 0);
+	NUTS_TRUE(sa.s_in.sa_addr = nuts_be32(0x7f000001));
+	NUTS_PASS(nng_dialer_create_url(&d, s2, url));
+	NUTS_PASS(nng_dialer_set_tls(d, c2));
+	NUTS_PASS(nng_dialer_start(d, 0));
+	nng_msleep(50);
+	NUTS_SEND(s1, "text");
+	NUTS_PASS(nng_recvmsg(s2, &msg, 0));
+	p = nng_msg_get_pipe(msg);
+	NUTS_TRUE(nng_pipe_id(p) >= 0);
+#if !defined(NNG_TLS_ENGINE_WOLFSSL) || defined(NNG_WOLFSSL_HAVE_PEER_CERT)
+	char  *cn;
+	char **alts;
+	NUTS_PASS(nng_pipe_get_string(p, NNG_OPT_TLS_PEER_CN, &cn));
+	NUTS_ASSERT(cn != NULL);
+	NUTS_MATCH(cn, "127.0.0.1");
+	nng_strfree(cn);
+#endif
+	nng_msg_free(msg);
+	NUTS_CLOSE(s2);
+	NUTS_CLOSE(s1);
+	nng_tls_config_free(c1);
+	nng_tls_config_free(c2);
+}
+
+void
 test_tls_malformed_address(void)
 {
 	nng_socket s1;
@@ -392,6 +446,7 @@ NUTS_TESTS = {
 	{ "tls no delay option", test_tls_no_delay_option },
 	{ "tls keep alive option", test_tls_keep_alive_option },
 	{ "tls recv max", test_tls_recv_max },
+	{ "tls pipe details", test_tls_pipe_details },
 	{ "tls pre-shared key", test_tls_psk },
 	{ "tls bad cert mutual", test_tls_bad_cert_mutual },
 	{ "tls cert mutual", test_tls_cert_mutual },


### PR DESCRIPTION
This also provides an implementation for getting ALT names, although nothing uses that yet.  We plan to provide a new certificate API to replace these with a nicer API, as obtaining the full list of certs may be unreasonable.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
