### PR TITLE
fixes #2173 New TLS cert API - replaces the properties for CN and ALT…

### DIFF
--- a/docs/man/nng_tls.7.adoc
+++ b/docs/man/nng_tls.7.adoc
@@ -107,7 +107,6 @@ Note that setting these must be done before the transport is started.
 * xref:nng_tcp_options.5.adoc#NNG_OPT_TCP_NODELAY[`NNG_OPT_TCP_NODELAY`]
 * xref:nng_tls_options.5.adoc#NNG_OPT_TLS_VERIFIED[`NNG_OPT_TLS_VERIFIED_`]
 * xref:nng_tls_options.5.adoc#NNG_OPT_TLS_PEER_CN[`NNG_OPT_TLS_PEER_CN`]
-* xref:nng_tls_options.5.adoc#NNG_OPT_TLS_PEER_ALT_NAMES[`NNG_OPT_TLS_PEER_ALT_NAMES`]
 * xref:nng_options.5.adoc#NNG_OPT_URL[`NNG_OPT_URL`]
 
 == SEE ALSO

--- a/docs/man/nng_tls_options.5.adoc
+++ b/docs/man/nng_tls_options.5.adoc
@@ -22,7 +22,6 @@ nng_tls_options - TLS-specific options
 
 #define NNG_OPT_TLS_VERIFIED       "tls-verified"
 #define NNG_OPT_TLS_PEER_CN        "tls-peer-cn"
-#define NNG_OPT_TLS_PEER_ALT_NAMES "tls-peer-alt-names"
 ----
 
 == DESCRIPTION
@@ -65,11 +64,6 @@ May return incorrect results if peer authentication is disabled.
 (string)
 This read-only option returns the common name of the peer certificate.
 May return incorrect results if peer authentication is disabled.
-
-[[NNG_OPT_TLS_PEER_ALT_NAMES]]((`NNG_OPT_TLS_PEER_ALT_NAMES`))::
-(string)
-This read-only option returns string list with the subject alternative names of the
-peer certificate. May return incorrect results if peer authentication is disabled.
 
 === Inherited Options
 

--- a/docs/man/nng_ws.7.adoc
+++ b/docs/man/nng_ws.7.adoc
@@ -159,11 +159,6 @@ May return incorrect results if peer authentication is disabled.
 (string) This read-only option returns the common name of the peer certificate.
 May return incorrect results if peer authentication is disabled.
 
-`NNG_OPT_TLS_PEER_ALT_NAMES`::
-(string list) returns string list with the subject alternative names of the
-peer certificate. May return incorrect results if peer authentication
-is disabled.
-
 // We should also look at a hook mechanism for listeners. Probably this could
 // look like NNG_OPT_WS_LISTEN_HOOK_FUNC which would take a function pointer
 // along the lines of int hook(void *, char *req_headers, char **res_headers),

--- a/docs/ref/api/http.md
+++ b/docs/ref/api/http.md
@@ -349,6 +349,26 @@ This function is most useful when called from a handler function.
 > This function is intended to facilitate uses cases that involve changing the protocol from HTTP, such as WebSocket.
 > Most applications will never need to use this function.
 
+### Obtaining TLS Connection Details
+
+```c
+nng_err nng_http_peer_cert(nng_http_conn *conn, nng_tls_cert **certp);
+```
+
+TODO: We need to document the cert API.
+
+The {{i:`nng_http_peer_cert`}} function will obtain the TLS certificate object for the peer, if one is available.
+This can then be used for additional authentication or identity specific logic.
+
+The certificate must be released with [`nng_tls_cert_free`] when no longer in use.
+See [`nng_tls_cert`] for more information about working with TLS certificates.
+
+> [!NOTE]
+> While it should be obvious that this function is only available when using HTTPS,
+> it also requires that peer authentication is in use, and may require that the underlying
+> TLS engine support peer certificate colleciton. (Some minimal configurations elide this
+> to save space in embedded environments.)
+
 ## Client API
 
 The NNG client API consists of an API for creating connections, and an API for performing

--- a/docs/ref/migrate/nng1.md
+++ b/docs/ref/migrate/nng1.md
@@ -156,6 +156,15 @@ The ability to configure multiple keys and certificates for a given TLS configur
 The intended purpose was to support alternative cryptographic algorithms, but this is not necessary, was never
 used, and was error prone.
 
+## TLS Peer Certificate APIs Replaced
+
+The `NNG_OPT_TLS_PEER_CN` and `NNG_OPT_TLS_PEER_ALT_NAMES` properties have been removed.
+They are replaced with functions like [`nng_pipe_peer_cert`], [`nng_stream_peer_cert`],
+and [`nng_http_peer_cert`] which return a new `nng_tls_cert` object.
+
+This object supports methods to get additional information about the certificate, as well
+as to obtain the raw DER content so that it can be imported for use in other APIs.
+
 ## Support for Local Addresses in Dial URLs Removed
 
 NNG 1.x had an undocumented ability to specify the local address to bind

--- a/include/nng/http.h
+++ b/include/nng/http.h
@@ -207,6 +207,10 @@ NNG_DECL void nng_http_set_body(nng_http *, void *, size_t);
 // makes a local copy.  It can fail due to NNG_ENOMEM.
 NNG_DECL nng_err nng_http_copy_body(nng_http *, const void *, size_t);
 
+// nng_http_peer_cert returns the HTTP peer cert, if the one is available.
+// Only available for HTTPS connections.
+NNG_DECL nng_err nng_http_peer_cert(nng_http *, nng_tls_cert **);
+
 // nng_http_handler is a handler used on the server side to handle HTTP
 // requests coming into a specific URL.
 //

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -14,7 +14,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <nng/nng.h>
+#include "nng/nng.h"
 
 // C compilers may get unhappy when named arguments are not used.  While
 // there are things like __attribute__((unused)) which are arguably

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -430,3 +430,12 @@ nni_pipe_peer_addr(nni_pipe *p, char buf[NNG_MAXADDRSTRLEN])
 	nng_str_sockaddr(&sa, buf, NNG_MAXADDRSTRLEN);
 	return (buf);
 }
+
+nng_err
+nni_pipe_peer_cert(nni_pipe *p, nng_tls_cert **certp)
+{
+	if (p->p_tran_ops.p_peer_cert == NULL) {
+		return (NNG_ENOTSUP);
+	}
+	return (p->p_tran_ops.p_peer_cert(p->p_tran_data, certp));
+}

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -39,6 +39,9 @@ extern uint16_t nni_pipe_peer(nni_pipe *);
 extern nng_err nni_pipe_getopt(
     nni_pipe *, const char *, void *, size_t *, nni_opt_type);
 
+// nni_pipe_peer_cert obtains the peer TLS certificate, if available.
+extern nng_err nni_pipe_peer_cert(nni_pipe *, nng_tls_cert **);
+
 // nni_pipe_find finds a pipe given its ID.  It places a hold on the
 // pipe, which must be released by the caller when it is done.
 extern nng_err nni_pipe_find(nni_pipe **, uint32_t);

--- a/src/core/sockfd.h
+++ b/src/core/sockfd.h
@@ -10,7 +10,7 @@
 #ifndef CORE_FDC_H
 #define CORE_FDC_H
 
-#include "core/nng_impl.h"
+#include "nng/nng.h"
 
 // the nni_sfd_conn struct is provided by platform code to wrap
 // an arbitrary byte stream file descriptor (UNIX) or handle (Windows)

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -12,12 +12,13 @@
 
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "nng_impl.h"
 
-#include "core/sockfd.h"
-#include "core/tcp.h"
-#include "supplemental/tls/tls_api.h"
-#include "supplemental/websocket/websocket.h"
+#include "sockfd.h"
+#include "tcp.h"
+
+#include "../supplemental/tls/tls_api.h"
+#include "../supplemental/websocket/websocket.h"
 
 static struct {
 	const char *scheme;
@@ -382,6 +383,15 @@ nng_err
 nng_stream_get_addr(nng_stream *s, const char *n, nng_sockaddr *v)
 {
 	return (nni_stream_get(s, n, v, NULL, NNI_TYPE_SOCKADDR));
+}
+
+nng_err
+nng_stream_peer_cert(nng_stream *s, nng_tls_cert **certp)
+{
+	if (s->s_peer_cert == NULL) {
+		return (NNG_ENOTSUP);
+	}
+	return (s->s_peer_cert(s, certp));
 }
 
 nng_err

--- a/src/core/stream.h
+++ b/src/core/stream.h
@@ -50,6 +50,7 @@ struct nng_stream {
 	void (*s_send)(void *, nng_aio *);
 	nng_err (*s_get)(void *, const char *, void *, size_t *, nni_type);
 	nng_err (*s_set)(void *, const char *, const void *, size_t, nni_type);
+	nng_err (*s_peer_cert)(void *, nng_tls_cert **);
 };
 
 // Dialer implementation.  Stream dialers create streams.

--- a/src/core/tcp.h
+++ b/src/core/tcp.h
@@ -10,7 +10,7 @@
 #ifndef CORE_TCP_H
 #define CORE_TCP_H
 
-#include "core/nng_impl.h"
+#include "nng/nng.h"
 
 // These are interfaces we use for TCP internally.  These are not exposed
 // to the public API.

--- a/src/nng.c
+++ b/src/nng.c
@@ -670,7 +670,7 @@ void
 nng_dialer_start_aio(nng_dialer did, int flags, nng_aio *aio)
 {
 	nni_dialer *d;
-	int       rv;
+	int         rv;
 
 	if (aio != NULL) {
 		nni_aio_reset(aio);
@@ -1373,6 +1373,20 @@ nng_err
 nng_pipe_get_addr(nng_pipe id, const char *n, nng_sockaddr *v)
 {
 	return (pipe_get(id, n, v, NULL, NNI_TYPE_SOCKADDR));
+}
+
+nng_err
+nng_pipe_peer_cert(nng_pipe p, nng_tls_cert **certp)
+{
+	nng_err   rv;
+	nni_pipe *pipe;
+
+	if ((rv = nni_pipe_find(&pipe, p.id)) != 0) {
+		return (rv);
+	}
+	rv = nni_pipe_peer_cert(pipe, certp);
+	nni_pipe_rele(pipe);
+	return (rv);
 }
 
 nng_socket

--- a/src/sp/transport.h
+++ b/src/sp/transport.h
@@ -188,6 +188,10 @@ struct nni_sp_pipe_ops {
 	// p_getopt is used to obtain an option.  Pipes don't implement
 	// option setting.
 	nng_err (*p_getopt)(void *, const char *, void *, size_t *, nni_type);
+
+	// p_peer_cert is used to obtain a peer cert for transports that
+	// implement TLS.
+	nng_err (*p_peer_cert)(void *, nng_tls_cert **);
 };
 
 // Transport implementation details.  Transports must implement the

--- a/src/sp/transport/dtls/dtls.c
+++ b/src/sp/transport/dtls/dtls.c
@@ -6,18 +6,18 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "core/aio.h"
-#include "core/defs.h"
-#include "core/idhash.h"
-#include "core/message.h"
-#include "core/nng_impl.h"
-#include "core/options.h"
-#include "core/pipe.h"
-#include "core/platform.h"
-#include "core/socket.h"
-#include "core/stats.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/message.h"
+#include "../../../core/nng_impl.h"
+#include "../../../core/options.h"
+#include "../../../core/pipe.h"
+#include "../../../core/platform.h"
+#include "../../../core/socket.h"
+#include "../../../core/stats.h"
+#include "../../../supplemental/tls/tls_common.h"
 #include "nng/nng.h"
-#include "supplemental/tls/tls_common.h"
 
 #include <string.h>
 
@@ -1070,6 +1070,14 @@ dtls_pipe_getopt(
 	return (nni_getopt(dtls_pipe_options, name, p, buf, szp, t));
 }
 
+static nng_err
+dtls_pipe_peer_cert(void *arg, nng_tls_cert **certp)
+{
+	dtls_pipe *p = arg;
+
+	return (nni_tls_peer_cert(&p->tls, certp));
+}
+
 static void
 dtls_ep_fini(void *arg)
 {
@@ -1676,15 +1684,16 @@ dtls_ep_accept(void *arg, nni_aio *aio)
 }
 
 static nni_sp_pipe_ops dtls_pipe_ops = {
-	.p_size   = dtls_pipe_size,
-	.p_init   = dtls_pipe_init,
-	.p_fini   = dtls_pipe_fini,
-	.p_stop   = dtls_pipe_stop,
-	.p_send   = dtls_pipe_send,
-	.p_recv   = dtls_pipe_recv,
-	.p_close  = dtls_pipe_close,
-	.p_peer   = dtls_pipe_peer,
-	.p_getopt = dtls_pipe_getopt,
+	.p_size      = dtls_pipe_size,
+	.p_init      = dtls_pipe_init,
+	.p_fini      = dtls_pipe_fini,
+	.p_stop      = dtls_pipe_stop,
+	.p_send      = dtls_pipe_send,
+	.p_recv      = dtls_pipe_recv,
+	.p_close     = dtls_pipe_close,
+	.p_peer      = dtls_pipe_peer,
+	.p_getopt    = dtls_pipe_getopt,
+	.p_peer_cert = dtls_pipe_peer_cert,
 };
 
 static const nni_option dtls_ep_opts[] = {

--- a/src/sp/transport/tcp/tcp.c
+++ b/src/sp/transport/tcp/tcp.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/nng_impl.h"
 #include "nng/nng.h"
 
 // TCP transport.   Platform specific TCP operations must be

--- a/src/sp/transport/tcp/tcp_test.c
+++ b/src/sp/transport/tcp/tcp_test.c
@@ -11,7 +11,8 @@
 //
 
 #include "nng/nng.h"
-#include <nuts.h>
+
+#include "../../../testing/nuts.h"
 
 // TCP tests.
 
@@ -231,6 +232,9 @@ check_props_v4(nng_msg *msg)
 
 	NUTS_PASS(nng_pipe_get_bool(p, NNG_OPT_TCP_NODELAY, &b));
 	NUTS_TRUE(b); // default
+
+	nng_tls_cert *cert;
+	NUTS_FAIL(nng_pipe_peer_cert(p, &cert), NNG_ENOTSUP);
 }
 
 void

--- a/src/sp/transport/tls/tls.c
+++ b/src/sp/transport/tls/tls.c
@@ -952,6 +952,14 @@ tlstran_pipe_getopt(
 	return (rv);
 }
 
+static nng_err
+tlstran_pipe_peer_cert(void *arg, nng_tls_cert **certp)
+{
+	tlstran_pipe *p = arg;
+
+	return (nng_stream_peer_cert(p->tls, certp));
+}
+
 static size_t
 tlstran_pipe_size(void)
 {
@@ -959,15 +967,16 @@ tlstran_pipe_size(void)
 }
 
 static nni_sp_pipe_ops tlstran_pipe_ops = {
-	.p_size   = tlstran_pipe_size,
-	.p_init   = tlstran_pipe_init,
-	.p_fini   = tlstran_pipe_fini,
-	.p_stop   = tlstran_pipe_stop,
-	.p_send   = tlstran_pipe_send,
-	.p_recv   = tlstran_pipe_recv,
-	.p_close  = tlstran_pipe_close,
-	.p_peer   = tlstran_pipe_peer,
-	.p_getopt = tlstran_pipe_getopt,
+	.p_size      = tlstran_pipe_size,
+	.p_init      = tlstran_pipe_init,
+	.p_fini      = tlstran_pipe_fini,
+	.p_stop      = tlstran_pipe_stop,
+	.p_send      = tlstran_pipe_send,
+	.p_recv      = tlstran_pipe_recv,
+	.p_close     = tlstran_pipe_close,
+	.p_peer      = tlstran_pipe_peer,
+	.p_getopt    = tlstran_pipe_getopt,
+	.p_peer_cert = tlstran_pipe_peer_cert,
 };
 
 static nni_option tlstran_ep_options[] = {

--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -13,8 +13,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "core/nng_impl.h"
-#include "supplemental/websocket/websocket.h"
+#include "../../../core/nng_impl.h"
+#include "../../../supplemental/websocket/websocket.h"
+#include "nng/nng.h"
 
 typedef struct ws_dialer   ws_dialer;
 typedef struct ws_listener ws_listener;
@@ -328,6 +329,14 @@ wstran_pipe_getopt(
 	return (rv);
 }
 
+static nng_err
+wstran_pipe_peer_cert(void *arg, nng_tls_cert **certp)
+{
+	ws_pipe *p = arg;
+
+	return (nng_stream_peer_cert(p->ws, certp));
+}
+
 static size_t
 wstran_pipe_size(void)
 {
@@ -335,15 +344,16 @@ wstran_pipe_size(void)
 }
 
 static nni_sp_pipe_ops ws_pipe_ops = {
-	.p_size   = wstran_pipe_size,
-	.p_init   = wstran_pipe_init,
-	.p_fini   = wstran_pipe_fini,
-	.p_stop   = wstran_pipe_stop,
-	.p_send   = wstran_pipe_send,
-	.p_recv   = wstran_pipe_recv,
-	.p_close  = wstran_pipe_close,
-	.p_peer   = wstran_pipe_peer,
-	.p_getopt = wstran_pipe_getopt,
+	.p_size      = wstran_pipe_size,
+	.p_init      = wstran_pipe_init,
+	.p_fini      = wstran_pipe_fini,
+	.p_stop      = wstran_pipe_stop,
+	.p_send      = wstran_pipe_send,
+	.p_recv      = wstran_pipe_recv,
+	.p_close     = wstran_pipe_close,
+	.p_peer      = wstran_pipe_peer,
+	.p_getopt    = wstran_pipe_getopt,
+	.p_peer_cert = wstran_pipe_peer_cert,
 };
 
 static void

--- a/src/sp/transport/ws/wss_test.c
+++ b/src/sp/transport/ws/wss_test.c
@@ -14,7 +14,7 @@
 
 #include <nng/nng.h>
 
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 static nng_tls_config *
 wss_server_config(void)
@@ -381,6 +381,79 @@ test_wss_psk(void)
 #endif
 }
 
+void
+test_wss_pipe_details(void)
+{
+	nng_socket      s1;
+	nng_socket      s2;
+	nng_tls_config *c1, *c2;
+	nng_sockaddr    sa;
+	nng_listener    l;
+	nng_dialer      d;
+	nng_msg        *msg;
+	nng_pipe        p;
+	const nng_url  *url;
+
+	c1 = wss_server_config_ecdsa();
+	c2 = wss_client_config_ecdsa();
+
+	NUTS_ENABLE_LOG(NNG_LOG_DEBUG);
+	NUTS_OPEN(s1);
+	NUTS_OPEN(s2);
+	NUTS_PASS(nng_tls_config_auth_mode(c1, NNG_TLS_AUTH_MODE_REQUIRED));
+	NUTS_PASS(nng_tls_config_ca_chain(c1, nuts_ecdsa_server_crt, NULL));
+	NUTS_PASS(nng_tls_config_ca_chain(c2, nuts_ecdsa_server_crt, NULL));
+	NUTS_PASS(nng_listener_create(&l, s1, "wss://127.0.0.1:0/test"));
+	NUTS_PASS(nng_listener_set_tls(l, c1));
+	NUTS_PASS(nng_listener_start(l, 0));
+	NUTS_PASS(nng_listener_get_url(l, &url));
+	NUTS_MATCH(nng_url_scheme(url), "wss");
+	NUTS_PASS(nng_listener_get_addr(l, NNG_OPT_LOCADDR, &sa));
+	NUTS_TRUE(sa.s_in.sa_family == NNG_AF_INET);
+	NUTS_TRUE(sa.s_in.sa_port != 0);
+	NUTS_TRUE(sa.s_in.sa_addr = nuts_be32(0x7f000001));
+	NUTS_PASS(nng_dialer_create_url(&d, s2, url));
+	NUTS_PASS(nng_dialer_set_tls(d, c2));
+	NUTS_PASS(nng_dialer_start(d, 0));
+	nng_msleep(50);
+	NUTS_SEND(s1, "text");
+	NUTS_PASS(nng_recvmsg(s2, &msg, 0));
+	p = nng_msg_get_pipe(msg);
+	NUTS_TRUE(nng_pipe_id(p) >= 0);
+#if !defined(NNG_TLS_ENGINE_WOLFSSL) || defined(NNG_WOLFSSL_HAVE_PEER_CERT)
+	nng_tls_cert *cert;
+	char         *name;
+	NUTS_PASS(nng_pipe_peer_cert(p, &cert));
+	NUTS_PASS(nng_tls_cert_subject(cert, &name));
+	NUTS_ASSERT(name != NULL);
+	nng_log_debug(NULL, "SUBJECT: %s", name);
+	NUTS_PASS(nng_tls_cert_issuer(cert, &name));
+	NUTS_ASSERT(name != NULL);
+	nng_log_debug(NULL, "ISSUER: %s", name);
+	NUTS_PASS(nng_tls_cert_serial_number(cert, &name));
+	NUTS_ASSERT(name != NULL);
+	nng_log_debug(NULL, "SERIAL: %s", name);
+	NUTS_PASS(nng_tls_cert_subject_cn(cert, &name));
+	NUTS_MATCH(name, "127.0.0.1");
+	NUTS_PASS(nng_tls_cert_next_alt(cert, &name));
+	nng_log_debug(NULL, "FIRST ALT: %s", name);
+	NUTS_MATCH(name, "localhost");
+	NUTS_FAIL(nng_tls_cert_next_alt(cert, &name), NNG_ENOENT);
+	struct tm when;
+	NUTS_PASS(nng_tls_cert_not_before(cert, &when));
+	nng_log_debug(NULL, "BEGINS: %s", asctime(&when));
+	NUTS_PASS(nng_tls_cert_not_after(cert, &when));
+	nng_log_debug(NULL, "EXPIRES: %s", asctime(&when));
+
+	nng_tls_cert_free(cert);
+#endif
+	nng_msg_free(msg);
+	NUTS_CLOSE(s2);
+	NUTS_CLOSE(s1);
+	nng_tls_config_free(c1);
+	nng_tls_config_free(c2);
+}
+
 NUTS_TESTS = {
 	{ "wss port zero bind", test_wss_port_zero_bind },
 	{ "wss malformed address", test_wss_malformed_address },
@@ -390,6 +463,7 @@ NUTS_TESTS = {
 	{ "wss pre-shared key", test_wss_psk },
 	{ "wss bad cert mutual", test_wss_bad_cert_mutual },
 	{ "wss cert mutual", test_wss_cert_mutual },
+	{ "wss pipe details", test_wss_pipe_details },
 
 	{ NULL, NULL },
 };

--- a/src/supplemental/http/http_api.h
+++ b/src/supplemental/http/http_api.h
@@ -99,6 +99,7 @@ extern void nni_http_conn_close(nng_http *);
 extern void nni_http_conn_fini(nni_http_conn *);
 extern int  nni_http_conn_getopt(
      nng_http *, const char *, void *, size_t *, nni_type);
+extern nng_err nni_http_conn_peer_cert(nng_http *, nng_tls_cert **);
 
 // Reading messages -- the caller must supply a preinitialized (but otherwise
 // idle) message.  We recommend the caller store this in the aio's user data.

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -1482,6 +1482,20 @@ nni_http_conn_getopt(
 	return (rv);
 }
 
+nng_err
+nni_http_conn_peer_cert(nni_http_conn *conn, nng_tls_cert **certp)
+{
+	int rv;
+	nni_mtx_lock(&conn->mtx);
+	if (conn->closed) {
+		rv = NNG_ECLOSED;
+	} else {
+		rv = nng_stream_peer_cert(conn->sock, certp);
+	}
+	nni_mtx_unlock(&conn->mtx);
+	return (rv);
+}
+
 void
 nni_http_conn_fini(nni_http_conn *conn)
 {

--- a/src/supplemental/http/http_public.c
+++ b/src/supplemental/http/http_public.c
@@ -651,3 +651,15 @@ nng_http_reset(nng_http *conn)
 	NNI_ARG_UNUSED(conn);
 #endif
 }
+
+nng_err
+nng_http_peer_cert(nng_http *conn, nng_tls_cert **certp)
+{
+#ifdef NNG_SUPP_HTTP
+	return (nni_http_conn_peer_cert(conn, certp));
+#else
+	NNI_ARG_UNUSED(conn);
+	NNI_ARG_UNUSED(certp);
+	return (NNG_ENOTSUP);
+#endif
+}

--- a/src/supplemental/tls/mbedtls/mbedtls.c
+++ b/src/supplemental/tls/mbedtls/mbedtls.c
@@ -76,6 +76,16 @@ psk_free(psk *p)
 	}
 }
 
+struct nng_tls_engine_cert {
+	mbedtls_x509_crt crt;
+	char             subject[1024];
+	char             issuer[1024];
+	char             last_alt[256];
+	char             serial[64]; // 20 bytes per RFC, x 3 for display
+	char             cn[65];     // 64 + null
+	int              next_alt;
+};
+
 struct nng_tls_engine_conn {
 	void               *tls; // parent conn
 	mbedtls_ssl_context ctx;
@@ -370,11 +380,32 @@ conn_verified(nng_tls_engine_conn *ec)
 	return (mbedtls_ssl_get_verify_result(&ec->ctx) == 0);
 }
 
+static nng_err
+conn_peer_cert(nng_tls_engine_conn *ec, nng_tls_engine_cert **certp)
+{
+	nng_tls_engine_cert *cert;
+
+	const mbedtls_x509_crt *crt = mbedtls_ssl_get_peer_cert(&ec->ctx);
+
+	if (crt == NULL) {
+		return (NNG_ENOENT);
+	}
+	if ((cert = nni_zalloc(sizeof(*cert))) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	// In order to ensure that we get our *own* copy that might outlive the
+	// cert buffer from the connection, we do a parse.
+	mbedtls_x509_crt_parse(&cert->crt, crt->raw.p, crt->raw.len);
+
+	*certp = cert;
+	return (NNG_OK);
+}
+
 static char *
 conn_peer_cn(nng_tls_engine_conn *ec)
 {
 	const mbedtls_x509_crt *crt = mbedtls_ssl_get_peer_cert(&ec->ctx);
-	if (!crt) {
+	if (crt == NULL) {
 		return (NULL);
 	}
 
@@ -398,47 +429,6 @@ conn_peer_cn(nng_tls_engine_conn *ec)
 	char *rv = malloc(len);
 	memcpy(rv, pos, len);
 	return (rv);
-}
-
-static char **
-conn_peer_alt_names(nng_tls_engine_conn *ec)
-{
-	const mbedtls_x509_crt *crt = mbedtls_ssl_get_peer_cert(&ec->ctx);
-	if (!crt) {
-		return (NULL);
-	}
-
-	const mbedtls_asn1_sequence *seq = &crt->subject_alt_names;
-
-	// get count
-	int count = 0;
-	do {
-		if (seq->buf.len > 0)
-			++count;
-		seq = seq->next;
-	} while (seq);
-	if (count == 0)
-		return NULL;
-
-	seq = &crt->subject_alt_names;
-
-	// copy strings
-	char **rv = malloc((count + 1) * sizeof(char *));
-	int    i  = 0;
-	do {
-		if (seq->buf.len == 0)
-			continue;
-
-		rv[i] = malloc(seq->buf.len + 1);
-		memcpy(rv[i], seq->buf.p, seq->buf.len);
-		rv[i][seq->buf.len] = 0;
-		++i;
-
-		seq = seq->next;
-	} while (seq);
-	rv[i] = NULL;
-
-	return rv;
 }
 
 static void
@@ -713,6 +703,223 @@ err:
 	return (rv);
 }
 
+static void
+cert_fini(nng_tls_engine_cert *crt)
+{
+	mbedtls_x509_crt_free(&crt->crt);
+	nni_free(crt, sizeof(*crt));
+}
+
+static nng_err
+cert_parse_der(nng_tls_engine_cert **crtp, const uint8_t *der, size_t size)
+{
+	nng_tls_engine_cert *cert;
+	int                  rv;
+
+	if ((cert = nni_zalloc(sizeof(*cert))) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	mbedtls_x509_crt_init(&cert->crt);
+	if ((rv = mbedtls_x509_crt_parse_der(&cert->crt, der, size)) != 0) {
+		tls_log_err(
+		    "NNG-TLS-DER", "Failure parsing DER certificate", rv);
+		rv = tls_mk_err(rv);
+		cert_fini(cert);
+		return (rv);
+	}
+	*crtp = cert;
+	return (NNG_OK);
+}
+
+static nng_err
+cert_parse_pem(nng_tls_engine_cert **crtp, const char *pem, size_t size)
+{
+	nng_tls_engine_cert *cert;
+	int                  rv;
+
+	if ((cert = nni_zalloc(sizeof(*cert))) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	mbedtls_x509_crt_init(&cert->crt);
+	if ((rv = mbedtls_x509_crt_parse(
+	         &cert->crt, (const uint8_t *) pem, size)) != 0) {
+		tls_log_err(
+		    "NNG-TLS-PEM", "Failure parsing PEM certificate", rv);
+		rv = tls_mk_err(rv);
+		cert_fini(cert);
+		return (rv);
+	}
+	*crtp = cert;
+	return (NNG_OK);
+}
+
+static nng_err
+cert_get_der(nng_tls_engine_cert *crt, uint8_t *buf, size_t *sizep)
+{
+	if (*sizep < crt->crt.raw.len) {
+		*sizep = crt->crt.raw.len;
+		return (NNG_ENOSPC);
+	}
+	*sizep = crt->crt.raw.len;
+	memcpy(buf, crt->crt.raw.p, *sizep);
+	return (NNG_OK);
+}
+
+static nng_err
+cert_subject(nng_tls_engine_cert *crt, char **namep)
+{
+	if (crt->subject[0] != 0) {
+		*namep = (char *) &crt->subject[0];
+		return (NNG_OK);
+	}
+	int len = mbedtls_x509_dn_gets(
+	    crt->subject, sizeof(crt->subject), &crt->crt.subject);
+	if (len <= 0) {
+		return (NNG_ENOTSUP);
+	}
+	*namep = &crt->subject[0];
+	return (NNG_OK);
+}
+
+static nng_err
+cert_issuer(nng_tls_engine_cert *crt, char **namep)
+{
+	if (crt->issuer[0] != 0) {
+		*namep = (char *) &crt->issuer[0];
+		return (NNG_OK);
+	}
+	int len = mbedtls_x509_dn_gets(
+	    crt->issuer, sizeof(crt->issuer), &crt->crt.issuer);
+	if (len <= 0) {
+		return (NNG_ENOTSUP);
+	}
+	*namep = &crt->issuer[0];
+	return (NNG_OK);
+}
+
+static nng_err
+cert_serial(nng_tls_engine_cert *crt, char **namep)
+{
+	if (crt->serial[0] != 0) {
+		*namep = (char *) &crt->serial[0];
+		return (NNG_OK);
+	}
+	int len = mbedtls_x509_serial_gets(
+	    crt->serial, sizeof(crt->serial), &crt->crt.serial);
+	if (len < 0) {
+		return (tls_mk_err(len));
+	}
+	*namep = &crt->serial[0];
+	return (NNG_OK);
+}
+
+static nng_err
+cert_subject_cn(nng_tls_engine_cert *crt, char **namep)
+{
+	nng_err rv;
+	char   *subject;
+	char   *s;
+	if (crt->cn[0] != 0) {
+		*namep = (char *) &crt->cn[0];
+		return (NNG_OK);
+	}
+	if ((rv = cert_subject(crt, &subject)) != NNG_OK) {
+		return (rv);
+	}
+	if ((s = strstr(crt->subject, "CN=")) == NULL) {
+		return (NNG_ENOENT);
+	}
+	s += 3;
+	int  n   = 0;
+	bool esc = false;
+	while (n < 64) {
+		if (*s == 0) {
+			crt->cn[n++] = 0;
+			break;
+		}
+		if (esc) {
+			esc          = false;
+			crt->cn[n++] = *s++;
+		} else if (*s == '\\') {
+			esc = true;
+		} else if (*s == ',') {
+			crt->cn[n++] = 0;
+			break;
+		} else {
+			crt->cn[n++] = *s++;
+		}
+	}
+	if ((n == 0) || (n > 64)) {
+		nng_log_warn(
+		    "NNG-TLS-CN", "X.509 Subject CN length is invalid");
+		return (NNG_EINVAL);
+	}
+	*namep = (char *) &crt->cn[0];
+	return (0);
+}
+
+static nng_err
+cert_next_alt(nng_tls_engine_cert *crt, char **namep)
+{
+	const mbedtls_asn1_sequence *seq = &crt->crt.subject_alt_names;
+
+	// get count
+	int count = 0;
+	for (seq = &crt->crt.subject_alt_names; seq != NULL; seq = seq->next) {
+		if (seq->buf.len == 0) {
+			continue;
+		}
+		if (count == crt->next_alt) {
+			break;
+		}
+		count++;
+	}
+	if (seq == NULL) {
+		return (NNG_ENOENT);
+	}
+	crt->next_alt++;
+	if (seq->buf.len >= sizeof(crt->last_alt)) {
+		return (NNG_EINVAL);
+	}
+	memcpy(crt->last_alt, seq->buf.p, seq->buf.len);
+	crt->last_alt[seq->buf.len] = 0;
+	*namep                      = crt->last_alt;
+	return (NNG_OK);
+}
+
+static void
+mbed_time_to_tm(mbedtls_x509_time *mt, struct tm *tmp)
+{
+	memset(tmp, 0, sizeof(*tmp)); // also clears any zone offset, etc
+	if (mt->year < 100) {
+		// all dates > Y2K, relative to 1900
+		tmp->tm_year = mt->year + 100;
+	} else {
+		tmp->tm_year = mt->year - 1900;
+	}
+	tmp->tm_mon  = mt->mon - 1; // month is zero based
+	tmp->tm_mday = mt->day;
+	tmp->tm_hour = mt->hour;
+	tmp->tm_min  = mt->min;
+	tmp->tm_sec  = mt->sec;
+	// canonicalize the time
+	(void) mktime(tmp);
+}
+
+static nng_err
+cert_not_before(nng_tls_engine_cert *cert, struct tm *tmp)
+{
+	mbed_time_to_tm(&cert->crt.valid_from, tmp);
+	return (NNG_OK);
+}
+
+static nng_err
+cert_not_after(nng_tls_engine_cert *cert, struct tm *tmp)
+{
+	mbed_time_to_tm(&cert->crt.valid_to, tmp);
+	return (NNG_OK);
+}
+
 static int
 config_version(nng_tls_engine_config *cfg, nng_tls_version min_ver,
     nng_tls_version max_ver)
@@ -826,22 +1033,37 @@ static nng_tls_engine_config_ops config_ops = {
 };
 
 static nng_tls_engine_conn_ops conn_ops = {
-	.size           = sizeof(nng_tls_engine_conn),
-	.init           = conn_init,
-	.fini           = conn_fini,
-	.close          = conn_close,
-	.recv           = conn_recv,
-	.send           = conn_send,
-	.handshake      = conn_handshake,
-	.verified       = conn_verified,
-	.peer_cn        = conn_peer_cn,
-	.peer_alt_names = conn_peer_alt_names,
+	.size      = sizeof(nng_tls_engine_conn),
+	.init      = conn_init,
+	.fini      = conn_fini,
+	.close     = conn_close,
+	.recv      = conn_recv,
+	.send      = conn_send,
+	.handshake = conn_handshake,
+	.verified  = conn_verified,
+	.peer_cert = conn_peer_cert,
+	.peer_cn   = conn_peer_cn,
+};
+
+static nng_tls_engine_cert_ops cert_ops = {
+	.fini          = cert_fini,
+	.parse_der     = cert_parse_der,
+	.parse_pem     = cert_parse_pem,
+	.get_der       = cert_get_der,
+	.subject       = cert_subject,
+	.issuer        = cert_issuer,
+	.serial_number = cert_serial,
+	.subject_cn    = cert_subject_cn,
+	.next_alt_name = cert_next_alt,
+	.not_before    = cert_not_before,
+	.not_after     = cert_not_after,
 };
 
 nng_tls_engine nng_tls_engine_ops = {
 	.version     = NNG_TLS_ENGINE_VERSION,
 	.config_ops  = &config_ops,
 	.conn_ops    = &conn_ops,
+	.cert_ops    = &cert_ops,
 	.name        = "mbed",
 	.description = MBEDTLS_VERSION_STRING_FULL,
 	.init        = tls_engine_init,

--- a/src/supplemental/tls/tls_common.h
+++ b/src/supplemental/tls/tls_common.h
@@ -49,6 +49,8 @@ struct nng_tls_config {
 	// ... engine config data follows
 };
 
+struct nng_tls_cert_s;
+
 typedef struct nni_tls_bio_ops_s {
 	void (*bio_send)(void *, nng_aio *);
 	void (*bio_recv)(void *, nng_aio *);
@@ -99,6 +101,7 @@ extern void nni_tls_recv(nni_tls_conn *conn, nni_aio *aio);
 extern void nni_tls_send(nni_tls_conn *conn, nni_aio *aio);
 extern bool nni_tls_verified(nni_tls_conn *conn);
 extern const char *nni_tls_peer_cn(nni_tls_conn *conn);
+extern nng_err     nni_tls_peer_cert(nni_tls_conn *conn, nng_tls_cert **certp);
 extern nng_err     nni_tls_run(nni_tls_conn *conn);
 extern size_t      nni_tls_engine_conn_size(void);
 

--- a/src/supplemental/tls/tls_dialer.c
+++ b/src/supplemental/tls/tls_dialer.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "../../core/nng_impl.h"
 
 #include "tls_common.h"
 #include "tls_engine.h"

--- a/src/supplemental/tls/tls_listener.c
+++ b/src/supplemental/tls/tls_listener.c
@@ -13,7 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "../../core/nng_impl.h"
 
 #include "tls_common.h"
 #include "tls_engine.h"

--- a/src/supplemental/tls/wolfssl/CMakeLists.txt
+++ b/src/supplemental/tls/wolfssl/CMakeLists.txt
@@ -60,7 +60,13 @@ if (NNG_TLS_ENGINE STREQUAL "wolf")
     if (NNG_WOLFSSL_HAVE_PEER_CERT)
         nng_defines(NNG_WOLFSSL_HAVE_PEER_CERT)
     else ()
-        message(STATUS "wolfSSL configured without peer cert chain support.")
+        message(STATUS "wolfSSL configured without full certificate APIs.")
+        message(NOTICE "
+        ************************************************************
+        WolfSSL functionality for working with certificates is missing.
+        Consider rebuilding WolfSSL for full functionality.
+        ************************************************************")
+
     endif ()
 
     if (NNG_WOLFSSL_HAVE_PSK)


### PR DESCRIPTION
…NAMES.

This will replace the NNG_OPT_TLS_PEER_ALTNAMES and NNG_OPT_TLS_PEER_CN properties, and gives a bit more access to the certificate, as well as direct access to the raw DER form, which should allow use in other APIs.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
