### PR TITLE
[codex] document listener start errors

### DIFF
--- a/docs/man/nng_listener_start.3.adoc
+++ b/docs/man/nng_listener_start.3.adoc
@@ -44,7 +44,9 @@ This function returns 0 on success, and non-zero otherwise.
 == ERRORS
 
 [horizontal]
+`NNG_EADDRINUSE`:: The address specified by the listener is already in use.
 `NNG_ECLOSED`:: Parameter _l_ does not refer to an open listener.
+`NNG_EPERM`:: Permission was denied when binding to the address.
 `NNG_ESTATE`:: The listener _l_ is already started.
 
 == SEE ALSO


### PR DESCRIPTION
fixes #2168 nng_listener_start can return more errors

Document that `nng_listener_start` can return `NNG_EADDRINUSE` when the listener address is already in use and `NNG_EPERM` when binding is denied.

Validated with `git diff --check`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `nng_listener_start` documentation to include additional error code information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->