### PR TITLE
fix(udp): close fd only once in nni_plat_udp_close

### DIFF
--- a/src/platform/posix/posix_pollq_epoll.c
+++ b/src/platform/posix/posix_pollq_epoll.c
@@ -180,6 +180,7 @@ nni_posix_pfd_fini(nni_posix_pfd *pfd)
 	}
 
 	(void) close(pfd->fd);
+	pfd->fd = -1;
 }
 
 static void

--- a/src/platform/posix/posix_pollq_kqueue.c
+++ b/src/platform/posix/posix_pollq_kqueue.c
@@ -150,6 +150,7 @@ nni_posix_pfd_fini(nni_posix_pfd *pf)
 	nni_posix_pfd_stop(pf);
 
 	(void) close(pf->fd);
+	pf->fd = -1;
 	nni_cv_fini(&pf->cv);
 }
 

--- a/src/platform/posix/posix_pollq_poll.c
+++ b/src/platform/posix/posix_pollq_poll.c
@@ -138,6 +138,7 @@ nni_posix_pfd_fini(nni_posix_pfd *pfd)
 
 	// We're exclusive now.
 	(void) close(pfd->fd);
+	pfd->fd = -1;
 }
 
 int

--- a/src/platform/posix/posix_pollq_port.c
+++ b/src/platform/posix/posix_pollq_port.c
@@ -117,6 +117,7 @@ nni_posix_pfd_fini(nni_posix_pfd *pfd)
 
 	// We're exclusive now.
 	(void) close(pfd->fd);
+	pfd->fd = -1;
 }
 
 int

--- a/src/platform/posix/posix_pollq_select.c
+++ b/src/platform/posix/posix_pollq_select.c
@@ -126,6 +126,7 @@ nni_posix_pfd_fini(nni_posix_pfd *pfd)
 
 	// We're exclusive now.
 	(void) close(fd);
+	pfd->fd = -1;
 	nni_cv_fini(&pfd->cv);
 	nni_mtx_fini(&pfd->mtx);
 }

--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -377,7 +377,6 @@ nni_plat_udp_close(nni_plat_udp *udp)
 {
 	nni_plat_udp_stop(udp);
 	nni_posix_pfd_fini(&udp->udp_pfd);
-	(void) close(udp->udp_fd);
 	nni_mtx_fini(&udp->udp_mtx);
 	NNI_FREE_STRUCT(udp);
 }


### PR DESCRIPTION
`nni_plat_udp_close` called `nni_posix_pfd_fini` (which closes `pf->fd`) and then close(`udp->udp_fd`) on the same numeric fd. In a multi- threaded process, another thread can open a new fd between the two `close` calls and be given the just-freed number, after which nng's second close silently steals it. The symptom in callers is `EBADF` from unrelated syscalls.

Drop the redundant close in `posix_udp.c`. As defense in depth, set `pfd->fd = -1` in every `nni_posix_pfd_fini` backend impl so any potential future double-fini becomes a harmless `close(-1)` instead of closing a recycled fd.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Closed file descriptors are now explicitly invalidated after cleanup across POSIX platforms, preventing accidental reuse or double-close of formerly-closed descriptors.
  * UDP teardown now relies on orderly shutdown and finalization steps before freeing resources, reducing the risk of duplicate closes and improving resource cleanup reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->