### PR TITLE
[codex] add nng_pipe_get_scheme

### DIFF
--- a/docs/ref/api/pipe.md
+++ b/docs/ref/api/pipe.md
@@ -143,6 +143,23 @@ The pipe option functions can return the following errors:
 - [`NNG_ENOMEM`]: Insufficient memory (returned by `nng_pipe_get_strdup` if allocation fails).
 - [`NNG_ENOSPC`]: Buffer too small (returned by `nng_pipe_get_strcpy` if buffer is insufficient).
 
+## Pipe Scheme
+
+```c
+nng_err nng_pipe_get_scheme(nng_pipe p, const char **schemep);
+```
+
+{{hi:`nng_pipe_get_scheme`}}
+The `nng_pipe_get_scheme` function returns the scheme from the URL of the endpoint that created
+the pipe, such as `tcp`, `ipc`, or `inproc`.
+The returned string is immutable and does not need to be freed by the caller.
+
+### Errors
+
+The `nng_pipe_get_scheme` function can return the following errors:
+
+- [`NNG_ENOENT`]: The pipe _p_ does not refer to an existing pipe.
+
 ## Pipe Notifications
 
 ```c

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -772,6 +772,7 @@ NNG_DECL nng_err nng_pipe_get_string(nng_pipe, const char *, const char **);
 NNG_DECL nng_err nng_pipe_get_strdup(nng_pipe, const char *, char **);
 NNG_DECL nng_err nng_pipe_get_strcpy(nng_pipe, const char *, char *, size_t);
 NNG_DECL nng_err nng_pipe_get_strlen(nng_pipe, const char *, size_t *);
+NNG_DECL nng_err nng_pipe_get_scheme(nng_pipe, const char **);
 NNG_DECL nng_err nng_pipe_peer_addr(nng_pipe, nng_sockaddr *);
 NNG_DECL nng_err nng_pipe_self_addr(nng_pipe, nng_sockaddr *);
 NNG_DECL nng_err nng_pipe_peer_cert(nng_pipe, nng_tls_cert **);

--- a/src/core/pipe.c
+++ b/src/core/pipe.c
@@ -377,6 +377,18 @@ nni_pipe_dialer_id(nni_pipe *p)
 	return (p->p_dialer ? nni_dialer_id(p->p_dialer) : 0);
 }
 
+const char *
+nni_pipe_scheme(nni_pipe *p)
+{
+	if (p->p_dialer != NULL) {
+		return (nng_url_scheme(nni_dialer_url(p->p_dialer)));
+	}
+	if (p->p_listener != NULL) {
+		return (nng_url_scheme(nni_listener_url(p->p_listener)));
+	}
+	return (NULL);
+}
+
 void
 nni_pipe_add_stat(nni_pipe *p, nni_stat_item *item)
 {

--- a/src/core/pipe.h
+++ b/src/core/pipe.h
@@ -55,6 +55,9 @@ extern uint32_t nni_pipe_listener_id(nni_pipe *);
 // nni_pipe_dialer_id returns the dialer id for the pipe (or 0 if none).
 extern uint32_t nni_pipe_dialer_id(nni_pipe *);
 
+// nni_pipe_scheme returns the URL scheme for the pipe's creator endpoint.
+extern const char *nni_pipe_scheme(nni_pipe *);
+
 // nni_pipe_rele releases the hold on the pipe placed by nni_pipe_find.
 extern void nni_pipe_rele(nni_pipe *);
 

--- a/src/nng.c
+++ b/src/nng.c
@@ -1411,6 +1411,24 @@ nng_pipe_get_ms(nng_pipe id, const char *n, nng_duration *v)
 }
 
 nng_err
+nng_pipe_get_scheme(nng_pipe p, const char **schemep)
+{
+	nng_err     rv;
+	nni_pipe   *pipe;
+	const char *scheme;
+
+	if ((rv = nni_pipe_find(&pipe, p.id)) != 0) {
+		return (rv);
+	}
+	scheme = nni_pipe_scheme(pipe);
+	if (scheme != NULL) {
+		*schemep = scheme;
+	}
+	nni_pipe_rele(pipe);
+	return (scheme == NULL ? NNG_ENOTSUP : NNG_OK);
+}
+
+nng_err
 nng_pipe_peer_cert(nng_pipe p, nng_tls_cert **certp)
 {
 	nng_err   rv;

--- a/src/sp/pipe_test.c
+++ b/src/sp/pipe_test.c
@@ -149,6 +149,31 @@ fini_cases(struct testcase *push, struct testcase *pull)
 }
 
 static void
+start_cases(struct testcase *push, struct testcase *pull)
+{
+	NUTS_PASS(nng_listener_start(pull->l, 0));
+	NUTS_PASS(nng_dialer_start(push->d, 0));
+	NUTS_TRUE(expect(pull, &pull->add_pre, 1));
+	NUTS_TRUE(expect(pull, &pull->add_post, 1));
+	NUTS_TRUE(expect(pull, &pull->rem, 0));
+	NUTS_TRUE(expect(pull, &pull->err, 0));
+	NUTS_TRUE(expect(push, &push->add_pre, 1));
+	NUTS_TRUE(expect(push, &push->add_post, 1));
+	NUTS_TRUE(expect(push, &push->rem, 0));
+	NUTS_TRUE(expect(push, &push->err, 0));
+}
+
+static void
+check_pipe_scheme(nng_pipe p, const char *want)
+{
+	const char *scheme;
+
+	scheme = NULL;
+	NUTS_PASS(nng_pipe_get_scheme(p, &scheme));
+	NUTS_MATCH(scheme, want);
+}
+
+static void
 test_pipe_msg_id(void)
 {
 	static struct testcase push = { 0 };
@@ -160,18 +185,7 @@ test_pipe_msg_id(void)
 
 	init_cases(addr, &push, &pull);
 
-	NUTS_PASS(nng_listener_start(pull.l, 0));
-	NUTS_PASS(nng_dialer_start(push.d, 0));
-	NUTS_TRUE(expect(&pull, &pull.add_pre, 1));
-	NUTS_TRUE(expect(&pull, &pull.add_post, 1));
-	NUTS_TRUE(expect(&pull, &pull.add_pre, 1));
-	NUTS_TRUE(expect(&pull, &pull.add_post, 1));
-	NUTS_TRUE(expect(&pull, &pull.rem, 0));
-	NUTS_TRUE(expect(&pull, &pull.err, 0));
-	NUTS_TRUE(expect(&push, &push.add_pre, 1));
-	NUTS_TRUE(expect(&push, &push.add_post, 1));
-	NUTS_TRUE(expect(&push, &push.rem, 0));
-	NUTS_TRUE(expect(&push, &push.err, 0));
+	start_cases(&push, &pull);
 
 	NUTS_PASS(nng_msg_alloc(&msg, 0));
 	NUTS_PASS(nng_msg_append(msg, "hello", strlen("hello") + 1));
@@ -183,6 +197,46 @@ test_pipe_msg_id(void)
 	NUTS_MATCH(nng_msg_body(msg), "hello");
 	NUTS_TRUE(nng_pipe_id(nng_msg_get_pipe(msg)) == nng_pipe_id(pull.p));
 	nng_msg_free(msg);
+	fini_cases(&push, &pull);
+}
+
+static void
+test_pipe_dialer_scheme(void)
+{
+	struct testcase push = { 0 };
+	struct testcase pull = { 0 };
+	char           *addr;
+
+	NUTS_ADDR(addr, "inproc");
+
+	init_cases(addr, &push, &pull);
+	start_cases(&push, &pull);
+
+	NUTS_TRUE(
+	    nng_dialer_id(nng_pipe_dialer(push.p)) == nng_dialer_id(push.d));
+	NUTS_TRUE(nng_listener_id(nng_pipe_listener(push.p)) < 0);
+	check_pipe_scheme(push.p, "inproc");
+
+	fini_cases(&push, &pull);
+}
+
+static void
+test_pipe_listener_scheme(void)
+{
+	struct testcase push = { 0 };
+	struct testcase pull = { 0 };
+	char           *addr;
+
+	NUTS_ADDR(addr, "inproc");
+
+	init_cases(addr, &push, &pull);
+	start_cases(&push, &pull);
+
+	NUTS_TRUE(nng_dialer_id(nng_pipe_dialer(pull.p)) < 0);
+	NUTS_TRUE(nng_listener_id(nng_pipe_listener(pull.p)) ==
+	    nng_listener_id(pull.l));
+	check_pipe_scheme(pull.p, "inproc");
+
 	fini_cases(&push, &pull);
 }
 
@@ -270,15 +324,19 @@ test_pipe_invalid(void)
 {
 	nng_pipe     p;
 	nng_sockaddr sa;
+	const char  *scheme;
 	p.id = 45; // a random invalid pipe
 
 	NUTS_FAIL(nng_pipe_peer_addr(p, &sa), NNG_ENOENT);
 	NUTS_FAIL(nng_pipe_self_addr(p, &sa), NNG_ENOENT);
+	NUTS_FAIL(nng_pipe_get_scheme(p, &scheme), NNG_ENOENT);
 	NUTS_FAIL(nng_pipe_close(p), NNG_ENOENT);
 }
 
 NUTS_TESTS = {
 	{ "pipe msg id", test_pipe_msg_id },
+	{ "pipe dialer scheme", test_pipe_dialer_scheme },
+	{ "pipe listener scheme", test_pipe_listener_scheme },
 	{ "pipe reconnect", test_pipe_reconnect },
 	{ "pipe reject", test_pipe_reject },
 	{ "pipe invalid", test_pipe_invalid },


### PR DESCRIPTION
fixes #2228 add nng_pipe_get_scheme API

Adds `nng_pipe_get_scheme()` so applications can retrieve the URL scheme from the endpoint that created a pipe without first resolving the listener or dialer handle.
The implementation uses the pipe's stored creator endpoint and includes documentation plus pipe tests for both listener-side and dialer-side pipes.
Validated with `cmake --build build --target pipe_test -j 8` and `ctest --test-dir build -R '^nng\\.sp\\.pipe_test$' --output-on-failure`.

You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `nng_pipe_get_scheme()` API function to retrieve the URL scheme (tcp, ipc, inproc) associated with a pipe.

* **Documentation**
  * Added documentation for the pipe scheme accessor, including function signature and error handling details.

* **Tests**
  * Added test coverage for retrieving pipe schemes from dialer and listener endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->