### PR TITLE
header file refactoring for IWYU (protocols)

### DIFF
--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -12,6 +12,7 @@
 #define CORE_DEFS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #include "nng/nng.h"

--- a/src/sp/protocol/bus0/bus.c
+++ b/src/sp/protocol/bus0/bus.c
@@ -8,11 +8,13 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdbool.h>
-#include <stdlib.h>
-
-#include "core/nng_impl.h"
-#include <stdio.h>
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Bus protocol.  The BUS protocol, each peer sends a message to its peers.
 // However, bus protocols do not "forward" (absent a device).  So in order

--- a/src/sp/protocol/bus0/bus_test.c
+++ b/src/sp/protocol/bus0/bus_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define SECOND 1000
 

--- a/src/sp/protocol/pair0/pair.c
+++ b/src/sp/protocol/pair0/pair.c
@@ -8,10 +8,13 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
-
-#include "core/nng_impl.h"
-#include "core/pipe.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Pair protocol.  The PAIR protocol is a simple 1:1 messaging pattern.
 // While a peer is connected to the server, all other peer connection

--- a/src/sp/protocol/pair1/pair.c
+++ b/src/sp/protocol/pair1/pair.c
@@ -8,9 +8,16 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
-
-#include "../../../core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/list.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/platform.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Pair protocol.  The PAIRv1 protocol is a simple 1:1 messaging pattern.
 

--- a/src/sp/protocol/pair1/pair1_poly.c
+++ b/src/sp/protocol/pair1/pair1_poly.c
@@ -8,9 +8,15 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
-
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/message.h"
+#include "../../../core/msgqueue.h"
+#include "../../../core/pipe.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
+#include "../../../core/stats.h"
 
 #define PAIR1_SELF_NAME "pair1"
 #define PAIR1_PEER_NAME "pair1"

--- a/src/sp/protocol/pair1/pair1_poly_test.c
+++ b/src/sp/protocol/pair1/pair1_poly_test.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2017 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -8,7 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define SECOND 1000
 

--- a/src/sp/protocol/pair1/pair1_test.c
+++ b/src/sp/protocol/pair1/pair1_test.c
@@ -8,8 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include "nuts.h"
+#include "../../../testing/nuts.h"
 
 #define SECOND 1000
 

--- a/src/sp/protocol/pipeline0/pull.c
+++ b/src/sp/protocol/pipeline0/pull.c
@@ -8,9 +8,13 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
-
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/list.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Pull protocol.  The PULL protocol is the "read" side of a pipeline.
 

--- a/src/sp/protocol/pipeline0/pull_test.c
+++ b/src/sp/protocol/pipeline0/pull_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 static void
 test_pull_identity(void)

--- a/src/sp/protocol/pipeline0/push.c
+++ b/src/sp/protocol/pipeline0/push.c
@@ -10,7 +10,13 @@
 
 #include <stdlib.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Push protocol.  The PUSH protocol is the "write" side of a pipeline.
 // Push distributes fairly, or tries to, by giving messages in round-robin

--- a/src/sp/protocol/pipeline0/push_test.c
+++ b/src/sp/protocol/pipeline0/push_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 static void
 test_push_identity(void)

--- a/src/sp/protocol/pubsub0/pub.c
+++ b/src/sp/protocol/pubsub0/pub.c
@@ -8,9 +8,14 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <string.h>
-
-#include "../../../core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Publish protocol.  The PUB protocol simply sends messages out, as
 // a broadcast.  It has nothing more sophisticated because it does not

--- a/src/sp/protocol/pubsub0/pub_test.c
+++ b/src/sp/protocol/pubsub0/pub_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 static void
 test_pub_identity(void)

--- a/src/sp/protocol/pubsub0/sub.c
+++ b/src/sp/protocol/pubsub0/sub.c
@@ -9,10 +9,16 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdbool.h>
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Subscriber protocol.  The SUB protocol receives messages sent to
 // it from publishers, and filters out those it is not interested in,

--- a/src/sp/protocol/pubsub0/sub_test.c
+++ b/src/sp/protocol/pubsub0/sub_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 static void
 test_sub_identity(void)

--- a/src/sp/protocol/pubsub0/xsub.c
+++ b/src/sp/protocol/pubsub0/xsub.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -10,7 +10,13 @@
 
 #include <stdlib.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/message.h"
+#include "../../../core/msgqueue.h"
+#include "../../../core/pipe.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Subscriber protocol.  The SUB protocol receives messages sent to
 // it from publishers, and filters out those it is not interested in,

--- a/src/sp/protocol/pubsub0/xsub_test.c
+++ b/src/sp/protocol/pubsub0/xsub_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <nng/nng.h>
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 static void
 test_xsub_identity(void)

--- a/src/sp/protocol/reqrep0/rep.c
+++ b/src/sp/protocol/reqrep0/rep.c
@@ -10,7 +10,14 @@
 
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/list.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Response protocol.  The REP protocol is the "reply" side of a
 // request-reply pair.  This is useful for building RPC servers, for

--- a/src/sp/protocol/reqrep0/rep_test.c
+++ b/src/sp/protocol/reqrep0/rep_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define REP0_SELF 0x31
 #define REP0_PEER 0x30

--- a/src/sp/protocol/reqrep0/req.c
+++ b/src/sp/protocol/reqrep0/req.c
@@ -7,9 +7,17 @@
 // file was obtained (LICENSE.txt).  A copy of the license may also be
 // found online at https://opensource.org/licenses/MIT.
 //
-#include <stdio.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/list.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/platform.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Request protocol.  The REQ protocol is the "request" side of a
 // request-reply pair.  This is useful for building RPC clients, for example.

--- a/src/sp/protocol/reqrep0/req_test.c
+++ b/src/sp/protocol/reqrep0/req_test.c
@@ -8,8 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define REQ0_SELF 0x30
 #define REQ0_PEER 0x31

--- a/src/sp/protocol/reqrep0/reqstress_test.c
+++ b/src/sp/protocol/reqrep0/reqstress_test.c
@@ -12,9 +12,7 @@
 #include <string.h>
 #include <time.h>
 
-#include "nng/nng.h"
-
-#include "nuts.h"
+#include "../../../testing/nuts.h"
 
 #ifdef NDEBUG
 #define dprintf(...)

--- a/src/sp/protocol/reqrep0/xrep.c
+++ b/src/sp/protocol/reqrep0/xrep.c
@@ -8,9 +8,15 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <string.h>
-
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/message.h"
+#include "../../../core/msgqueue.h"
+#include "../../../core/pipe.h"
+#include "../../../core/platform.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 #define REP0_SELF 0x31
 #define REP0_PEER 0x30

--- a/src/sp/protocol/reqrep0/xrep_test.c
+++ b/src/sp/protocol/reqrep0/xrep_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define REP0_SELF 0x31
 #define REP0_PEER 0x30

--- a/src/sp/protocol/reqrep0/xreq.c
+++ b/src/sp/protocol/reqrep0/xreq.c
@@ -8,9 +8,13 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdio.h>
-
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/message.h"
+#include "../../../core/msgqueue.h"
+#include "../../../core/pipe.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 #define REQ0_SELF 0x30
 #define REQ0_PEER 0x31

--- a/src/sp/protocol/reqrep0/xreq_test.c
+++ b/src/sp/protocol/reqrep0/xreq_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define REQ0_SELF 0x30
 #define REQ0_PEER 0x31

--- a/src/sp/protocol/survey0/respond.c
+++ b/src/sp/protocol/survey0/respond.c
@@ -8,10 +8,16 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
 #include <string.h>
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/list.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Respondent protocol.  The RESPONDENT protocol is the "replier" side of
 // the surveyor pattern.  This is useful for building service discovery, or

--- a/src/sp/protocol/survey0/respond_test.c
+++ b/src/sp/protocol/survey0/respond_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define RESPONDENT0_SELF 0x63
 #define RESPONDENT0_PEER 0x62

--- a/src/sp/protocol/survey0/survey.c
+++ b/src/sp/protocol/survey0/survey.c
@@ -8,9 +8,16 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
-
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/list.h"
+#include "../../../core/lmq.h"
+#include "../../../core/message.h"
+#include "../../../core/pipe.h"
+#include "../../../core/platform.h"
+#include "../../../core/pollable.h"
+#include "../../../core/protocol.h"
 
 // Surveyor protocol.  The SURVEYOR protocol is the "survey" side of the
 // survey pattern.  This is useful for building service discovery, voting, etc.

--- a/src/sp/protocol/survey0/survey_test.c
+++ b/src/sp/protocol/survey0/survey_test.c
@@ -8,8 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define SURVEYOR0_SELF 0x62
 #define SURVEYOR0_PEER 0x63

--- a/src/sp/protocol/survey0/xrespond.c
+++ b/src/sp/protocol/survey0/xrespond.c
@@ -8,9 +8,14 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include <stdlib.h>
-
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/idhash.h"
+#include "../../../core/message.h"
+#include "../../../core/msgqueue.h"
+#include "../../../core/pipe.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Respondent protocol.  The RESPONDENT protocol is the "replier" side of
 // the surveyor pattern.  This is useful for building service discovery, or

--- a/src/sp/protocol/survey0/xrespond_test.c
+++ b/src/sp/protocol/survey0/xrespond_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define RESPONDENT0_SELF 0x63
 #define RESPONDENT0_PEER 0x62

--- a/src/sp/protocol/survey0/xsurvey.c
+++ b/src/sp/protocol/survey0/xsurvey.c
@@ -8,7 +8,15 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "core/nng_impl.h"
+#include "../../../core/aio.h"
+#include "../../../core/defs.h"
+#include "../../../core/list.h"
+#include "../../../core/message.h"
+#include "../../../core/msgqueue.h"
+#include "../../../core/pipe.h"
+#include "../../../core/platform.h"
+#include "../../../core/protocol.h"
+#include "../../../core/socket.h"
 
 // Surveyor protocol.  The SURVEYOR protocol is the "survey" side of the
 // survey pattern.  This is useful for building service discovery, voting, etc.

--- a/src/sp/protocol/survey0/xsurvey_test.c
+++ b/src/sp/protocol/survey0/xsurvey_test.c
@@ -7,8 +7,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
-#include "nng/nng.h"
-#include <nuts.h>
+#include "../../../testing/nuts.h"
 
 #define SURVEYOR0_SELF 0x62
 #define SURVEYOR0_PEER 0x63


### PR DESCRIPTION
This changes the header files mostly in the protocols to include directly rather than through the commmon nng_impl.h header.  This should lead to faster compiles, and by properly making all includes relative should reduce friction with language servers and other tooling.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.
