### PR TITLE
[codex] Document DTLS transport

### DIFF
--- a/docs/ref/SUMMARY.md
+++ b/docs/ref/SUMMARY.md
@@ -72,6 +72,7 @@
   - [Inter-Process Transport](./tran/ipc.md)
   - [TCP Transport](./tran/tcp.md)
   - [TLS Transport](./tran/tls.md)
+  - [DTLS Transport (Experimental)](./tran/dtls.md)
   - [WebSocket Transport](./tran/websocket.md)
   - [BSD Socket (Experimental)](./tran/socket.md)
   - [UDP Transport (Experimental)](./tran/udp.md)

--- a/docs/ref/api/tls.md
+++ b/docs/ref/api/tls.md
@@ -2,8 +2,8 @@
 
 NNG provides {{i:TLS}} ({{i:Transport Layer Security}}) support for transports and
 stream-based services that need encrypted and authenticated communication.
-TLS is used by the [TLS transport], secure [WebSocket transport], HTTP clients and servers,
-and raw [streams] implementations that support it.
+TLS is used by the [TLS transport], [DTLS transport], secure [WebSocket transport],
+HTTP clients and servers, and raw [streams] implementations that support it.
 
 TLS support depends on a TLS engine being available when NNG is built.
 If TLS support is not enabled, the TLS functions may be present as stubs and will return

--- a/docs/ref/tran/dtls.md
+++ b/docs/ref/tran/dtls.md
@@ -1,0 +1,123 @@
+# DTLS Transport (Experimental)
+
+## DESCRIPTION
+
+The {{i:*dtls* transport}}{{hi:*dtls*}} provides encrypted and authenticated
+communication between peers using {{i:DTLS}} over {{i:UDP}}.
+Both {{i:IPv4}} and {{i:IPv6}} are supported when the underlying platform
+supports them.
+
+DTLS provides TLS-like security for datagram transports. This transport is
+message-oriented and preserves NNG message boundaries, but it is still based on
+UDP and does not provide TCP-style reliable delivery. Applications should avoid
+large messages and should tolerate message loss caused by the network.
+
+TLS configuration objects and certificate APIs are documented in [TLS].
+DTLS [dialers][dialer] and [listeners][listener] must be configured with
+[`nng_dialer_set_tls`] or [`nng_listener_set_tls`] before they are started.
+
+> [!NOTE]
+> This transport is _experimental_.
+> It requires TLS support and the `NNG_TRANSPORT_DTLS` build option.
+> It supports unicast UDP endpoints only; multicast and broadcast are not
+> supported.
+
+### URI Formats
+
+This transport uses URIs using the scheme {{i:`dtls://`}}, followed by an
+{{i:IP address}} or {{i:hostname}}, and a UDP port number.
+For example, `dtls://127.0.0.1:4433` and `dtls://localhost:4433`
+both refer to port 4433 on the local host.
+
+For IPv6 literal addresses, the IPv6 address must be enclosed in square brackets,
+then the colon and finally the UDP port.
+For example, `dtls://[::1]:4433` refers to port 4433 on the IPv6 loopback
+address.
+
+#### Forcing IPv4 or IPv6
+
+To force either IPv4 or IPv6, the scheme may be specified as `dtls4://` or
+`dtls6://`.
+This should only be needed when a hostname might resolve to either address family.
+
+> [!NOTE]
+> Specifying `dtls6://` may not prevent IPv4 hosts from being used with
+> IPv4-in-IPv6 addresses, particularly when listening on wildcard addresses.
+> The details vary across operating systems.
+> The `dtls4://` and `dtls6://` schemes are specific to NNG.
+
+#### Listening to All Addresses
+
+When listening, a zero IP address can be supplied by either eliding the address
+altogether, or by specifying `0.0.0.0` (IPv4) or `::` (IPv6) explicitly.
+If left empty, IPv6 will be selected if available on the host, otherwise IPv4
+will be selected.
+
+For example, the following URIs are equivalent for listening on UDP port 9999:
+
+- `dtls://0.0.0.0:9999`
+- `dtls://:9999`
+
+> [!TIP]
+> Certificate validation generally works best when clients use host names rather
+> than IP addresses.
+> Configure the expected server name with [`nng_tls_config_server_name`] when the
+> certificate identity differs from the URL host, or when an IP address is used.
+
+### TLS Configuration
+
+DTLS endpoints use [`nng_tls_config`] objects in the same way as the [TLS transport].
+Listeners normally use a server-mode configuration with a local certificate and
+private key.
+Dialers normally use a client-mode configuration with certificate authority
+material and the expected server name.
+Pre-shared key configurations may also be used when supported by the selected TLS
+engine.
+
+The TLS configuration must be set before the dialer or listener is started.
+After a DTLS endpoint has started, attempts to change its TLS configuration or
+its receive maximum will fail with [`NNG_EBUSY`].
+
+Peer certificates can be obtained from connected pipes with [`nng_pipe_peer_cert`],
+subject to the TLS engine's certificate support and the authentication mode.
+
+### Socket Address
+
+When using an [`nng_sockaddr`] structure,
+the concrete type is either [`nng_sockaddr_in`] or [`nng_sockaddr_in6`],
+depending on whether IPv4 or IPv6 is in use.
+
+### Transport Options
+
+The following transport options are supported by this transport,
+where supported by the underlying platform.
+Options that change connection behavior must be set before the dialer or
+listener is started.
+
+| Option                                                | Type     | Description                                                                                                                     |
+| ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| [`NNG_OPT_RECVMAXSZ`]                                 | `size_t` | Maximum size of incoming messages. Values larger than the DTLS transport maximum are clamped to the transport maximum.          |
+| `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a> | `int`    | The locally bound UDP port number (1-65535), read-only for [listener] objects only.                                             |
+
+The DTLS transport does not support TCP-specific options such as
+`NNG_OPT_TCP_NODELAY` or `NNG_OPT_TCP_KEEPALIVE`.
+
+### Maximum Message Size
+
+This transport maps each NNG message to a DTLS record carried over UDP.
+The transport maximum is smaller than the 16 KiB DTLS record size to leave room
+for DTLS and transport headers.
+The receive maximum can be configured with [`NNG_OPT_RECVMAXSZ`], but it cannot
+exceed the DTLS transport maximum.
+
+Applications are encouraged to use much smaller messages whenever possible.
+Large UDP datagrams are more likely to be fragmented at the IP layer, and a lost
+fragment causes the entire message to be lost.
+
+### Keep Alive
+
+DTLS maintains a logical connection for each peer and uses periodic transport
+control messages to refresh that state.
+Peers that are inactive for too long are closed and their resources are reclaimed.
+
+{{#include ../xref.md}}

--- a/docs/ref/tran/index.md
+++ b/docs/ref/tran/index.md
@@ -6,6 +6,7 @@ This section documents transports for Scalability Protocols implemented by NNG.
 - [Inter-Process Transport](ipc.md)
 - [TCP](tcp.md)
 - [TLS](tls.md)
+- [DTLS](dtls.md)
 - [WebSocket](websocket.md)
 - [BSD Socket](socket.md)
 - [UDP](udp.md)

--- a/docs/ref/xref.md
+++ b/docs/ref/xref.md
@@ -592,6 +592,7 @@
 [tcp]: ../tran/tcp.md
 [TLS]: ../api/tls.md
 [TLS transport]: ../tran/tls.md
+[DTLS transport]: ../tran/dtls.md
 [WebSocket transport]: ../tran/websocket.md
 [udp]: ../tran/udp.md
 [url]: ../api/url.md


### PR DESCRIPTION
fixes #2276 Document DTLS transport

Adds reference documentation for the experimental DTLS transport, including URL schemes, TLS configuration, socket address behavior, supported options, message size guidance, and keep-alive behavior. It also wires the page into the transport index and mdBook summary, and updates the TLS API overview to mention DTLS. Validated with `mdbook build docs`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for the experimental DTLS transport, including setup, supported URI formats, configuration options, and usage notes.
  * Added DTLS entries to the transport index, cross-references, and summary navigation.

* **Documentation**
  * Updated TLS-related reference text to include DTLS alongside other secure transport options and broaden the listed supported use cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->