### PR TITLE
chore(doc): extend possible errors from nng_pipe_get with ENOENT

### DIFF
--- a/docs/man/nng_pipe_get.3.adoc
+++ b/docs/man/nng_pipe_get.3.adoc
@@ -131,6 +131,7 @@ These functions return 0 on success, and non-zero otherwise.
 [horizontal]
 `NNG_EBADTYPE`:: Incorrect type for option.
 `NNG_ECLOSED`:: Parameter _p_ does not refer to an open pipe.
+`NNG_ENOENT`:: Parameter _p_ does not refer to an existing pipe.
 `NNG_ENOTSUP`:: The option _opt_ is not supported.
 `NNG_ENOMEM`:: Insufficient memory exists.
 `NNG_EINVAL`:: Size of destination _val_ too small for object.


### PR DESCRIPTION
`nng_pipe_get` might return `ENOENT` if the referred pipe is not found. This is missing in the documentation and is added.

