### PR TITLE
Restrict POSIX file creation permissions

### DIFF
--- a/src/platform/files_test.c
+++ b/src/platform/files_test.c
@@ -15,18 +15,58 @@
 #include <string.h>
 
 #ifdef NNG_PLATFORM_POSIX
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
+
+static int
+test_file_mode(const char *path, mode_t *modep)
+{
+	int         fd;
+	int         rv;
+	struct stat st;
+
+	if ((fd = open(path, O_RDONLY)) < 0) {
+		return (-1);
+	}
+	rv = fstat(fd, &st);
+	(void) close(fd);
+	if (rv != 0) {
+		return (rv);
+	}
+	*modep = st.st_mode;
+	return (0);
+}
+
+static int
+test_chmod_file(const char *path, mode_t mode)
+{
+	int fd;
+	int rv;
+
+	if ((fd = open(path, O_RDWR)) < 0) {
+		return (-1);
+	}
+	rv = fchmod(fd, mode);
+	(void) close(fd);
+	return (rv);
+}
 #endif
 
 static void
 test_permissions(void)
 {
 #ifdef NNG_PLATFORM_POSIX
-	char  *temp;
-	char  *file;
-	void  *data;
-	size_t n;
+	char        *temp;
+	char        *file;
+	void        *data;
+	size_t       n;
+	mode_t       mode;
+#ifdef __linux__
+	char       *fifo;
+	int         fd;
+#endif
+
 	if (geteuid() == 0) {
 		NUTS_SKIP("Cannot test permissions as root");
 		return;
@@ -35,9 +75,29 @@ test_permissions(void)
 	NUTS_TRUE(temp != NULL);
 	file = nni_file_join(temp, "nng_files_perms_test");
 	NUTS_PASS(nni_file_put(file, "abc", 4));
-	chmod(file, 0);
+	NUTS_PASS(test_file_mode(file, &mode));
+	NUTS_TRUE((mode & (S_IRWXG | S_IRWXO)) == 0);
+	NUTS_PASS(test_chmod_file(file,
+	    S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP));
+	NUTS_PASS(nni_file_put(file, "def", 4));
+	NUTS_PASS(test_file_mode(file, &mode));
+	NUTS_TRUE((mode & (S_IRWXG | S_IRWXO)) == 0);
+	// Exercise the path where we can open the file but cannot chmod it.
+	NUTS_FAIL(nni_file_put("/dev/null", "x", 2), NNG_EPERM);
+#ifdef __linux__
+	fifo = nni_file_join(temp, "nng_files_perms_fifo");
+	NUTS_TRUE(fifo != NULL);
+	nni_file_delete(fifo);
+	NUTS_TRUE(mkfifo(fifo, S_IRUSR | S_IWUSR) == 0);
+	NUTS_TRUE((fd = open(fifo, O_RDONLY | O_NONBLOCK)) >= 0);
+	NUTS_FAIL(nni_file_put(fifo, "abc", 4), NNG_EINVAL);
+	(void) close(fd);
+	nni_file_delete(fifo);
+	nni_strfree(fifo);
+#endif
+	NUTS_PASS(test_chmod_file(file, 0));
 	NUTS_FAIL(nni_file_get(file, &data, &n), NNG_EPERM);
-	NUTS_FAIL(nni_file_put(file, "def", 4), NNG_EPERM);
+	NUTS_FAIL(nni_file_put(file, "ghi", 4), NNG_EPERM);
 	nni_file_delete(file);
 	nni_strfree(file);
 	nni_strfree(temp);

--- a/src/platform/posix/posix_file.c
+++ b/src/platform/posix/posix_file.c
@@ -62,6 +62,24 @@ nni_plat_make_parent_dirs(const char *path)
 	return (0);
 }
 
+static int
+nni_plat_file_put_close_fd(int fd)
+{
+	int rv = nni_plat_errno(errno);
+
+	(void) close(fd);
+	return (rv);
+}
+
+static int
+nni_plat_file_put_close_file(FILE *f)
+{
+	int rv = nni_plat_errno(errno);
+
+	(void) fclose(f);
+	return (rv);
+}
+
 // nni_plat_file_put writes the named file, with the provided data,
 // and the given size.  If the file already exists it is overwritten.
 // The permissions on the file should be limited to read and write
@@ -70,6 +88,7 @@ int
 nni_plat_file_put(const char *name, const void *data, size_t len)
 {
 	FILE *f;
+	int   fd;
 	int   rv = 0;
 
 	// It is possible that the name contains a directory path
@@ -81,8 +100,17 @@ nni_plat_file_put(const char *name, const void *data, size_t len)
 		}
 	}
 
-	if ((f = fopen(name, "wb")) == NULL) {
+	if ((fd = open(name, O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR)) < 0) {
 		return (nni_plat_errno(errno));
+	}
+	if (fchmod(fd, S_IRUSR | S_IWUSR) != 0) {
+		return (nni_plat_file_put_close_fd(fd));
+	}
+	if ((f = fdopen(fd, "wb")) == NULL) {
+		return (nni_plat_file_put_close_fd(fd));
+	}
+	if (ftruncate(fd, 0) != 0) {
+		return (nni_plat_file_put_close_file(f));
 	}
 	if (fwrite(data, 1, len, f) != len) {
 		rv = nni_plat_errno(errno);


### PR DESCRIPTION
Fixes CodeQL alert 32: file created without restricting permissions.

POSIX file writes now use open(..., 0600) and fdopen rather than fopen, and existing files are tightened with fchmod before writing. The platform file permission test now checks both fresh creation and overwrite of a broad-permission file. Validated with cmake --build build --target files_test and ctest --test-dir build -R '^nng\.platform\.files_test$' --output-on-failure.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved file-permission tests with POSIX-specific coverage, stricter validation, and additional failure checks for special file types.

* **Refactor**
  * More robust file-write handling: explicit permission enforcement, safer truncation, and improved cleanup on error paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nanomsg/nng/pull/2252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->