### PR TITLE
docs: document possible errors for nng_pipe_get functions

### DIFF
--- a/docs/ref/api/pipe.md
+++ b/docs/ref/api/pipe.md
@@ -133,6 +133,16 @@ The `nng_pipe_get_strlen` function is used to obtain the length of the string. T
 to find the size of the buffer needed by the `nng_pipe_get_strcpy` function for a property.
 Note that like `strlen`, this size does not account for the zero byte to terminate the string.
 
+### Errors
+
+The pipe option functions can return the following errors:
+
+- [`NNG_ENOENT`]: The pipe _p_ does not refer to an existing pipe.
+- [`NNG_ENOTSUP`]: The option _opt_ is not supported.
+- [`NNG_EBADTYPE`]: Incorrect type used for the option.
+- [`NNG_ENOMEM`]: Insufficient memory (returned by `nng_pipe_get_strdup` if allocation fails).
+- [`NNG_ENOSPC`]: Buffer too small (returned by `nng_pipe_get_strcpy` if buffer is insufficient).
+
 ## Pipe Notifications
 
 ```c


### PR DESCRIPTION
Add error documentation for pipe option getter functions, including `NNG_ENOENT` which can be returned when the pipe does not exist.

fixes #2198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "Errors" subsection for pipe-related options that enumerates possible return error codes and clarifies which option-accessors may specifically surface memory or storage shortage errors, improving clarity on failure modes for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->