### PR TITLE
Avoid duplicate PR CI runs

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,7 @@
 name: coverage
 on:
-  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 jobs:
   linux-coverage:

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -1,8 +1,7 @@
 name: darwin
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 jobs:
   build:

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,9 +1,8 @@
 name: freebsd
 
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,8 +1,7 @@
 name: linux
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 jobs:
   build:

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -1,9 +1,8 @@
 name: omnios
 
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 
 jobs:

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -1,8 +1,7 @@
 name: openssl
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 jobs:
   build:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,8 +1,7 @@
 name: sanitize
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 jobs:
   sanitize:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,8 +1,7 @@
 name: windows
 on:
-  push:
-    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
+    types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]
 jobs:
   build:


### PR DESCRIPTION
Removes broad branch `push` triggers from the standard CI workflows so PR branches do not run duplicate push and pull request jobs.

The workflows now run on `pull_request` for opened, synchronized, and reopened PRs, which still covers new commits pushed to an open PR.

Coverage is moved to the same PR-driven trigger behavior.

Validated by parsing all workflow YAML files and running `git diff --check`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified GitHub Actions workflows to trigger only on pull request events (`opened`, `synchronize`, `reopened`), removing push-based triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->