### PR TITLE
Convert TLS docs to mdbook

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -27,7 +27,7 @@ jobs:
           mdbook-version: "0.5.2"
 
       - run: cargo install mdbook-indexing
-      - run: mdbook build -d ./book docs
+      - run: mdbook build -d ./docs/book docs
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v4

--- a/docs/ref/SUMMARY.md
+++ b/docs/ref/SUMMARY.md
@@ -36,6 +36,8 @@
 
   - [Streams](./api/stream.md)
 
+  - [TLS](./api/tls.md)
+
   - [HTTP](./api/http.md)
 
   - [Miscellaneous](./api/misc.md)
@@ -61,6 +63,8 @@
 
   - [Intra-Process Transport](./tran/inproc.md)
   - [Inter-Process Transport](./tran/ipc.md)
+  - [TCP Transport](./tran/tcp.md)
+  - [TLS Transport](./tran/tls.md)
   - [BSD Socket (Experimental)](./tran/socket.md)
   - [UDP Transport (Experimental)](./tran/udp.md)
 

--- a/docs/ref/api/stream.md
+++ b/docs/ref/api/stream.md
@@ -88,6 +88,18 @@ const nng_sockaddr *nng_stream_self_addr(nng_stream *s);
 These functions are used to obtain value of the local (self) or remote (peer) addresses
 for the given stream _s_.
 
+## TLS Peer Certificates
+
+```c
+nng_err nng_stream_peer_cert(nng_stream *s, nng_tls_cert **certp);
+```
+
+{{hi:`nng_stream_peer_cert`}}
+The `nng_stream_peer_cert` function obtains the peer TLS certificate for a stream, when one is available.
+The certificate is returned in the location referenced by _certp_ and must be released with
+[`nng_tls_cert_free`] when it is no longer needed.
+See [`nng_tls_cert`] for more information.
+
 ## Getting Stream Options
 
 ```c

--- a/docs/ref/api/tls.md
+++ b/docs/ref/api/tls.md
@@ -1,0 +1,361 @@
+# TLS
+
+NNG provides {{i:TLS}} ({{i:Transport Layer Security}}) support for transports and
+stream-based services that need encrypted and authenticated communication.
+TLS is used by the [TLS transport], secure WebSocket transport, HTTP clients and servers,
+and raw [streams] implementations that support it.
+
+TLS support depends on a TLS engine being available when NNG is built.
+If TLS support is not enabled, the TLS functions may be present as stubs and will return
+[`NNG_ENOTSUP`] where appropriate.
+The active engine can be inspected with [`nng_tls_engine_name`] and
+[`nng_tls_engine_description`].
+The public TLS declarations are available from `<nng/nng.h>`.
+
+## Configuration Objects
+
+```c
+typedef struct nng_tls_config nng_tls_config;
+
+typedef enum nng_tls_mode {
+    NNG_TLS_MODE_CLIENT,
+    NNG_TLS_MODE_SERVER
+} nng_tls_mode;
+
+nng_err nng_tls_config_alloc(nng_tls_config **cfgp, nng_tls_mode mode);
+void nng_tls_config_hold(nng_tls_config *cfg);
+void nng_tls_config_free(nng_tls_config *cfg);
+```
+
+{{hi:`nng_tls_config`}}
+{{hi:`nng_tls_config_alloc`}}
+{{hi:`nng_tls_config_hold`}}
+{{hi:`nng_tls_config_free`}}
+{{hi:`NNG_TLS_MODE_CLIENT`}}
+{{hi:`NNG_TLS_MODE_SERVER`}}
+A {{i:TLS configuration}} object represents the policy and key material used to create TLS sessions.
+Configuration data includes the operating mode, certificate authorities used for peer validation,
+the local certificate and private key, the expected server name, protocol version limits,
+and pre-shared keys.
+
+The `nng_tls_config_alloc` function allocates a configuration object and stores it in _cfgp_.
+The _mode_ determines whether it will be used as a client or server.
+
+A configuration object starts with a reference count of one.
+The `nng_tls_config_hold` function increments that reference count, and
+`nng_tls_config_free` decrements it, freeing the object when the last reference is released.
+
+> [!NOTE]
+> TLS configuration objects become read-only once they are used to create a connection or service.
+> After that point, attempts to modify the configuration will fail with [`NNG_EBUSY`].
+
+## Authentication Mode
+
+```c
+typedef enum nng_tls_auth_mode {
+    NNG_TLS_AUTH_MODE_NONE,
+    NNG_TLS_AUTH_MODE_OPTIONAL,
+    NNG_TLS_AUTH_MODE_REQUIRED
+} nng_tls_auth_mode;
+
+nng_err nng_tls_config_auth_mode(nng_tls_config *cfg, nng_tls_auth_mode mode);
+```
+
+{{hi:`nng_tls_config_auth_mode`}}
+{{hi:`NNG_TLS_AUTH_MODE_NONE`}}
+{{hi:`NNG_TLS_AUTH_MODE_OPTIONAL`}}
+{{hi:`NNG_TLS_AUTH_MODE_REQUIRED`}}
+The `nng_tls_config_auth_mode` function configures how the remote peer is authenticated.
+
+| Mode                         | Description                                                                                                  |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `NNG_TLS_AUTH_MODE_NONE`     | No TLS peer authentication is performed. This is the default for server configurations.                       |
+| `NNG_TLS_AUTH_MODE_OPTIONAL` | A presented certificate is validated, but the session may proceed if the peer presents no valid certificate. |
+| `NNG_TLS_AUTH_MODE_REQUIRED` | The peer must present a valid certificate. This is the default for client configurations.                     |
+
+When authentication is required, the configuration must include certificate authority material that can validate
+the peer certificate.
+
+## Certificates and Keys
+
+```c
+nng_err nng_tls_config_ca_chain(nng_tls_config *cfg, const char *chain, const char *crl);
+nng_err nng_tls_config_ca_file(nng_tls_config *cfg, const char *path);
+nng_err nng_tls_config_own_cert(nng_tls_config *cfg, const char *cert,
+    const char *key, const char *pass);
+nng_err nng_tls_config_cert_key_file(nng_tls_config *cfg, const char *path,
+    const char *pass);
+nng_err nng_tls_config_server_name(nng_tls_config *cfg, const char *name);
+```
+
+{{hi:`nng_tls_config_ca_chain`}}
+{{hi:`nng_tls_config_ca_file`}}
+{{hi:`nng_tls_config_own_cert`}}
+{{hi:`nng_tls_config_cert_key_file`}}
+{{hi:`nng_tls_config_server_name`}}
+The `nng_tls_config_ca_chain` function adds one or more certificate authority certificates,
+and optionally a certificate revocation list, to _cfg_.
+Both _chain_ and _crl_ use zero-terminated PEM data; _crl_ may be `NULL`.
+The _chain_ may contain multiple certificates concatenated together.
+
+The `nng_tls_config_ca_file` function loads certificate authority and optional revocation list material
+from a file.
+The file must contain at least one PEM X.509 certificate and may also contain PEM CRL objects.
+
+The `nng_tls_config_own_cert` function configures the local certificate chain and associated private key
+from zero-terminated PEM strings.
+The _pass_ value is used to decrypt an encrypted private key, and may be `NULL`.
+A configuration accepts only one local certificate and key; a second attempt will fail with [`NNG_EBUSY`].
+
+The `nng_tls_config_cert_key_file` function loads the local certificate chain and private key from a file.
+The certificate and private key must both be present in PEM form in that file.
+
+The `nng_tls_config_server_name` function configures the expected remote server name for client configurations.
+This name is used for certificate validation and may also be sent with {{i:Server Name Indication}} (SNI).
+
+> [!TIP]
+> Server configurations normally need a local certificate and private key.
+> Client configurations normally need certificate authority material and a server name unless authentication is disabled.
+
+## Pre-Shared Keys
+
+```c
+nng_err nng_tls_config_psk(nng_tls_config *cfg, const char *identity,
+    const uint8_t *key, size_t key_len);
+```
+
+{{hi:`nng_tls_config_psk`}}
+{{i:Pre-shared key}} (PSK) configurations use an identity string and a shared secret instead of certificate-based authentication.
+The `nng_tls_config_psk` function configures a PSK identity and key.
+
+Client configurations can call this function once.
+Server configurations can call it multiple times to install keys for different client identities.
+Support for PSK depends on the configured TLS engine.
+
+## TLS Versions
+
+```c
+typedef enum nng_tls_version {
+    NNG_TLS_1_2 = 0x303,
+    NNG_TLS_1_3 = 0x304
+} nng_tls_version;
+
+nng_err nng_tls_config_version(nng_tls_config *cfg,
+    nng_tls_version min, nng_tls_version max);
+```
+
+{{hi:`nng_tls_config_version`}}
+{{hi:`NNG_TLS_1_2`}}
+{{hi:`NNG_TLS_1_3`}}
+The `nng_tls_config_version` function restricts the TLS protocol versions that may be used
+when creating sessions with _cfg_.
+By default, NNG attempts to use TLS v1.2 and TLS v1.3, subject to TLS engine support.
+If the engine cannot support any version in the requested range, this function returns [`NNG_ENOTSUP`].
+
+NNG does not support SSL v2.0, SSL v3.0, TLS v1.0, or TLS v1.1.
+TLS v1.3 zero round trip time (0-RTT) and session resumption are not supported.
+
+## Using Configuration Objects
+
+```c
+nng_err nng_dialer_get_tls(nng_dialer dialer, nng_tls_config **cfgp);
+nng_err nng_dialer_set_tls(nng_dialer dialer, nng_tls_config *cfg);
+nng_err nng_listener_get_tls(nng_listener listener, nng_tls_config **cfgp);
+nng_err nng_listener_set_tls(nng_listener listener, nng_tls_config *cfg);
+```
+
+{{hi:`nng_dialer_get_tls`}}
+{{hi:`nng_dialer_set_tls`}}
+{{hi:`nng_listener_get_tls`}}
+{{hi:`nng_listener_set_tls`}}
+The `nng_dialer_set_tls` and `nng_listener_set_tls` functions configure TLS for Scalability Protocol
+[dialer] and [listener] objects whose transports support TLS.
+These functions must be called before the dialer or listener is started.
+They take their own hold on the configuration object, so the caller may release its reference after a successful call.
+
+The `nng_dialer_get_tls` and `nng_listener_get_tls` functions retrieve the associated configuration object.
+They do not add a new hold; applications that need to retain the object independently should call
+[`nng_tls_config_hold`].
+
+The [Streams API][streams] has corresponding [`nng_stream_dialer_set_tls`],
+[`nng_stream_dialer_get_tls`], [`nng_stream_listener_set_tls`], and
+[`nng_stream_listener_get_tls`] functions.
+HTTP clients and servers also use TLS configuration objects for HTTPS; see [`nng_http_client_set_tls`]
+and related HTTP APIs.
+
+## Examples
+
+The following examples use Scalability Protocol [dialer] and [listener] objects.
+For raw [streams], use the same configuration steps, but attach the configuration with
+[`nng_stream_dialer_set_tls`] or [`nng_stream_listener_set_tls`].
+
+The examples use certificate files for clarity.
+Files passed to `nng_tls_config_cert_key_file` must contain both the certificate chain and the private key
+in PEM form.
+If the certificate and private key are stored separately, load them as strings and use
+[`nng_tls_config_own_cert`] instead.
+
+### Client Authentication of a Server
+
+This is the usual client-side TLS configuration.
+The client validates the server certificate against a trusted CA and verifies that the certificate
+matches the expected server name.
+
+```c
+nng_tls_config *tls;
+
+nng_tls_config_alloc(&tls, NNG_TLS_MODE_CLIENT);
+nng_tls_config_ca_file(tls, "ca.pem");
+nng_tls_config_server_name(tls, "server.example.com");
+nng_dialer_set_tls(dialer, tls);
+nng_tls_config_free(tls);
+```
+
+> [!TIP]
+> If the URL uses a DNS name, NNG may use that name for verification by default.
+> Calling `nng_tls_config_server_name` is still a good habit when the expected identity matters,
+> especially when dialing an IP address, an alias, or a name that differs from the certificate.
+
+### Server With a Certificate
+
+This is the usual server-side TLS configuration.
+The server presents its certificate and private key to clients.
+By default, server configurations do not require client certificates.
+
+```c
+nng_tls_config *tls;
+
+nng_tls_config_alloc(&tls, NNG_TLS_MODE_SERVER);
+nng_tls_config_cert_key_file(tls, "server.pem", NULL);
+nng_listener_set_tls(listener, tls);
+nng_tls_config_free(tls);
+```
+
+### Mutual TLS
+
+{{i:mutual TLS}}{{hi:mTLS}}
+With mutual TLS, both sides present certificates and both sides validate the peer.
+The server must require peer authentication and trust the CA that issued client certificates.
+The client must trust the CA that issued the server certificate and must also provide its own certificate.
+
+```c
+nng_tls_config *tls;
+
+// Server side.
+nng_tls_config_alloc(&tls, NNG_TLS_MODE_SERVER);
+nng_tls_config_cert_key_file(tls, "server.pem", NULL);
+nng_tls_config_ca_file(tls, "client-ca.pem");
+nng_tls_config_auth_mode(tls, NNG_TLS_AUTH_MODE_REQUIRED);
+nng_listener_set_tls(listener, tls);
+nng_tls_config_free(tls);
+
+// Client side.
+nng_tls_config_alloc(&tls, NNG_TLS_MODE_CLIENT);
+nng_tls_config_ca_file(tls, "server-ca.pem");
+nng_tls_config_server_name(tls, "server.example.com");
+nng_tls_config_cert_key_file(tls, "client.pem", NULL);
+nng_dialer_set_tls(dialer, tls);
+nng_tls_config_free(tls);
+```
+
+### Pre-Shared Keys
+
+{{i:pre-shared key}}{{i:PSK}}
+Pre-shared key configurations use matching identity and key values on both sides.
+They do not use certificate chains for peer authentication.
+The server may install multiple identities; the client installs the identity it will present.
+
+```c
+nng_tls_config *tls;
+uint8_t         key[32]; // Already provisioned securely.
+
+// Server side.
+nng_tls_config_alloc(&tls, NNG_TLS_MODE_SERVER);
+nng_tls_config_psk(tls, "client-1", key, sizeof(key));
+nng_listener_set_tls(listener, tls);
+nng_tls_config_free(tls);
+
+// Client side.
+nng_tls_config_alloc(&tls, NNG_TLS_MODE_CLIENT);
+nng_tls_config_psk(tls, "client-1", key, sizeof(key));
+nng_dialer_set_tls(dialer, tls);
+nng_tls_config_free(tls);
+```
+
+> [!NOTE]
+> PSK support depends on TLS engine capabilities.
+> If PSK is unavailable or the supplied identity or key is not acceptable to the engine,
+> `nng_tls_config_psk` will fail.
+> Real applications should provision high-entropy secret key material securely.
+
+## Peer Certificates
+
+```c
+typedef struct nng_tls_cert_s nng_tls_cert;
+
+nng_err nng_pipe_peer_cert(nng_pipe pipe, nng_tls_cert **certp);
+nng_err nng_stream_peer_cert(nng_stream *stream, nng_tls_cert **certp);
+nng_err nng_http_peer_cert(nng_http *conn, nng_tls_cert **certp);
+
+nng_err nng_tls_cert_parse_pem(nng_tls_cert **certp, const char *pem, size_t size);
+nng_err nng_tls_cert_parse_der(nng_tls_cert **certp, const uint8_t *der, size_t size);
+void nng_tls_cert_der(nng_tls_cert *cert, uint8_t *buf, size_t *sizep);
+void nng_tls_cert_free(nng_tls_cert *cert);
+
+nng_err nng_tls_cert_subject(nng_tls_cert *cert, char **namep);
+nng_err nng_tls_cert_issuer(nng_tls_cert *cert, char **namep);
+nng_err nng_tls_cert_serial_number(nng_tls_cert *cert, char **serialp);
+nng_err nng_tls_cert_subject_cn(nng_tls_cert *cert, char **namep);
+nng_err nng_tls_cert_next_alt(nng_tls_cert *cert, char **namep);
+nng_err nng_tls_cert_not_before(nng_tls_cert *cert, struct tm *timep);
+nng_err nng_tls_cert_not_after(nng_tls_cert *cert, struct tm *timep);
+```
+
+{{hi:`nng_tls_cert`}}
+{{hi:`nng_pipe_peer_cert`}}
+{{hi:`nng_stream_peer_cert`}}
+{{hi:`nng_http_peer_cert`}}
+{{hi:`nng_tls_cert_parse_pem`}}
+{{hi:`nng_tls_cert_parse_der`}}
+{{hi:`nng_tls_cert_der`}}
+{{hi:`nng_tls_cert_free`}}
+{{hi:`nng_tls_cert_subject`}}
+{{hi:`nng_tls_cert_issuer`}}
+{{hi:`nng_tls_cert_serial_number`}}
+{{hi:`nng_tls_cert_subject_cn`}}
+{{hi:`nng_tls_cert_next_alt`}}
+{{hi:`nng_tls_cert_not_before`}}
+{{hi:`nng_tls_cert_not_after`}}
+The `nng_tls_cert` object represents an X.509 certificate.
+Peer certificates can be obtained from a TLS [pipe], [stream], or HTTP connection.
+The certificate object must be released with `nng_tls_cert_free` when it is no longer needed.
+
+The parse functions create certificate objects from PEM or DER encoded certificate data.
+The `nng_tls_cert_der` function writes the DER form of a certificate into _buf_, using _sizep_
+as both the input buffer size and output byte count.
+
+The certificate information functions retrieve common X.509 fields.
+`nng_tls_cert_next_alt` iterates through subject alternative names and returns [`NNG_ENOENT`]
+when there are no more names.
+Applications that need to keep returned string values after changing or freeing the certificate object
+should copy those strings.
+
+## TLS Engine
+
+```c
+const char *nng_tls_engine_name(void);
+const char *nng_tls_engine_description(void);
+bool nng_tls_engine_fips_mode(void);
+```
+
+{{hi:`nng_tls_engine_name`}}
+{{hi:`nng_tls_engine_description`}}
+{{hi:`nng_tls_engine_fips_mode`}}
+The `nng_tls_engine_name` function returns a short name for the active TLS engine.
+The `nng_tls_engine_description` function returns a short descriptive string.
+These functions are principally useful for diagnostics.
+
+The `nng_tls_engine_fips_mode` function returns `true` if the engine is operating in FIPS mode.
+The default TLS engine does not support FIPS mode; alternative engines may provide that capability.
+
+{{#include ../xref.md}}

--- a/docs/ref/tran/tls.md
+++ b/docs/ref/tran/tls.md
@@ -1,0 +1,75 @@
+# TLS Transport
+
+## DESCRIPTION
+
+The {{i:*tls* transport}}{{hi:*tls*}} provides communication between
+peers across a TCP/IP network using {{i:TLS}} over TCP.
+Both {{i:IPv4}} and {{i:IPv6}} are supported when the underlying platform supports them.
+
+The protocol details are documented in the
+[TLS Mapping for Scalability Protocols](http://nanomsg.org/rfcs/sp-tls-v1.html).
+TLS configuration objects and certificate APIs are documented in [TLS].
+
+### URI Formats
+
+This transport uses URIs using the scheme {{i:`tls+tcp://`}}, followed by an
+{{i:IP address}} or {{i:hostname}}, and a TCP port number.
+For example, `tls+tcp://127.0.0.1:4433` and `tls+tcp://localhost:4433`
+both refer to port 4433 on the local host.
+
+For IPv6 literal addresses, the IPv6 address must be enclosed in square brackets,
+then the colon and finally the TCP port.
+For example, `tls+tcp://[::1]:4433` refers to port 4433 on the IPv6 loopback address.
+
+#### Forcing IPv4 or IPv6
+
+To force either IPv4 or IPv6, the scheme may be specified as `tls+tcp4://` or
+`tls+tcp6://`.
+This should only be needed when a hostname might resolve to either address family.
+
+> [!NOTE]
+> Specifying `tls+tcp6://` may not prevent IPv4 hosts from being used with
+> IPv4-in-IPv6 addresses, particularly when listening on wildcard addresses.
+> The details vary across operating systems.
+> The `tls+tcp4://` and `tls+tcp6://` schemes are specific to NNG.
+
+#### Listening to All Addresses
+
+When listening, a zero IP address can be supplied by either eliding the address altogether,
+or by specifying `0.0.0.0` (IPv4) or `::` (IPv6) explicitly.
+If left empty, IPv6 will be selected if available on the host, otherwise IPv4 will be selected.
+
+For example, the following URIs are equivalent for listening on port 9999:
+
+- `tls+tcp://0.0.0.0:9999`
+- `tls+tcp://:9999`
+
+> [!TIP]
+> Certificate validation generally works best when clients use host names rather than IP addresses.
+> The name in the URL is used when validating the certificate supplied by the server.
+
+### Socket Address
+
+When using an [`nng_sockaddr`] structure,
+the concrete type is either [`nng_sockaddr_in`] or [`nng_sockaddr_in6`],
+depending on whether IPv4 or IPv6 is in use.
+
+### Transport Options
+
+The following transport options are supported by this transport,
+where supported by the underlying platform.
+Options that change connection behavior must be set before the dialer or listener is started.
+
+| Option                                                                 | Type     | Description                                                                                                                     |
+| ---------------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `NNG_OPT_TCP_NODELAY`                                                  | `bool`   | Disable or enable use of {{i:Nagle's algorithm}} for TCP connections. Normally should be set to `true`.                         |
+| `NNG_OPT_TCP_KEEPALIVE`                                                | `bool`   | Enable or disable use of TCP keep-alive. Set to `false` by default.                                                             |
+| `NNG_OPT_TLS_VERIFIED`<a name="NNG_OPT_TLS_VERIFIED"></a>              | `bool`   | Read-only option indicating whether the remote peer was verified using TLS authentication.                                      |
+| `NNG_OPT_TLS_PEER_CN`<a name="NNG_OPT_TLS_PEER_CN"></a>                | `string` | Read-only option returning the common name from the peer certificate, when available.                                           |
+| `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a>                  | `int`    | The locally bound TCP port number (1-65535), read-only for [listener] objects only.                                             |
+
+> [!NOTE]
+> `NNG_OPT_TLS_VERIFIED` and `NNG_OPT_TLS_PEER_CN` may not be meaningful if peer authentication is disabled.
+> For richer peer certificate information, use [`nng_pipe_peer_cert`] or another peer certificate API.
+
+{{#include ../xref.md}}

--- a/docs/ref/xref.md
+++ b/docs/ref/xref.md
@@ -120,6 +120,7 @@
 [`nng_stream_close`]: ../api/stream.md#closing-a-stream
 [`nng_stream_stop`]: ../api/stream.md#closing-a-stream
 [`nng_stream_free`]: ../api/stream.md#closing-a-stream
+[`nng_stream_peer_cert`]: ../api/stream.md#tls-peer-certificates
 [`nng_stream_get`]: ../api/stream.md#getting-stream-options
 [`nng_stream_get_bool`]: ../api/stream.md#getting-stream-options
 [`nng_stream_get_int`]: ../api/stream.md#getting-stream-options
@@ -198,10 +199,10 @@
 [`nng_req0_open_raw`]: ../api/sock.md#raw-mode-sockets
 [`nng_sub0_open_raw`]: ../api/sock.md#raw-mode-sockets
 [`nng_surveyor0_open_raw`]: ../api/sock.md#raw-mode-sockets
-[`nng_dialer_set_tls`]: ../TODO.md
-[`nng_dialer_get_tls`]: ../TODO.md
-[`nng_listener_set_tls`]: ../TODO.md
-[`nng_listener_get_tls`]: ../TODO.md
+[`nng_dialer_set_tls`]: ../api/tls.md#using-configuration-objects
+[`nng_dialer_get_tls`]: ../api/tls.md#using-configuration-objects
+[`nng_listener_set_tls`]: ../api/tls.md#using-configuration-objects
+[`nng_listener_get_tls`]: ../api/tls.md#using-configuration-objects
 [`nng_args_parse`]: ../api/args.md#parse-command-line-arguments
 [`nng_aio_finish`]: ../api/aio.md#finishing-an-operation
 [`nng_aio_reset`]: ../api/aio.md#starting-an-operation
@@ -209,8 +210,18 @@
 [`nng_recv`]: ../TODO.md
 [`nng_listener_get_url`]: ../TODO.md
 [`nng_dialer_get_url`]: ../TODO.md
-[`nng_tls_config`]: ../TODO.md
-[`nng_tls_config_own_cert`]: ../TODO.md
+[`nng_tls_config`]: ../api/tls.md#configuration-objects
+[`nng_tls_config_alloc`]: ../api/tls.md#configuration-objects
+[`nng_tls_config_hold`]: ../api/tls.md#configuration-objects
+[`nng_tls_config_free`]: ../api/tls.md#configuration-objects
+[`nng_tls_config_auth_mode`]: ../api/tls.md#authentication-mode
+[`nng_tls_config_ca_chain`]: ../api/tls.md#certificates-and-keys
+[`nng_tls_config_ca_file`]: ../api/tls.md#certificates-and-keys
+[`nng_tls_config_own_cert`]: ../api/tls.md#certificates-and-keys
+[`nng_tls_config_cert_key_file`]: ../api/tls.md#certificates-and-keys
+[`nng_tls_config_server_name`]: ../api/tls.md#certificates-and-keys
+[`nng_tls_config_psk`]: ../api/tls.md#pre-shared-keys
+[`nng_tls_config_version`]: ../api/tls.md#tls-versions
 [`nng_listener_set_security_descriptor`]: ../TODO.md
 [`nng_device`]: ../TODO.md
 [`nng_dial`]: ../TODO.md
@@ -256,6 +267,7 @@
 [`nng_pipe_notify`]: ../api/pipe.md#pipe-notifications
 [`nng_pipe_peer_addr`]: ../api/pipe.md#pipe-socket-addresses
 [`nng_pipe_self_addr`]: ../api/pipe.md#pipe-socket-addresses
+[`nng_pipe_peer_cert`]: ../api/tls.md#peer-certificates
 [`nng_sockaddr`]: ../TODO.md
 [`nng_sockaddr_in`]: ../TODO.md
 [`nng_sockaddr_in6`]: ../TODO.md
@@ -272,6 +284,7 @@
 [`nng_http_client_connect`]: ../api/http.md#creating-connections
 [`nng_http_client_set_tls`]: ../api/http.md#client-tls
 [`nng_http_client_get_tls`]: ../api/http.md#client-tls
+[`nng_http_peer_cert`]: ../api/http.md#obtaining-tls-connection-details
 [`nng_http_close`]: ../api/http.md#closing-the-connection
 [`nng_http_reset`]: ../api/http.md#reset-connection-state
 [`nng_http_get_version`]: ../api/http.md#http-protocol-versions
@@ -380,8 +393,28 @@
 
 <!-- TLS -->
 
-[`nng_tls_cert`]: ../TODO.md
-[`nng_tls_cert`]: ../TODO.md
+[`nng_tls_cert`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_parse_pem`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_parse_der`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_der`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_free`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_subject`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_issuer`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_serial_number`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_subject_cn`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_next_alt`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_not_before`]: ../api/tls.md#peer-certificates
+[`nng_tls_cert_not_after`]: ../api/tls.md#peer-certificates
+[`nng_tls_engine_name`]: ../api/tls.md#tls-engine
+[`nng_tls_engine_description`]: ../api/tls.md#tls-engine
+[`nng_tls_engine_fips_mode`]: ../api/tls.md#tls-engine
+[`NNG_TLS_MODE_CLIENT`]: ../api/tls.md#configuration-objects
+[`NNG_TLS_MODE_SERVER`]: ../api/tls.md#configuration-objects
+[`NNG_TLS_AUTH_MODE_NONE`]: ../api/tls.md#authentication-mode
+[`NNG_TLS_AUTH_MODE_OPTIONAL`]: ../api/tls.md#authentication-mode
+[`NNG_TLS_AUTH_MODE_REQUIRED`]: ../api/tls.md#authentication-mode
+[`NNG_TLS_1_2`]: ../api/tls.md#tls-versions
+[`NNG_TLS_1_3`]: ../api/tls.md#tls-versions
 
 <!-- Macros -->
 
@@ -437,7 +470,7 @@
 [`NNG_UNIT_MILLIS`]: ../api/stats.md#statistic-units
 [`NNG_UNIT_EVENTS`]: ../api/stats.md#statistic-units
 [`NNG_FLAG_NONBLOCK`]: ../TODO.md
-[`NNG_OPT_LISTEN_FD`]: ../api/streams.md#socket-activation
+[`NNG_OPT_LISTEN_FD`]: ../api/stream.md#socket-activation
 [`NNG_OPT_MAXTTL`]: ../api/sock.md#NNG_OPT_MAXTTL
 [`NNG_OPT_RECONNMAXT`]: ../api/sock.md#NNG_OPT_RECONNMAXT
 [`NNG_OPT_RECONNMINT`]: ../api/sock.md#NNG_OPT_RECONNMINT
@@ -452,6 +485,10 @@
 [`NNG_OPT_PEER_ZONEID`]: ../tran/ipc.md#NNG_OPT_PEER_ZONEID
 [`NNG_OPT_SUB_PREF_NEW`]: ../proto/sub.md#protocol-options
 [`NNG_OPT_IPC_PERMISSIONS`]: ../tran/ipc.md#NNG_OPT_IPC_PERMISSIONS
+[`NNG_OPT_TCP_KEEPALIVE`]: ../tran/tcp.md#transport-options
+[`NNG_OPT_TCP_NODELAY`]: ../tran/tcp.md#transport-options
+[`NNG_OPT_TLS_VERIFIED`]: ../tran/tls.md#NNG_OPT_TLS_VERIFIED
+[`NNG_OPT_TLS_PEER_CN`]: ../tran/tls.md#NNG_OPT_TLS_PEER_CN
 [`NNG_SOCKET_INITIALIZER`]: ../api/sock.md#socket-structure
 [`NNG_CTX_INITIALIZER`]: ../api/ctx.md#context-structure
 [`NNG_PIPE_INITIALIZER`]: ../api/pipe.md#initialization
@@ -478,7 +515,10 @@
 [ipc]: ../tran/ipc.md
 [inproc]: ../tran/inproc.md
 [tcp]: ../tran/tcp.md
+[TLS]: ../api/tls.md
+[TLS transport]: ../tran/tls.md
 [udp]: ../tran/udp.md
+[streams]: ../api/stream.md
 
 <!-- Concept index -->
 


### PR DESCRIPTION
Converts the TLS transport documentation from the old man-page form into mdbook pages. Adds a shared TLS chapter covering configuration objects, authentication modes, certificates, TLS versions, peer certificates, engine diagnostics, and focused examples for client, server, mutual TLS, and PSK setup. Updates the stream API peer certificate entry, SUMMARY navigation, and xref targets so transport and API pages can link to the shared TLS material. Validated with `mdbook build docs` and `git diff --check origin/main...`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive TLS API docs: config, auth modes, cert management, peer-certificate retrieval, engine inspection, and examples (client/server/mTLS/PSK).
  * Added TLS transport docs: URI formats, IPv4/IPv6 semantics, listening behavior, and transport options.
  * Updated navigation, cross-references, and transport index to include TLS entries.
* **Chores**
  * Fixed documentation build workflow input path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->