### PR TITLE
fixes #2261 Extra call to WSACleanup

### DIFF
--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -440,7 +440,6 @@ nni_plat_fini(void)
 	nni_win_udp_sysfini();
 	nni_win_tcp_sysfini();
 	nni_win_io_sysfini();
-	WSACleanup();
 	if (hKernel32 != NULL) {
 		FreeLibrary(hKernel32);
 	}


### PR DESCRIPTION
fixes #2261 Extra call to WSACleanup

Remove the unpaired WSACleanup call from Windows platform shutdown so Winsock cleanup remains owned by the TCP and UDP subsystem finalizers that performed WSAStartup.
This prevents an extra cleanup when nng_fini() is called multiple times while preserving the existing TCP and UDP startup/cleanup balance.
Validated with git diff --check and static inspection of Windows WSAStartup/WSACleanup call sites; a Windows build was not run from this macOS workspace.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Windows shutdown cleanup behavior to avoid unnecessary network stack cleanup during application finalization, resulting in a smoother and more reliable shutdown sequence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->