### PR TITLE
feat: aio with skippable callback (fixes #2235)

### DIFF
--- a/docs/ref/api/aio.md
+++ b/docs/ref/api/aio.md
@@ -28,6 +28,7 @@ An {{i:`nng_aio`}}{{hi:aio}} is an opaque structure used in conjunction with
 Every asynchronous operation uses one of these structures, each of which
 can only be used with a single operation at a time.
 
+{{hi:callback}}
 Asynchronous operations are performed without blocking calling application threads.
 Instead the application registers a callback function to be executed
 when the operation is complete (whether successfully or not).
@@ -165,6 +166,44 @@ This is the same test used internally by [`nng_aio_wait`].
 > [!IMPORTANT]
 > The caller is responsible for coordinating any use of this with any reuse of the _aio_.
 > Because the _aio_ can be reused use of this function can be racy.
+
+## Skipping Callbacks
+
+```c
+void nng_aio_skip_callback(nng_aio *aio, bool *skip);
+```
+
+Sometimes it is useful to avoid the use of a callback when an operation can be completed immediately
+without scheduling on an asynchronous thread.
+Applications can opt in to this behavior by calling {{i:`nng_aio_skip_callback`}}, which signals to
+the framework that instead of dispatching a completion callback, the value of _skip_ should be set
+to `true`, indicating that the operation finished immediately.
+
+After starting the operation, the consumer of the _aio_ should check the value of _skip_, and if it is
+true then the completion is finished and the results will be in the _aio_. The [callback] for the _aio_
+will _not_ be executed in this case. If the value is _false_, then the completion will be executed
+asynchronously.
+
+This function should be called before the operation is started, each time an operation is performed.
+The changes made by it to the _aio_ do not persist across operations.
+
+> [!TIP]
+> Use of this function can reduce overhead and latency by eliminating unnecessary context switching,
+> but it does require extra complexity on the part of the caller.
+
+### Example 1: Waiting for An Operation
+
+One of easiest ways to use this function is with [`nng_aio_wait`]. (In fact, the [`nng_sendmsg`] and
+[`nng_recvmsg`] family of functions do this internally.) For example:
+
+```c
+bool skipped;
+nng_aio_skip_callback(aio, &skipped);
+nng_ctx_send(ctx, aio);
+if (!skipped) {
+    nng_aio_wait(aio);
+}
+```
 
 ## Result of Operation
 

--- a/docs/ref/xref.md
+++ b/docs/ref/xref.md
@@ -104,6 +104,7 @@
 [`nng_aio_get_input`]: ../api/aio.md#inputs-and-outputs
 [`nng_aio_set_input`]: ../api/aio.md#inputs-and-outputs
 [`nng_aio_set_output`]: ../api/aio.md#inputs-and-outputs
+[`nng_aio_skip_callback`]: ../api/aio.md#skipping-callbacks
 [`nng_iov`]: ../api/aio.md#scatter-gather-vectors
 [`nng_socket_id`]: ../api/sock.md#socket-identity
 [`nng_socket_raw`]: ../api/sock.md#socket-identity

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -707,6 +707,17 @@ NNG_DECL void nng_aio_finish(nng_aio *, nng_err);
 typedef void (*nng_aio_cancelfn)(nng_aio *, void *, nng_err);
 NNG_DECL bool nng_aio_start(nng_aio *, nng_aio_cancelfn, void *);
 
+// nng_aio_skip_callback is set on aio to indicate that the caller would prefer
+// to have completion reported synchronously through the supplied bool pointer,
+// if possible. After the caller submits operation for work, it must check the
+// value of the pointed boolean, and if it is true then the function was
+// completed synchronously without any callback being fired.  This avoids
+// unnecessary context switching, but requires the caller to check the boolean
+// status and handle the result synchronously if it is true. If the operation
+// could not be completed synchronously, then the bool will be false, and the
+// callback will be executed on completion.
+NNG_DECL void nng_aio_skip_callback(nng_aio *, bool *);
+
 // nng_aio_sleep does a "sleeping" operation, basically does nothing
 // but wait for the specified number of milliseconds to expire, then
 // calls the callback.  This returns 0, rather than NNG_ETIMEDOUT.

--- a/src/core/aio.c
+++ b/src/core/aio.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -335,11 +335,12 @@ nni_aio_busy(nni_aio *aio)
 void
 nni_aio_reset(nni_aio *aio)
 {
-	aio->a_result    = NNG_OK;
-	aio->a_count     = 0;
-	aio->a_abort     = false;
-	aio->a_expire_ok = false;
-	aio->a_sleep     = false;
+	aio->a_result           = NNG_OK;
+	aio->a_count            = 0;
+	aio->a_abort            = false;
+	aio->a_expire_ok        = false;
+	aio->a_sleep            = false;
+	aio->a_skipped_callback = NULL;
 
 	for (unsigned i = 0; i < NNI_NUM_ELEMENTS(aio->a_outputs); i++) {
 		aio->a_outputs[i] = NULL;
@@ -372,6 +373,11 @@ nni_aio_start(nni_aio *aio, nni_aio_cancel_fn cancel, void *data)
 	if (!aio->a_sleep) {
 		aio->a_expire_ok = false;
 	}
+
+	// If we're going to run asynchronously, we cannot skip the completion
+	// callback.
+	aio->a_skipped_callback = NULL;
+
 	// Do this outside the lock.  Note that we don't strictly need to have
 	// done this for the failure cases below (the task framework does the
 	// right thing if the task isn't prepped), but those should be uncommon
@@ -463,6 +469,7 @@ nni_aio_finish_impl(
     nni_aio *aio, nng_err rv, size_t count, nni_msg *msg, bool sync)
 {
 	nni_aio_expire_q *eq = aio->a_expire_q;
+	bool             *skipped_cb;
 
 	nni_mtx_lock(&eq->eq_mtx);
 
@@ -475,12 +482,16 @@ nni_aio_finish_impl(
 		aio->a_msg = msg;
 	}
 
-	aio->a_expire     = NNI_TIME_NEVER;
-	aio->a_sleep      = false;
-	aio->a_use_expire = false;
+	aio->a_expire           = NNI_TIME_NEVER;
+	aio->a_sleep            = false;
+	aio->a_use_expire       = false;
+	skipped_cb              = aio->a_skipped_callback;
+	aio->a_skipped_callback = NULL;
 	nni_mtx_unlock(&eq->eq_mtx);
 
-	if (sync) {
+	if (skipped_cb != NULL) {
+		*skipped_cb = true;
+	} else if (sync) {
 		nni_task_exec(&aio->a_task);
 	} else {
 		nni_task_dispatch(&aio->a_task);
@@ -510,6 +521,13 @@ nni_aio_finish_msg(nni_aio *aio, nni_msg *msg)
 {
 	NNI_ASSERT(msg != NULL);
 	nni_aio_finish_impl(aio, 0, nni_msg_len(msg), msg, false);
+}
+
+void
+nni_aio_skip_callback(nni_aio *aio, bool *skipped_callback)
+{
+	*skipped_callback       = false;
+	aio->a_skipped_callback = skipped_callback;
 }
 
 void

--- a/src/core/aio.h
+++ b/src/core/aio.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -173,6 +173,12 @@ extern bool nni_aio_start(nni_aio *, nni_aio_cancel_fn, void *);
 
 extern void nni_sleep_aio(nni_duration, nni_aio *);
 
+// nni_aio_skip_callback indicates that the caller would like to not run a
+// callback if the operation can complete synchronously, and instead be
+// notified by having the boolean variable marked true if the operation was
+// completed synchronously.
+extern void nni_aio_skip_callback(nni_aio *, bool *);
+
 // nni_aio_completion_list is used after removing the aio from an
 // active work queue, and keeping them so that the completions can
 // be run in a deferred manner.  These lists are simple, and intended
@@ -238,6 +244,15 @@ struct nng_aio {
 	// specific operation.
 	void *a_inputs[4];
 	void *a_outputs[4];
+
+	// If non-nil, then when the aio is completed, instead of running the
+	// callback, the addressed boolean will be set to true.  This allows
+	// for a caller to process synchronous completions without relying an a
+	// thread dispatch, which can be used to obtain lower latency at the
+	// cost of more complex processing on the part of the consumer.  The
+	// value pointed to must be false before calling starting an operation.
+	// This pointer is cleared by nng_aio_start.
+	bool *a_skipped_callback;
 
 	// Provider-use fields.
 	nni_aio_cancel_fn a_cancel_fn;

--- a/src/nng.c
+++ b/src/nng.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -8,6 +8,7 @@
 // found online at https://opensource.org/licenses/MIT.
 //
 
+#include "core/aio.h"
 #include "core/alloc.h"
 #include "core/defs.h"
 #include "core/nng_impl.h"
@@ -96,12 +97,14 @@ nng_recvmsg(nng_socket s, nng_msg **msgp, int flags)
 	int       rv;
 	nni_sock *sock;
 	nni_aio   aio;
+	bool      skipped;
 
 	if ((rv = nni_sock_find(&sock, s.id)) != 0) {
 		return (rv);
 	}
 
 	nni_aio_init(&aio, NULL, NULL);
+	nni_aio_skip_callback(&aio, &skipped);
 	if (flags & NNG_FLAG_NONBLOCK) {
 		nng_aio_set_timeout(&aio, NNG_DURATION_ZERO);
 	} else {
@@ -110,7 +113,9 @@ nng_recvmsg(nng_socket s, nng_msg **msgp, int flags)
 	nni_sock_recv(sock, &aio);
 	nni_sock_rele(sock);
 
-	nni_aio_wait(&aio);
+	if (!skipped) {
+		nni_aio_wait(&aio);
+	}
 
 	if ((rv = nni_aio_result(&aio)) == 0) {
 		*msgp = nng_aio_get_msg(&aio);
@@ -147,6 +152,7 @@ nng_sendmsg(nng_socket s, nng_msg *msg, int flags)
 	int       rv;
 	nni_aio   aio;
 	nni_sock *sock;
+	bool      skipped;
 
 	if (msg == NULL) {
 		return (NNG_EINVAL);
@@ -156,6 +162,7 @@ nng_sendmsg(nng_socket s, nng_msg *msg, int flags)
 	}
 
 	nni_aio_init(&aio, NULL, NULL);
+	nni_aio_skip_callback(&aio, &skipped);
 	if ((flags & NNG_FLAG_NONBLOCK) == NNG_FLAG_NONBLOCK) {
 		nni_aio_set_timeout(&aio, NNG_DURATION_ZERO);
 	} else {
@@ -166,7 +173,9 @@ nng_sendmsg(nng_socket s, nng_msg *msg, int flags)
 	nni_sock_send(sock, &aio);
 	nni_sock_rele(sock);
 
-	nni_aio_wait(&aio);
+	if (!skipped) {
+		nni_aio_wait(&aio);
+	}
 	rv = nni_aio_result(&aio);
 	nni_aio_fini(&aio);
 
@@ -262,12 +271,14 @@ nng_ctx_recvmsg(nng_ctx cid, nng_msg **msgp, int flags)
 	int      rv;
 	nni_aio  aio;
 	nni_ctx *ctx;
+	bool     skipped;
 
 	if ((rv = nni_ctx_find(&ctx, cid.id)) != 0) {
 		return (rv);
 	}
 
 	nni_aio_init(&aio, NULL, NULL);
+	nni_aio_skip_callback(&aio, &skipped);
 	if (flags & NNG_FLAG_NONBLOCK) {
 		nng_aio_set_timeout(&aio, NNG_DURATION_ZERO);
 	} else {
@@ -276,7 +287,9 @@ nng_ctx_recvmsg(nng_ctx cid, nng_msg **msgp, int flags)
 	nni_ctx_recv(ctx, &aio);
 	nni_ctx_rele(ctx);
 
-	nni_aio_wait(&aio);
+	if (!skipped) {
+		nni_aio_wait(&aio);
+	}
 
 	if ((rv = nni_aio_result(&aio)) == 0) {
 		*msgp = nng_aio_get_msg(&aio);
@@ -330,6 +343,7 @@ nng_ctx_sendmsg(nng_ctx cid, nng_msg *msg, int flags)
 	int      rv;
 	nni_aio  aio;
 	nni_ctx *ctx;
+	bool     skipped;
 
 	if (msg == NULL) {
 		return (NNG_EINVAL);
@@ -339,6 +353,7 @@ nng_ctx_sendmsg(nng_ctx cid, nng_msg *msg, int flags)
 	}
 
 	nni_aio_init(&aio, NULL, NULL);
+	nni_aio_skip_callback(&aio, &skipped);
 	if ((flags & NNG_FLAG_NONBLOCK) == NNG_FLAG_NONBLOCK) {
 		nni_aio_set_timeout(&aio, NNG_DURATION_ZERO);
 	} else {
@@ -349,7 +364,9 @@ nng_ctx_sendmsg(nng_ctx cid, nng_msg *msg, int flags)
 	nni_ctx_send(ctx, &aio);
 	nni_ctx_rele(ctx);
 
-	nni_aio_wait(&aio);
+	if (!skipped) {
+		nni_aio_wait(&aio);
+	}
 	rv = nni_aio_result(&aio);
 	nni_aio_fini(&aio);
 
@@ -2091,6 +2108,12 @@ nng_aio_start(nng_aio *aio, nng_aio_cancelfn fn, void *arg)
 {
 	nni_aio_reset(aio);
 	return (nni_aio_start(aio, fn, arg));
+}
+
+void
+nng_aio_skip_callback(nng_aio *aio, bool *skipped_callback)
+{
+	nni_aio_skip_callback(aio, skipped_callback);
 }
 
 void

--- a/src/sp/protocol/pubsub0/sub_test.c
+++ b/src/sp/protocol/pubsub0/sub_test.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -45,6 +45,7 @@ test_sub_context_cannot_send(void)
 	nng_ctx    ctx;
 	nng_msg   *m;
 	nng_aio   *aio;
+	bool       skipped;
 
 	NUTS_PASS(nng_sub0_open(&sub));
 	NUTS_PASS(nng_ctx_open(&ctx, sub));
@@ -52,8 +53,11 @@ test_sub_context_cannot_send(void)
 	NUTS_PASS(nng_aio_alloc(&aio, NULL, NULL));
 	nng_aio_set_msg(aio, m);
 	nng_aio_set_timeout(aio, 1000);
+	nng_aio_skip_callback(aio, &skipped);
 	nng_ctx_send(ctx, aio);
-	nng_aio_wait(aio);
+	if (!skipped) {
+		nng_aio_wait(aio);
+	}
 	NUTS_FAIL(nng_aio_result(aio), NNG_ENOTSUP);
 	NUTS_PASS(nng_ctx_close(ctx));
 	NUTS_CLOSE(sub);


### PR DESCRIPTION
fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AIO helper to detect immediate completion and optionally skip dispatching the completion callback, reporting this via a boolean instead.
* **Documentation**
  * Updated the AIO API reference with a “Skipping Callbacks” section and added a symbol cross-reference entry.
* **Bug Fixes**
  * Improved message send/receive behavior to avoid waiting when operations complete immediately.
* **Tests**
  * Adjusted pub/sub test logic to account for immediate-completion skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->