### PR TITLE
fix: fix tcp_peer_addr signature mismatch with s_peer_addr

### DIFF
--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -297,7 +297,7 @@ tcp_self_addr(void *arg)
 }
 
 static const nng_sockaddr *
-tcp_peer_addr(void *arg, const nng_sockaddr **sap)
+tcp_peer_addr(void *arg)
 {
 	nni_tcp_conn *c = arg;
 	return (&c->peername);


### PR DESCRIPTION
The extra unused `const nng_sockaddr **sap` parameter caused MSVC warning [C4113](https://learn.microsoft.com/lb-lu/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4113?view=msvc-160).

> nng\src\platform\windows\win_tcpconn.c(389,21): warning C4113: 'const nng_sockaddr *(__cdecl *)(void *,const nng_sockaddr **)' differs in parameter lists from 'const nng_sockaddr *(__cdecl *)(void *)' [C:\a\nng-ci-build\nng-ci-build\build\nng.vcxproj]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal TCP connection handling logic.
  * Internal callback/interface adjustments to reduce code complexity.
  * No user-facing behavior or public API changes; functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->