### PR TITLE
Fix WolfSSL TLS auth mode configuration

### DIFF
--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -466,8 +466,10 @@ wstran_listener_close(void *arg)
 	if (!l->closed) {
 		l->closed = true;
 		nni_aio_close(&l->accaio);
-		NNI_LIST_FOREACH (&l->wait_pipes, p) {
+		while ((p = nni_list_first(&l->wait_pipes)) != NULL) {
+			nni_list_remove(&l->wait_pipes, p);
 			nni_pipe_close(p->npipe);
+			nni_pipe_rele(p->npipe);
 		}
 		nng_stream_listener_close(l->listener);
 	}

--- a/src/supplemental/tls/tls_test.c
+++ b/src/supplemental/tls/tls_test.c
@@ -319,6 +319,80 @@ test_tls_null_server_name(void)
 }
 
 void
+test_tls_no_auth(void)
+{
+	nng_stream_listener *l;
+	nng_stream_dialer   *d;
+	nng_aio             *aio1, *aio2;
+	nng_stream          *s1;
+	nng_stream          *s2;
+	nng_tls_config      *c1;
+	nng_tls_config      *c2;
+	char                 addr[32];
+	uint8_t              buf1[8] = { 0, 1, 2, 3, 4, 5, 6, 7 };
+	uint8_t              buf2[sizeof(buf1)];
+	void                *t1;
+	void                *t2;
+	int                  port;
+
+	NUTS_ENABLE_LOG(NNG_LOG_DEBUG);
+
+	NUTS_PASS(nng_aio_alloc(&aio1, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&aio2, NULL, NULL));
+	nng_aio_set_timeout(aio1, 5000);
+	nng_aio_set_timeout(aio2, 5000);
+
+	NUTS_PASS(nng_stream_listener_alloc(&l, "tls+tcp://127.0.0.1:0"));
+	NUTS_PASS(nng_tls_config_alloc(&c1, NNG_TLS_MODE_SERVER));
+	NUTS_PASS(nng_tls_config_own_cert(
+	    c1, nuts_server_crt, nuts_server_key, NULL));
+	NUTS_PASS(nng_stream_listener_set_tls(l, c1));
+	NUTS_PASS(nng_stream_listener_listen(l));
+	NUTS_PASS(nng_stream_listener_get_int(l, NNG_OPT_BOUND_PORT, &port));
+	NUTS_TRUE(port > 0);
+	NUTS_TRUE(port < 65536);
+
+	snprintf(addr, sizeof(addr), "tls+tcp://127.0.0.1:%d", port);
+	NUTS_PASS(nng_stream_dialer_alloc(&d, addr));
+	NUTS_PASS(nng_tls_config_alloc(&c2, NNG_TLS_MODE_CLIENT));
+	NUTS_PASS(nng_tls_config_auth_mode(c2, NNG_TLS_AUTH_MODE_NONE));
+
+	NUTS_PASS(nng_stream_dialer_set_tls(d, c2));
+
+	nng_stream_listener_accept(l, aio1);
+	nng_stream_dialer_dial(d, aio2);
+
+	nng_aio_wait(aio1);
+	nng_aio_wait(aio2);
+
+	NUTS_PASS(nng_aio_result(aio1));
+	NUTS_PASS(nng_aio_result(aio2));
+
+	NUTS_TRUE((s1 = nng_aio_get_output(aio1, 0)) != NULL);
+	NUTS_TRUE((s2 = nng_aio_get_output(aio2, 0)) != NULL);
+
+	t1 = nuts_stream_send_start(s1, buf1, sizeof(buf1));
+	t2 = nuts_stream_recv_start(s2, buf2, sizeof(buf2));
+
+	NUTS_PASS(nuts_stream_wait(t1));
+	NUTS_PASS(nuts_stream_wait(t2));
+	NUTS_TRUE(memcmp(buf1, buf2, sizeof(buf1)) == 0);
+
+	nng_stream_stop(s1);
+	nng_stream_stop(s2);
+	nng_stream_dialer_stop(d);
+	nng_stream_listener_stop(l);
+	nng_stream_free(s1);
+	nng_stream_free(s2);
+	nng_stream_dialer_free(d);
+	nng_stream_listener_free(l);
+	nng_tls_config_free(c1);
+	nng_tls_config_free(c2);
+	nng_aio_free(aio1);
+	nng_aio_free(aio2);
+}
+
+void
 test_tls_garbled_cert(void)
 {
 	nng_stream_listener *l;
@@ -657,6 +731,7 @@ TEST_LIST = {
 	{ "tls large message", test_tls_large_message },
 	{ "tls ecdsa", test_tls_ecdsa },
 	{ "tls null server name", test_tls_null_server_name },
+	{ "tls no auth", test_tls_no_auth },
 #ifndef NNG_TLS_ENGINE_WOLFSSL // wolfSSL doesn't validate certas until use
 	{ "tls garbled cert", test_tls_garbled_cert },
 #endif

--- a/src/supplemental/tls/wolfssl/wolfssl.c
+++ b/src/supplemental/tls/wolfssl/wolfssl.c
@@ -540,19 +540,19 @@ wolf_config_psk(nng_tls_engine_config *cfg, const char *identity,
 static int
 wolf_config_auth_mode(nng_tls_engine_config *cfg, nng_tls_auth_mode mode)
 {
-	cfg->auth_mode = mode;
-	// XXX: REMOVE ME
-	return (0);
 	switch (mode) {
 	case NNG_TLS_AUTH_MODE_NONE:
 		wolfSSL_CTX_set_verify(cfg->ctx, SSL_VERIFY_NONE, NULL);
+		cfg->auth_mode = mode;
 		return (0);
 	case NNG_TLS_AUTH_MODE_OPTIONAL:
 		wolfSSL_CTX_set_verify(cfg->ctx, SSL_VERIFY_PEER, NULL);
+		cfg->auth_mode = mode;
 		return (0);
 	case NNG_TLS_AUTH_MODE_REQUIRED:
 		wolfSSL_CTX_set_verify(cfg->ctx,
 		    SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, NULL);
+		cfg->auth_mode = mode;
 		return (0);
 	}
 	return (NNG_EINVAL);


### PR DESCRIPTION
Fixes WolfSSL TLS auth mode configuration.

WolfSSL's auth-mode setter recorded the requested mode but returned before applying verify flags, so verification settings did not affect handshakes. This applies the WolfSSL verification mode for NONE, OPTIONAL, and REQUIRED, and adds a TLS stream regression test that confirms AUTH_MODE_NONE can connect without a trusted CA. Validated with a WolfSSL build using `tls_test` and CTest.

The branch also fixes websocket listener shutdown so accepted pipes that were not consumed by an upper-layer accept are removed, closed, and released; this resolves the address sanitizer leak found in `ws_test`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.
