### PR TITLE
fix: resolve build issues with MSYS2 UCRT64

### DIFF
--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -11,6 +11,7 @@
 #include "core/nng_impl.h"
 
 #include <ctype.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/src/platform/windows/win_socketpair.c
+++ b/src/platform/windows/win_socketpair.c
@@ -16,7 +16,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 
-int
+nng_err
 nni_socket_pair(int fds[2])
 {
 	int rv;
@@ -28,7 +28,7 @@ nni_socket_pair(int fds[2])
 	return (0);
 }
 #else
-int
+nng_err
 nni_socket_pair(int fds[2])
 {
 	NNI_ARG_UNUSED(fds);


### PR DESCRIPTION
This PR fixes several Windows build compatibility issues:

- add missing stdio.h include in win_resolv.c
- align nni_socket_pair() return type with platform.h

These changes resolve MinGW/UCRT build failures under MSYS2 UCRT64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error-return behavior for Windows socket pair handling to improve consistency across platform implementations.

* **Chores**
  * Added a missing C standard I/O header to ensure safe formatted-output usage in the Windows resolver component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->