### PR TITLE
fix: `sendmsg`/`readv` EINVAL for large iov on macOS and Windows

### DIFF
--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -14,6 +14,7 @@
 #include "reap.h"
 #include "taskq.h"
 
+#include <limits.h>
 #include <string.h>
 
 struct nni_aio_expire_q {
@@ -739,6 +740,13 @@ nni_aio_iov_count(nni_aio *aio)
 		residual += aio->a_iov[i].iov_len;
 	}
 	return (residual);
+}
+
+size_t
+nni_aio_iov_clamp_len(size_t len, size_t count)
+{
+	size_t headroom = (size_t) INT_MAX - count;
+	return (len < headroom ? len : headroom);
 }
 
 size_t

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -742,11 +742,16 @@ nni_aio_iov_count(nni_aio *aio)
 	return (residual);
 }
 
-size_t
-nni_aio_iov_clamp_len(size_t len, size_t count)
+bool
+nni_aio_iov_clamp_len(size_t *len, size_t *count)
 {
-	size_t headroom = (size_t) INT_MAX - count;
-	return (len < headroom ? len : headroom);
+	size_t headroom = (size_t) INT_MAX - *count;
+	bool   clamped  = *len > headroom;
+	if (clamped) {
+		*len = headroom;
+	}
+	*count += *len;
+	return clamped;
 }
 
 size_t

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -745,6 +745,7 @@ nni_aio_iov_count(nni_aio *aio)
 bool
 nni_aio_iov_clamp_len(size_t *len, size_t *count)
 {
+	NNI_ASSERT(*count <= (size_t) INT_MAX);
 	size_t headroom = (size_t) INT_MAX - *count;
 	bool   clamped  = *len > headroom;
 	if (clamped) {

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -139,6 +139,12 @@ extern size_t nni_aio_iov_advance(nni_aio *, size_t);
 // nni_aio_iov_count returns the number of bytes referenced by the aio iov.
 extern size_t nni_aio_iov_count(nni_aio *);
 
+// nni_aio_iov_clamp_len returns len clamped so that count + len does not
+// exceed INT_MAX, using a subtraction-based check that cannot wrap.
+// Used when building platform iov lists whose cumulative byte count must
+// not exceed INT_MAX (required by XNU sendmsg/readv and Windows WSABUF).
+extern size_t nni_aio_iov_clamp_len(size_t len, size_t count);
+
 extern nng_err nni_aio_set_iov(nni_aio *, unsigned, const nni_iov *);
 
 extern void         nni_aio_set_timeout(nni_aio *, nng_duration);

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -143,7 +143,8 @@ extern size_t nni_aio_iov_count(nni_aio *);
 // INT_MAX, adds *len to *count, and returns true if *len was reduced.
 // Used when building platform iov lists whose cumulative byte count must
 // not exceed INT_MAX (XNU sendmsg/readv, Windows WSABUF); callers should
-// stop appending entries on a true return.
+// stop appending entries on a true return.  Caller must seed *count to
+// a value <= INT_MAX (typically 0).
 extern bool nni_aio_iov_clamp_len(size_t *len, size_t *count);
 
 extern nng_err nni_aio_set_iov(nni_aio *, unsigned, const nni_iov *);

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -139,11 +139,12 @@ extern size_t nni_aio_iov_advance(nni_aio *, size_t);
 // nni_aio_iov_count returns the number of bytes referenced by the aio iov.
 extern size_t nni_aio_iov_count(nni_aio *);
 
-// nni_aio_iov_clamp_len returns len clamped so that count + len does not
-// exceed INT_MAX, using a subtraction-based check that cannot wrap.
+// nni_aio_iov_clamp_len clamps *len so *count + *len does not exceed
+// INT_MAX, adds *len to *count, and returns true if *len was reduced.
 // Used when building platform iov lists whose cumulative byte count must
-// not exceed INT_MAX (required by XNU sendmsg/readv and Windows WSABUF).
-extern size_t nni_aio_iov_clamp_len(size_t len, size_t count);
+// not exceed INT_MAX (XNU sendmsg/readv, Windows WSABUF); callers should
+// stop appending entries on a true return.
+extern bool nni_aio_iov_clamp_len(size_t *len, size_t *count);
 
 extern nng_err nni_aio_set_iov(nni_aio *, unsigned, const nni_iov *);
 

--- a/src/platform/ipc_stream_test.c
+++ b/src/platform/ipc_stream_test.c
@@ -371,6 +371,9 @@ test_ipc_stream_iov_exceeds_int_max(void)
 	}
 	NUTS_PASS(nng_aio_set_iov(saio, 8, iov));
 
+	// The peer never drains, so guard against any hang in the first
+	// sendmsg by bounding the wait.  Normal completion is sub-second.
+	nng_aio_set_timeout(saio, 10000);
 	nng_stream_send(c1, saio);
 	nng_aio_wait(saio);
 

--- a/src/platform/ipc_stream_test.c
+++ b/src/platform/ipc_stream_test.c
@@ -324,10 +324,14 @@ test_ipc_listen_activation_bad_arg(void)
 // Verifies the platform iov clamp handles cumulative iov totals exceeding
 // INT_MAX without triggering EINVAL (macOS/XNU sendmsg).  We build an
 // oversized iov cheaply by referencing a single chunk 8 times; peak memory
-// stays at ~256 MiB.
+// stays at ~256 MiB.  Not meaningful on Windows: named-pipe IPC uses
+// WriteFile (no scatter/gather) and already clamps writes to 16 MiB.
 void
 test_ipc_stream_iov_exceeds_int_max(void)
 {
+#ifndef NNG_PLATFORM_POSIX
+	NUTS_SKIP("Not POSIX");
+#else
 	nng_stream_dialer   *d    = NULL;
 	nng_stream_listener *l    = NULL;
 	char                *url;
@@ -397,6 +401,7 @@ test_ipc_stream_iov_exceeds_int_max(void)
 	nng_stream_free(c1);
 	nng_stream_close(c2);
 	nng_stream_free(c2);
+#endif
 }
 
 NUTS_TESTS = {

--- a/src/platform/ipc_stream_test.c
+++ b/src/platform/ipc_stream_test.c
@@ -9,6 +9,8 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include <limits.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <nng/nng.h>
@@ -319,6 +321,81 @@ test_ipc_listen_activation_bad_arg(void)
 #endif
 }
 
+// Verifies the platform iov clamp handles cumulative iov totals exceeding
+// INT_MAX without triggering EINVAL (macOS/XNU sendmsg).  We build an
+// oversized iov cheaply by referencing a single chunk 8 times; peak memory
+// stays at ~256 MiB.
+void
+test_ipc_stream_iov_exceeds_int_max(void)
+{
+	nng_stream_dialer   *d    = NULL;
+	nng_stream_listener *l    = NULL;
+	char                *url;
+	nng_aio             *daio = NULL;
+	nng_aio             *laio = NULL;
+	nng_aio             *saio = NULL;
+	nng_stream          *c1   = NULL;
+	nng_stream          *c2   = NULL;
+
+	NUTS_ADDR(url, "ipc");
+	NUTS_PASS(nng_aio_alloc(&daio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&laio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&saio, NULL, NULL));
+
+	NUTS_PASS(nng_stream_listener_alloc(&l, url));
+	NUTS_PASS(nng_stream_listener_listen(l));
+
+	NUTS_PASS(nng_stream_dialer_alloc(&d, url));
+	nng_stream_dialer_dial(d, daio);
+	nng_stream_listener_accept(l, laio);
+
+	nng_aio_wait(daio);
+	NUTS_PASS(nng_aio_result(daio));
+	nng_aio_wait(laio);
+	NUTS_PASS(nng_aio_result(laio));
+
+	c1 = nng_aio_get_output(daio, 0);
+	c2 = nng_aio_get_output(laio, 0);
+
+	// 8 x (INT_MAX/8 + 1) = INT_MAX + 1: cumulative iov just clears the
+	// 32-bit signed kernel cap while committing only ~256 MiB of memory.
+	const size_t per = ((size_t) INT_MAX / 8) + 1;
+	char        *buf = malloc(per);
+	NUTS_TRUE(buf != NULL);
+	memset(buf, 'A', per);
+
+	nng_iov iov[8];
+	for (int i = 0; i < 8; i++) {
+		iov[i].iov_buf = buf;
+		iov[i].iov_len = per;
+	}
+	NUTS_PASS(nng_aio_set_iov(saio, 8, iov));
+
+	nng_stream_send(c1, saio);
+	nng_aio_wait(saio);
+
+	// sendmsg only moves what fits in SO_SNDBUF, but it must not fail.
+	// Before the fix, macOS rejected the oversized iov with EINVAL.
+	NUTS_PASS(nng_aio_result(saio));
+	NUTS_TRUE(nng_aio_count(saio) > 0);
+	NUTS_TRUE(nng_aio_count(saio) <= (size_t) INT_MAX);
+
+	free(buf);
+	nng_aio_free(saio);
+	nng_aio_free(daio);
+	nng_aio_free(laio);
+	nng_stream_listener_close(l);
+	nng_stream_dialer_close(d);
+	nng_stream_listener_stop(l);
+	nng_stream_dialer_stop(d);
+	nng_stream_listener_free(l);
+	nng_stream_dialer_free(d);
+	nng_stream_close(c1);
+	nng_stream_free(c1);
+	nng_stream_close(c2);
+	nng_stream_free(c2);
+}
+
 NUTS_TESTS = {
 	{ "ipc stream", test_ipc_stream },
 	{ "ipc no connect", test_ipc_no_connect },
@@ -331,5 +408,7 @@ NUTS_TESTS = {
 	    test_ipc_listen_activation_bogus_fd },
 	{ "ipc socket activation bad arg",
 	    test_ipc_listen_activation_bad_arg },
+	{ "ipc stream iov exceeds INT_MAX",
+	    test_ipc_stream_iov_exceeds_int_max },
 	{ NULL, NULL },
 };

--- a/src/platform/ipc_stream_test.c
+++ b/src/platform/ipc_stream_test.c
@@ -361,7 +361,7 @@ test_ipc_stream_iov_exceeds_int_max(void)
 	// 32-bit signed kernel cap while committing only ~256 MiB of memory.
 	const size_t per = ((size_t) INT_MAX / 8) + 1;
 	char        *buf = malloc(per);
-	NUTS_TRUE(buf != NULL);
+	NUTS_ASSERT(buf != NULL);
 	memset(buf, 'A', per);
 
 	nng_iov iov[8];

--- a/src/platform/ipc_stream_test.c
+++ b/src/platform/ipc_stream_test.c
@@ -10,6 +10,7 @@
 //
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -331,6 +332,8 @@ test_ipc_stream_iov_exceeds_int_max(void)
 {
 #ifndef NNG_PLATFORM_POSIX
 	NUTS_SKIP("Not POSIX");
+#elif SIZE_MAX <= UINT32_MAX
+	NUTS_SKIP("Requires 64-bit size_t");
 #else
 	nng_stream_dialer   *d    = NULL;
 	nng_stream_listener *l    = NULL;

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -57,7 +57,7 @@ ipc_dowrite(ipc_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
@@ -132,7 +132,7 @@ ipc_doread(ipc_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -13,6 +13,7 @@
 #include "platform/posix/posix_peerid.h"
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <poll.h>
 #include <stdbool.h>
 #include <string.h>
@@ -52,10 +53,15 @@ ipc_dowrite(ipc_conn *c)
 		int           niov;
 		unsigned      i;
 
+		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				iovec[niov].iov_len  = aiov[i].iov_len;
+				size_t len = aiov[i].iov_len;
+				if (count + len > INT_MAX)
+					len = INT_MAX - count;
+				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
+				count += len;
 				niov++;
 			}
 		}
@@ -122,10 +128,15 @@ ipc_doread(ipc_conn *c)
 			nni_aio_finish_error(aio, NNG_EINVAL);
 			continue;
 		}
+		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				iovec[niov].iov_len  = aiov[i].iov_len;
+				size_t len = aiov[i].iov_len;
+				if (count + len > INT_MAX)
+					len = INT_MAX - count;
+				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
+				count += len;
 				niov++;
 			}
 		}

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -13,7 +13,6 @@
 #include "platform/posix/posix_peerid.h"
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>
 #include <poll.h>
 #include <stdbool.h>
 #include <string.h>
@@ -56,9 +55,8 @@ ipc_dowrite(ipc_conn *c)
 		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				size_t len = aiov[i].iov_len;
-				if (len > INT_MAX - count)
-					len = INT_MAX - count;
+				size_t len = nni_aio_iov_clamp_len(
+				    aiov[i].iov_len, count);
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
 				count += len;
@@ -131,9 +129,8 @@ ipc_doread(ipc_conn *c)
 		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = aiov[i].iov_len;
-				if (len > INT_MAX - count)
-					len = INT_MAX - count;
+				size_t len = nni_aio_iov_clamp_len(
+				    aiov[i].iov_len, count);
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
 				count += len;

--- a/src/platform/posix/posix_ipcconn.c
+++ b/src/platform/posix/posix_ipcconn.c
@@ -52,14 +52,14 @@ ipc_dowrite(ipc_conn *c)
 		int           niov;
 		unsigned      i;
 
-		size_t count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		size_t count   = 0;
+		bool   clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}
@@ -126,14 +126,14 @@ ipc_doread(ipc_conn *c)
 			nni_aio_finish_error(aio, NNG_EINVAL);
 			continue;
 		}
-		size_t count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		size_t count   = 0;
+		bool   clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -11,7 +11,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <limits.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <poll.h>
@@ -59,9 +58,8 @@ tcp_dowrite(nni_tcp_conn *c)
 		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				size_t len = aiov[i].iov_len;
-				if (len > INT_MAX - count)
-					len = INT_MAX - count;
+				size_t len = nni_aio_iov_clamp_len(
+				    aiov[i].iov_len, count);
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
 				count += len;
@@ -132,9 +130,8 @@ tcp_doread(nni_tcp_conn *c)
 		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = aiov[i].iov_len;
-				if (len > INT_MAX - count)
-					len = INT_MAX - count;
+				size_t len = nni_aio_iov_clamp_len(
+				    aiov[i].iov_len, count);
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
 				count += len;

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -60,7 +60,7 @@ tcp_dowrite(nni_tcp_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
@@ -133,7 +133,7 @@ tcp_doread(nni_tcp_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -11,6 +11,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <poll.h>
@@ -55,10 +56,15 @@ tcp_dowrite(nni_tcp_conn *c)
 		struct iovec  iovec[NNI_AIO_MAX_IOV];
 		int           niov;
 		unsigned      i;
+		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				iovec[niov].iov_len  = aiov[i].iov_len;
+				size_t len = aiov[i].iov_len;
+				if (count + len > INT_MAX)
+					len = INT_MAX - count;
+				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
+				count += len;
 				niov++;
 			}
 		}
@@ -123,10 +129,15 @@ tcp_doread(nni_tcp_conn *c)
 			nni_aio_finish_error(aio, NNG_EINVAL);
 			continue;
 		}
+		size_t count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				iovec[niov].iov_len  = aiov[i].iov_len;
+				size_t len = aiov[i].iov_len;
+				if (count + len > INT_MAX)
+					len = INT_MAX - count;
+				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
+				count += len;
 				niov++;
 			}
 		}

--- a/src/platform/posix/posix_tcpconn.c
+++ b/src/platform/posix/posix_tcpconn.c
@@ -55,14 +55,14 @@ tcp_dowrite(nni_tcp_conn *c)
 		struct iovec  iovec[NNI_AIO_MAX_IOV];
 		int           niov;
 		unsigned      i;
-		size_t count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		size_t count   = 0;
+		bool   clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len > 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}
@@ -127,14 +127,14 @@ tcp_doread(nni_tcp_conn *c)
 			nni_aio_finish_error(aio, NNG_EINVAL);
 			continue;
 		}
-		size_t count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		size_t count   = 0;
+		bool   clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
-				iovec[niov].iov_len  = len;
 				iovec[niov].iov_base = aiov[i].iov_buf;
-				count += len;
+				iovec[niov].iov_len  = aiov[i].iov_len;
+				clamped = nni_aio_iov_clamp_len(
+				    &iovec[niov].iov_len, &count);
 				niov++;
 			}
 		}

--- a/src/platform/tcp_stream_test.c
+++ b/src/platform/tcp_stream_test.c
@@ -472,6 +472,9 @@ test_tcp_stream_iov_exceeds_int_max(void)
 	}
 	NUTS_PASS(nng_aio_set_iov(saio, 8, iov));
 
+	// The peer never drains, so guard against any hang in the first
+	// sendmsg by bounding the wait.  Normal completion is sub-second.
+	nng_aio_set_timeout(saio, 10000);
 	nng_stream_send(c1, saio);
 	nng_aio_wait(saio);
 

--- a/src/platform/tcp_stream_test.c
+++ b/src/platform/tcp_stream_test.c
@@ -8,7 +8,9 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <nng/nng.h>
@@ -419,6 +421,80 @@ test_tcp_listen_activation_bad_arg(void)
 	nng_stream_listener_free(l1);
 }
 
+// Verifies the platform iov clamp handles cumulative iov totals exceeding
+// INT_MAX without triggering EINVAL (macOS/XNU sendmsg).  We build an
+// oversized iov cheaply by referencing a single chunk 8 times; peak memory
+// stays at ~256 MiB.
+void
+test_tcp_stream_iov_exceeds_int_max(void)
+{
+	nng_stream_dialer   *d    = NULL;
+	nng_stream_listener *l    = NULL;
+	nng_aio             *daio = NULL;
+	nng_aio             *laio = NULL;
+	nng_aio             *saio = NULL;
+	nng_stream          *c1   = NULL;
+	nng_stream          *c2   = NULL;
+	int                  port;
+
+	NUTS_PASS(nng_aio_alloc(&daio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&laio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&saio, NULL, NULL));
+
+	NUTS_PASS(nng_stream_listener_alloc(&l, "tcp://127.0.0.1"));
+	NUTS_PASS(nng_stream_listener_listen(l));
+	NUTS_PASS(nng_stream_listener_get_int(l, NNG_OPT_BOUND_PORT, &port));
+
+	char uri[64];
+	snprintf(uri, sizeof(uri), "tcp://127.0.0.1:%d", port);
+
+	NUTS_PASS(nng_stream_dialer_alloc(&d, uri));
+	nng_stream_dialer_dial(d, daio);
+	nng_stream_listener_accept(l, laio);
+	nng_aio_wait(daio);
+	NUTS_PASS(nng_aio_result(daio));
+	nng_aio_wait(laio);
+	NUTS_PASS(nng_aio_result(laio));
+	c1 = nng_aio_get_output(daio, 0);
+	c2 = nng_aio_get_output(laio, 0);
+
+	// 8 x (INT_MAX/8 + 1) = INT_MAX + 1: cumulative iov just clears the
+	// 32-bit signed kernel cap while committing only ~256 MiB of memory.
+	const size_t per = ((size_t) INT_MAX / 8) + 1;
+	char        *buf = malloc(per);
+	NUTS_TRUE(buf != NULL);
+	memset(buf, 'A', per);
+
+	nng_iov iov[8];
+	for (int i = 0; i < 8; i++) {
+		iov[i].iov_buf = buf;
+		iov[i].iov_len = per;
+	}
+	NUTS_PASS(nng_aio_set_iov(saio, 8, iov));
+
+	nng_stream_send(c1, saio);
+	nng_aio_wait(saio);
+
+	// sendmsg only moves what fits in SO_SNDBUF, but it must not fail.
+	// Before the fix, macOS rejected the oversized iov with EINVAL.
+	NUTS_PASS(nng_aio_result(saio));
+	NUTS_TRUE(nng_aio_count(saio) > 0);
+	NUTS_TRUE(nng_aio_count(saio) <= (size_t) INT_MAX);
+
+	free(buf);
+	nng_aio_free(saio);
+	nng_aio_free(daio);
+	nng_aio_free(laio);
+	nng_stream_close(c1);
+	nng_stream_close(c2);
+	nng_stream_stop(c1);
+	nng_stream_stop(c2);
+	nng_stream_free(c1);
+	nng_stream_free(c2);
+	nng_stream_dialer_free(d);
+	nng_stream_listener_free(l);
+}
+
 void
 test_tcp_dialer_loc_addr(void)
 {
@@ -471,5 +547,7 @@ NUTS_TESTS = {
 	{ "tcp socket activation bad arg",
 	    test_tcp_listen_activation_bad_arg },
 	{ "tcp dialer local address", test_tcp_dialer_loc_addr },
+	{ "tcp stream iov exceeds INT_MAX",
+	    test_tcp_stream_iov_exceeds_int_max },
 	{ NULL, NULL },
 };

--- a/src/platform/tcp_stream_test.c
+++ b/src/platform/tcp_stream_test.c
@@ -462,7 +462,7 @@ test_tcp_stream_iov_exceeds_int_max(void)
 	// 32-bit signed kernel cap while committing only ~256 MiB of memory.
 	const size_t per = ((size_t) INT_MAX / 8) + 1;
 	char        *buf = malloc(per);
-	NUTS_TRUE(buf != NULL);
+	NUTS_ASSERT(buf != NULL);
 	memset(buf, 'A', per);
 
 	nng_iov iov[8];

--- a/src/platform/tcp_stream_test.c
+++ b/src/platform/tcp_stream_test.c
@@ -9,6 +9,7 @@
 //
 
 #include <limits.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -428,6 +429,9 @@ test_tcp_listen_activation_bad_arg(void)
 void
 test_tcp_stream_iov_exceeds_int_max(void)
 {
+#if SIZE_MAX <= UINT32_MAX
+	NUTS_SKIP("Requires 64-bit size_t");
+#else
 	nng_stream_dialer   *d    = NULL;
 	nng_stream_listener *l    = NULL;
 	nng_aio             *daio = NULL;
@@ -496,6 +500,7 @@ test_tcp_stream_iov_exceeds_int_max(void)
 	nng_stream_free(c2);
 	nng_stream_dialer_free(d);
 	nng_stream_listener_free(l);
+#endif
 }
 
 void

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -27,6 +27,7 @@ tcp_recv_start(nni_tcp_conn *c)
 	nni_iov *aiov;
 	WSABUF   iov[8]; // we don't support more than this
 	DWORD    nrecv;
+	size_t   count;
 
 	c->recv_rv = 0;
 	while ((aio = nni_list_first(&c->recv_aios)) != NULL) {
@@ -39,10 +40,15 @@ tcp_recv_start(nni_tcp_conn *c)
 		nni_aio_get_iov(aio, &naiov, &aiov);
 
 		// Put the AIOs in Windows form.
+		count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
+				size_t len = aiov[i].iov_len;
+				if (count + len > INT_MAX)
+					len = INT_MAX - count;
 				iov[niov].buf = aiov[i].iov_buf;
-				iov[niov].len = (ULONG) aiov[i].iov_len;
+				iov[niov].len = (ULONG) len;
+				count += len;
 				niov++;
 			}
 		}
@@ -140,6 +146,7 @@ tcp_send_start(nni_tcp_conn *c)
 	nni_aio *aio;
 	int      rv;
 	DWORD    niov;
+	size_t   count;
 	unsigned i;
 	unsigned naiov;
 	nni_iov *aiov;
@@ -154,10 +161,15 @@ tcp_send_start(nni_tcp_conn *c)
 		nni_aio_get_iov(aio, &naiov, &aiov);
 
 		// Put the AIOs in Windows form.
+		count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
+				size_t len = aiov[i].iov_len;
+				if (count + len > INT_MAX)
+					len = INT_MAX - count;
 				iov[niov].buf = aiov[i].iov_buf;
-				iov[niov].len = (ULONG) aiov[i].iov_len;
+				iov[niov].len = (ULONG) len;
+				count += len;
 				niov++;
 			}
 		}

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -44,7 +44,7 @@ tcp_recv_start(nni_tcp_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iov[niov].buf = aiov[i].iov_buf;
 				iov[niov].len = (ULONG) len;
@@ -165,7 +165,7 @@ tcp_send_start(nni_tcp_conn *c)
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
 				size_t len = aiov[i].iov_len;
-				if (count + len > INT_MAX)
+				if (len > INT_MAX - count)
 					len = INT_MAX - count;
 				iov[niov].buf = aiov[i].iov_buf;
 				iov[niov].len = (ULONG) len;

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -43,9 +43,8 @@ tcp_recv_start(nni_tcp_conn *c)
 		count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = aiov[i].iov_len;
-				if (len > INT_MAX - count)
-					len = INT_MAX - count;
+				size_t len = nni_aio_iov_clamp_len(
+				    aiov[i].iov_len, count);
 				iov[niov].buf = aiov[i].iov_buf;
 				iov[niov].len = (ULONG) len;
 				count += len;
@@ -164,9 +163,8 @@ tcp_send_start(nni_tcp_conn *c)
 		count = 0;
 		for (niov = 0, i = 0; i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = aiov[i].iov_len;
-				if (len > INT_MAX - count)
-					len = INT_MAX - count;
+				size_t len = nni_aio_iov_clamp_len(
+				    aiov[i].iov_len, count);
 				iov[niov].buf = aiov[i].iov_buf;
 				iov[niov].len = (ULONG) len;
 				count += len;

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -40,14 +40,15 @@ tcp_recv_start(nni_tcp_conn *c)
 		nni_aio_get_iov(aio, &naiov, &aiov);
 
 		// Put the AIOs in Windows form.
-		count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		count        = 0;
+		bool clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
+				size_t len = aiov[i].iov_len;
+				clamped =
+				    nni_aio_iov_clamp_len(&len, &count);
 				iov[niov].buf = aiov[i].iov_buf;
 				iov[niov].len = (ULONG) len;
-				count += len;
 				niov++;
 			}
 		}
@@ -160,14 +161,15 @@ tcp_send_start(nni_tcp_conn *c)
 		nni_aio_get_iov(aio, &naiov, &aiov);
 
 		// Put the AIOs in Windows form.
-		count = 0;
-		for (niov = 0, i = 0; i < naiov; i++) {
+		count        = 0;
+		bool clamped = false;
+		for (niov = 0, i = 0; !clamped && i < naiov; i++) {
 			if (aiov[i].iov_len != 0) {
-				size_t len = nni_aio_iov_clamp_len(
-				    aiov[i].iov_len, count);
+				size_t len = aiov[i].iov_len;
+				clamped =
+				    nni_aio_iov_clamp_len(&len, &count);
 				iov[niov].buf = aiov[i].iov_buf;
 				iov[niov].len = (ULONG) len;
-				count += len;
 				niov++;
 			}
 		}


### PR DESCRIPTION
Fixes #2242 <`sendmsg`/`readv` EINVAL for large iov on macOS and Windows>

I've adopted this fix in the current dev version of https://github.com/r-lib/nanonext/pull/267 and I can confirm it fixes the issue.

--

On macOS (XNU kernel), `sendmsg()` and `readv()` return `EINVAL` when the total bytes across all iov entries exceeds `INT_MAX` (2,147,483,647). The XNU socket layer uses 32-bit signed integers internally for aggregate iov size calculations.

NNG's POSIX transport layer passes iov lengths directly from the SP transport without capping. For payloads larger than ~2 GiB, the body `iov_len` exceeds `INT_MAX`, and the syscall fails.

The failure is silent from the caller's perspective: `nng_sendmsg()` returns 0 because the pair protocol completes the application AIO immediately upon accepting the message. The `EINVAL` occurs asynchronously in the I/O thread, which closes the pipe. The receiver then either times out or gets a connection error.

On Windows, a similar truncation issue exists: `WSABUF.len` is `ULONG` (32-bit), so casting from 64-bit `size_t` silently truncates for large buffers.

Capping total iov bytes to `INT_MAX` per syscall resolves this. The SP transport already handles partial I/O, so the cap is transparent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent integer overflow when aggregating scatter/gather I/O by clamping per-buffer lengths during iovec/WSABUF construction across platforms, improving stability for very large multi-buffer sends/receives.

* **Tests**
  * Added IPC and TCP tests that exercise oversized I/O vectors to verify transfers succeed and reported byte counts do not exceed platform limits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->