### PR TITLE
feat(udp): expose UDP transport tuning as CMake cache variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,43 @@ if (NNG_MAX_POLLER_THREADS)
     add_definitions(-DNNG_MAX_POLLER_THREADS=${NNG_MAX_POLLER_THREADS})
 endif()
 
+# UDP transport tuning
+set(NNG_UDP_TXQUEUE_LEN 0 CACHE STRING "UDP TX queue length, 0 for default (32)")
+mark_as_advanced(NNG_UDP_TXQUEUE_LEN)
+if (NNG_UDP_TXQUEUE_LEN)
+    add_definitions(-DNNG_UDP_TXQUEUE_LEN=${NNG_UDP_TXQUEUE_LEN})
+endif()
+
+set(NNG_UDP_RXQUEUE_LEN 0 CACHE STRING "UDP RX queue length, 0 for default (16)")
+mark_as_advanced(NNG_UDP_RXQUEUE_LEN)
+if (NNG_UDP_RXQUEUE_LEN)
+    add_definitions(-DNNG_UDP_RXQUEUE_LEN=${NNG_UDP_RXQUEUE_LEN})
+endif()
+
+set(NNG_UDP_RECVMAX 0 CACHE STRING "UDP max receive size in bytes, 0 for default (65000)")
+mark_as_advanced(NNG_UDP_RECVMAX)
+if (NNG_UDP_RECVMAX)
+    add_definitions(-DNNG_UDP_RECVMAX=${NNG_UDP_RECVMAX})
+endif()
+
+set(NNG_UDP_COPYMAX 0 CACHE STRING "UDP copy-vs-loan threshold in bytes, 0 for default (1024)")
+mark_as_advanced(NNG_UDP_COPYMAX)
+if (NNG_UDP_COPYMAX)
+    add_definitions(-DNNG_UDP_COPYMAX=${NNG_UDP_COPYMAX})
+endif()
+
+set(NNG_UDP_REFRESH 0 CACHE STRING "UDP connection refresh interval in nanoseconds, 0 for default (5s)")
+mark_as_advanced(NNG_UDP_REFRESH)
+if (NNG_UDP_REFRESH)
+    add_definitions(-DNNG_UDP_REFRESH=${NNG_UDP_REFRESH})
+endif()
+
+set(NNG_UDP_CONNRETRY 0 CACHE STRING "UDP connection retry interval in nanoseconds, 0 for default (200ms)")
+mark_as_advanced(NNG_UDP_CONNRETRY)
+if (NNG_UDP_CONNRETRY)
+    add_definitions(-DNNG_UDP_CONNRETRY=${NNG_UDP_CONNRETRY})
+endif()
+
 #  Platform checks.
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -1213,7 +1213,7 @@ udp_ep_init(
 	ep->proto            = nni_sock_proto_id(sock);
 	ep->peer             = nni_sock_peer_id(sock);
 	ep->url              = url;
-	ep->refresh          = NNG_UDP_REFRESH; // one minute by default
+	ep->refresh          = NNG_UDP_REFRESH; // five seconds by default
 	ep->rcvmax           = NNG_UDP_RECVMAX;
 	ep->copymax          = NNG_UDP_COPYMAX;
 	if ((rv = nni_msg_alloc(&ep->rx_payload, ep->rcvmax) != 0)) {


### PR DESCRIPTION
The UDP transport has several compile-time tuning constants that were only configurable by passing raw `-D` flags to the compiler.

This is inconsistent with other advanced tuning options like `NNG_MAX_TASKQ_THREADS` or `NNG_MAX_POLLER_THREADS`, which are exposed as proper `CMake` cache variables with descriptions and defaults.

Add `CMake` cache variables for all six UDP tuning constants:

- `NNG_UDP_TXQUEUE_LEN` (default: 32)
- `NNG_UDP_RXQUEUE_LEN` (default: 16)
- `NNG_UDP_RECVMAX` (default: 65000)
- `NNG_UDP_COPYMAX` (default: 1024)
- `NNG_UDP_REFRESH` (default: 5s in nanoseconds)
- `NNG_UDP_CONNRETRY` (default: 200ms in nanoseconds)

All are marked as _advanced_, matching the convention of the existing thread-tuning options. A value of `0` means "use the compiled-in default", leveraging the existing `#ifndef` guards in `udp.c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tunable UDP transport parameters, enabling configuration of queue sizes, receive limits, buffer handling, refresh intervals, and retry timing for finer network performance tuning.

* **Documentation**
  * Clarified the default UDP connection refresh interval (documentation updated to reflect the shorter default).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->