### PR TITLE
Remove diagnostic pragma in posix.c

### DIFF
--- a/src/platform/posix/posix_pipe.c
+++ b/src/platform/posix/posix_pipe.c
@@ -103,7 +103,7 @@ nni_plat_pipe_raise(int wfd)
 {
 	char c = 1;
 
-	if (write(wfd, &c, 1)) {};
+	if (write(wfd, &c, 1)) {}
 }
 
 void

--- a/src/platform/posix/posix_pipe.c
+++ b/src/platform/posix/posix_pipe.c
@@ -98,16 +98,13 @@ nni_plat_pipe_open(int *wfd, int *rfd)
 	return (0);
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
 void
 nni_plat_pipe_raise(int wfd)
 {
 	char c = 1;
 
-	(void) write(wfd, &c, 1);
+	if (write(wfd, &c, 1)) {};
 }
-#pragma GCC diagnostic pop
 
 void
 nni_plat_pipe_clear(int rfd)


### PR DESCRIPTION
Fixes #2204 diagnostic pragma in posix.c

I've been working around this for the R binding [package checks](https://r-pkgs.org/R-CMD-check.html) through other means until now. But thought this fix may be welcome as a way to silence any potential compiler warning without a pragma.

This may or may not accord with your code style, but it doesn't cause any change to the compiled code AFAIU.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated compiler warnings by making return-value handling explicit in low-level platform pipe operations; preserves existing behavior and public interfaces with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->