### PR TITLE
Increase UDP socket buffers

### DIFF
--- a/src/platform/posix/posix_udp.c
+++ b/src/platform/posix/posix_udp.c
@@ -31,6 +31,10 @@
 #define MSG_NOSIGNAL 0
 #endif
 
+#ifndef NNG_UDP_SOCK_BUFSZ
+#define NNG_UDP_SOCK_BUFSZ (1024 * 1024)
+#endif
+
 #ifndef NNG_HAVE_INET6
 #ifdef NNG_HAVE_INET6_BSD
 #define NNG_HAVE_INET6
@@ -87,6 +91,26 @@ nni_posix_udp_doclose(nni_plat_udp *udp)
 #if !defined(NNG_HAVE_RECVMSG) || !defined(NNG_HAVE_SENDMSG)
 static uint8_t bouncebuf[65536];
 #endif
+
+static void
+nni_posix_udp_set_bufsize(int fd)
+{
+#if defined(SOL_SOCKET) && \
+    (defined(SO_RCVBUF) || defined(SO_SNDBUF))
+	int bufsz = NNG_UDP_SOCK_BUFSZ;
+
+#ifdef SO_RCVBUF
+	(void) setsockopt(
+	    fd, SOL_SOCKET, SO_RCVBUF, &bufsz, (socklen_t) sizeof(bufsz));
+#endif
+#ifdef SO_SNDBUF
+	(void) setsockopt(
+	    fd, SOL_SOCKET, SO_SNDBUF, &bufsz, (socklen_t) sizeof(bufsz));
+#endif
+#else
+	NNI_ARG_UNUSED(fd);
+#endif
+}
 
 #if !defined(NNG_HAVE_RECVMSG)
 static int
@@ -346,6 +370,7 @@ nni_plat_udp_open(nni_plat_udp **upp, const nni_sockaddr *bindaddr)
 		NNI_FREE_STRUCT(udp);
 		return (rv);
 	}
+	nni_posix_udp_set_bufsize(udp->udp_fd);
 
 	if (bind(udp->udp_fd, (void *) &sa, salen) != 0) {
 		rv = nni_plat_errno(errno);

--- a/src/platform/windows/win_udp.c
+++ b/src/platform/windows/win_udp.c
@@ -18,6 +18,10 @@
 #include <malloc.h>
 #include <stdio.h>
 
+#ifndef NNG_UDP_SOCK_BUFSZ
+#define NNG_UDP_SOCK_BUFSZ (1024 * 1024)
+#endif
+
 struct nni_plat_udp {
 	SOCKET           s;
 	nni_mtx          lk;
@@ -32,6 +36,26 @@ struct nni_plat_udp {
 
 static void udp_recv_cb(nni_win_io *, int, size_t);
 static void udp_recv_start(nni_plat_udp *);
+
+static void
+nni_win_udp_set_bufsize(SOCKET s)
+{
+#if defined(SOL_SOCKET) && \
+    (defined(SO_RCVBUF) || defined(SO_SNDBUF))
+	int bufsz = NNG_UDP_SOCK_BUFSZ;
+
+#ifdef SO_RCVBUF
+	(void) setsockopt(
+	    s, SOL_SOCKET, SO_RCVBUF, (char *) &bufsz, sizeof(bufsz));
+#endif
+#ifdef SO_SNDBUF
+	(void) setsockopt(
+	    s, SOL_SOCKET, SO_SNDBUF, (char *) &bufsz, sizeof(bufsz));
+#endif
+#else
+	NNI_ARG_UNUSED(s);
+#endif
+}
 
 // nni_plat_udp_open initializes a UDP socket, binding to the local
 // address specified specified.
@@ -61,6 +85,7 @@ nni_plat_udp_open(nni_plat_udp **udpp, const nni_sockaddr *sa)
 		nni_plat_udp_close(u);
 		return (rv);
 	}
+	nni_win_udp_set_bufsize(u->s);
 	// Don't inherit the handle (CLOEXEC really).
 	SetHandleInformation((HANDLE) u->s, HANDLE_FLAG_INHERIT, 0);
 	no = 0;


### PR DESCRIPTION
Increase UDP socket send and receive buffers to 1 MiB on POSIX and Windows.

The `setsockopt` calls are best-effort and conditionalized behind `SOL_SOCKET`, `SO_RCVBUF`, and `SO_SNDBUF`, so platforms without those macros build with a no-op.
This should reduce DTLS flakes caused by dropped UDP datagrams under CI scheduling pressure.
Validated with focused OpenSSL DTLS, UDP platform, UDP transport, and whitespace checks.
You agree that by submitting a PR, you have read and agreed to our contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * UDP socket buffer sizes are now initialized to 1MB by default for both Windows and POSIX platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->