### PR TITLE
Bound DTLS exchange test operations

### DIFF
--- a/src/sp/transport/dtls/dtls_tran_test.c
+++ b/src/sp/transport/dtls/dtls_tran_test.c
@@ -358,8 +358,10 @@ test_dtls_exchange_many(void)
 	NUTS_PASS(nng_dialer_set_tls(d, c1));
 	NUTS_PASS(nng_dialer_start(d, 0));
 
-	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 
 	// send a bunch of messages - we're hoping that by serializing we won't
 	// overwhelm the network.


### PR DESCRIPTION
Bounds DTLS exchange-many test operations so intermittent DTLS/OpenSSL stalls fail at the send/receive assertion instead of timing out the whole CTest job.

The loop now applies symmetric 1s send and receive timeouts to both sockets, which keeps the stress test tolerant of loaded CI while preserving useful failure reporting.

Validated with `ctest --test-dir .context/build -R '^nng\.sp\.transport\.dtls\.dtls_tran_test$' --output-on-failure`, a direct OpenSSL `dtls exchange many` run, and `git diff --check`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased socket operation timeouts in DTLS transport tests to improve test reliability and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->