### PR TITLE
fix: resolve build issues with MSYS2 UCRT64

### DIFF
--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -11,6 +11,7 @@
 #include "core/nng_impl.h"
 
 #include <ctype.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -297,7 +297,7 @@ tcp_self_addr(void *arg)
 }
 
 static const nng_sockaddr *
-tcp_peer_addr(void *arg, const nng_sockaddr **sap)
+tcp_peer_addr(void *arg)
 {
 	nni_tcp_conn *c = arg;
 	return (&c->peername);


### PR DESCRIPTION
This PR fixes several Windows build compatibility issues for MSYS2 UCRT64 builds:

- add missing stdio.h include in win_resolv.c
- align nni_socket_pair() return type with platform.h

These changes resolve build failures when compiling on Windows using MSYS2 UCRT64 GCC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal function signature by removing unused parameters
  * Added missing standard library header for Windows platform support to enable existing utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->