### PR TITLE
[codex] Add TLS PSK stub for disabled TLS builds

### DIFF
--- a/src/supplemental/tls/tls_stubs.c
+++ b/src/supplemental/tls/tls_stubs.c
@@ -114,6 +114,17 @@ nng_tls_config_alloc(nng_tls_config **cfgp, nng_tls_mode mode)
 	return (NNG_ENOTSUP);
 }
 
+int
+nng_tls_config_psk(nng_tls_config *cfg, const char *identity,
+    const uint8_t *key, size_t key_len)
+{
+	NNI_ARG_UNUSED(cfg);
+	NNI_ARG_UNUSED(identity);
+	NNI_ARG_UNUSED(key);
+	NNI_ARG_UNUSED(key_len);
+	return (NNG_ENOTSUP);
+}
+
 void
 nng_tls_config_hold(nng_tls_config *cfg)
 {


### PR DESCRIPTION
fixes #2233 nng_tls_config_psk stub missing

Adds the missing `nng_tls_config_psk` fallback implementation in `tls_stubs.c` for builds where TLS support is unavailable. The stub marks all arguments unused and returns `NNG_ENOTSUP`, matching the other unsupported TLS configuration stubs.

You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pre-shared key (PSK) configuration API for TLS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->