### PR TITLE
fix: resolve build issues with MSYS2 UCRT64

### DIFF
--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -11,6 +11,7 @@
 #include "core/nng_impl.h"
 
 #include <ctype.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/platform/windows/win_socketpair.c
+++ b/src/platform/windows/win_socketpair.c
@@ -16,7 +16,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 
-int
+nng_err
 nni_socket_pair(int fds[2])
 {
 	int rv;
@@ -28,7 +28,7 @@ nni_socket_pair(int fds[2])
 	return (0);
 }
 #else
-int
+nng_err
 nni_socket_pair(int fds[2])
 {
 	NNI_ARG_UNUSED(fds);

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -297,7 +297,7 @@ tcp_self_addr(void *arg)
 }
 
 static const nng_sockaddr *
-tcp_peer_addr(void *arg, const nng_sockaddr **sap)
+tcp_peer_addr(void *arg)
 {
 	nni_tcp_conn *c = arg;
 	return (&c->peername);


### PR DESCRIPTION
This PR fixes several Windows build compatibility issues for MSYS2 UCRT64 builds:

- add missing stdio.h include in win_resolv.c
- align nni_socket_pair() return type with platform.h
- update tcp_peer_addr() to match current callback signature

These changes resolve build failures when compiling on Windows using MSYS2 UCRT64 GCC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling type consistency for socket operations on Windows.
  * Added missing standard library header to Windows resolver implementation.

* **Refactor**
  * Streamlined internal Windows TCP connection function signature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->