### PR TITLE
fix(udp): wrong if statement for chop off.

### DIFF
--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -655,7 +655,7 @@ udp_recv_data(udp_ep *ep, udp_sp_msg *dreq, size_t len, const nng_sockaddr *sa)
 			return;
 		}
 
-		if (len > nng_msg_len(msg)) {
+		if (nng_msg_len(msg) > len) {
 			// chop off any unfilled tail
 			nng_msg_chop(msg, nng_msg_len(msg) - len);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized comparison logic in UDP message handling without affecting functionality. Messages exceeding the allowed length continue to be truncated as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->