### PR TITLE
fix tcp stream local address test

### DIFF
--- a/src/platform/tcp_stream_test.c
+++ b/src/platform/tcp_stream_test.c
@@ -423,7 +423,7 @@ void
 test_tcp_dialer_loc_addr(void)
 {
 	nng_stream_dialer *d;
-	nng_sockaddr       sa;
+	nng_sockaddr       sa = { 0 };
 	NUTS_PASS(nng_stream_dialer_alloc(&d, "tcp://127.0.0.1:80"));
 	NUTS_FAIL(nng_stream_dialer_set_addr(d, NNG_OPT_LOCADDR, &sa),
 	    NNG_EADDRINVAL);


### PR DESCRIPTION
## Summary

Initialize the `nng_sockaddr` used by `test_tcp_dialer_loc_addr` before passing it to `nng_stream_dialer_set_addr` as invalid input.

## Root Cause

The test previously passed an uninitialized stack `nng_sockaddr`. Under thread sanitizer in PR #2248, the stack contents happened to look like a valid IPv4 local address with port zero, so the setter correctly returned success instead of `NNG_EADDRINVAL`.

## Validation

- `cmake -S . -B build -G Ninja`
- `cmake --build build --target tcp_stream_test && ctest --test-dir build -R '^nng\.platform\.tcp_stream_test$' --output-on-failure`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test robustness by ensuring proper initialization of test data structures during validation routines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->