### PR TITLE
fix(security): bound receive message sizes by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,22 @@ if (NNG_UDP_CONNRETRY)
     add_definitions(-DNNG_UDP_CONNRETRY=${NNG_UDP_CONNRETRY})
 endif()
 
+set(NNG_RECVMAXSZ_DEFAULT 1073741824 CACHE STRING "Default max receive size in bytes")
+mark_as_advanced(NNG_RECVMAXSZ_DEFAULT)
+if (NNG_RECVMAXSZ_DEFAULT LESS 0)
+    message(FATAL_ERROR "NNG_RECVMAXSZ_DEFAULT cannot be negative")
+endif()
+if (CMAKE_SIZEOF_VOID_P LESS 8 AND NNG_RECVMAXSZ_DEFAULT GREATER 4294967295)
+    message(FATAL_ERROR "NNG_RECVMAXSZ_DEFAULT cannot exceed 4294967295 on 32-bit platforms")
+endif()
+if (NNG_RECVMAXSZ_DEFAULT GREATER 1152921504606846975)
+    message(FATAL_ERROR "NNG_RECVMAXSZ_DEFAULT cannot exceed 2^60-1")
+endif()
+if (NNG_RECVMAXSZ_DEFAULT GREATER 4294967295)
+    message(WARNING "NNG_RECVMAXSZ_DEFAULT above 4GiB will not be compatible with 32-bit peers")
+endif()
+add_definitions(-DNNG_RECVMAXSZ_DEFAULT=${NNG_RECVMAXSZ_DEFAULT})
+
 #  Platform checks.
 
 if (CMAKE_C_COMPILER_ID STREQUAL "GNU")

--- a/docs/ref/api/sock.md
+++ b/docs/ref/api/sock.md
@@ -316,7 +316,7 @@ The following options are available for many protocols, and always use the same 
 | `NNG_OPT_RECONNMAXT`<a name="NNG_OPT_RECONNMAXT"></a> | `nng_duration` | Maximum time [dialers][dialer] will delay before trying after failing to connect.                                                                                                 |
 | `NNG_OPT_RECONNMINT`<a name="NNG_OPT_RECONNMINT"></a> | `nng_duration` | Minimum time [dialers][dialer] will delay before trying after failing to connect.                                                                                                 |
 | `NNG_OPT_RECVBUF`<a name="NNG_OPT_RECVBUF"></a>       | `int`          | Maximum number of messages (0-8192) to buffer locally when receiving. Not all protocols support receive-side buffering.                                                          |
-| `NNG_OPT_RECVMAXSZ`<a name="NNG_OPT_RECVMAXSZ"></a>   | `size_t`       | Maximum message size acceptable for receiving. Zero means unlimited. Intended to prevent remote abuse. Can be tuned independently on [dialers][dialer] and [listeners][listener]. |
+| `NNG_OPT_RECVMAXSZ`<a name="NNG_OPT_RECVMAXSZ"></a>   | `size_t`       | Maximum message size acceptable for receiving. Defaults to 1 GiB unless changed at build time. Zero means unlimited. On 64-bit platforms, values above 4 GiB can be configured but are not compatible with 32-bit peers. Intended to prevent remote abuse. Can be tuned independently on [dialers][dialer] and [listeners][listener]. |
 | `NNG_OPT_RECVTIMEO`<a name="NNG_OPT_RECVTIMEO"></a>   | `nng_duration` | Default timeout (ms) for receiving messages.                                                                                                                                      |
 | `NNG_OPT_SENDBUF`<a name="NNG_OPT_SENDBUF"></a>       | `int`          | Maximum number of messages (0-8192) to buffer when sending messages.                                                                                                              |
 | `NNG_OPT_SENDTIMEO`<a name="NNG_OPT_SENDTIMEO"></a>   | `nng_duration` | Default timeout (ms) for sending messages.                                                                                                                                        |
@@ -331,7 +331,7 @@ The following options are available for many protocols, and always use the same 
 > [!NOTE]
 > `NNG_OPT_RECVMAXSZ` should be configured before creating dialers or
 > listeners, especially on hostile networks.
-> Setting it to a non-zero value helps defend against denial-of-service cases
+> Keeping it set to a non-zero value helps defend against denial-of-service cases
 > where a peer claims an extremely large message size without actually sending
 > the payload.
 

--- a/docs/ref/migrate/nng1.md
+++ b/docs/ref/migrate/nng1.md
@@ -297,6 +297,19 @@ The latter option is a hint for transports and intended to facilitate early
 detection (and possibly avoidance of extra allocations) of oversize messages,
 before bringing them into the socket itself.
 
+The default value for [`NNG_OPT_RECVMAXSZ`] changed from unlimited to 1 GiB.
+Applications that need to receive larger messages must opt in by setting this
+option explicitly, or by configuring `NNG_RECVMAXSZ_DEFAULT` at build time.
+Setting the option to zero restores unlimited behavior.
+On 64-bit platforms, values above 4 GiB can be configured up to the 60-bit
+message size limit, but they are not compatible with 32-bit peers.
+
+> [!CAUTION]
+> Applications should set [`NNG_OPT_RECVMAXSZ`] to the smallest practical value
+> for their message format, especially when accepting traffic from remote peers.
+> Larger values increase exposure to denial-of-service attacks from peers that
+> claim very large message sizes.
+
 The `NNG_OPT_TCP_BOUND_PORT` port is renamed to just [`NNG_OPT_BOUND_PORT`],
 and is available for listeners using transports based on either TCP or UDP.
 

--- a/src/core/defs.h
+++ b/src/core/defs.h
@@ -78,6 +78,29 @@ typedef void (*nni_cb)(void *);
 #define NNI_TIME_ZERO ((nni_time) 0)
 #define NNI_SECOND (1000)
 
+// Receive size defaults and wire limits.
+#ifndef NNG_RECVMAXSZ_DEFAULT
+#define NNG_RECVMAXSZ_DEFAULT (1U << 30)
+#endif
+
+#define NNI_RECVMAXSZ_DEFAULT ((size_t) NNG_RECVMAXSZ_DEFAULT)
+
+// Stream transports reserve the upper 4 bits of the 64-bit message size.
+#define NNI_MAX_STREAM_MSGSZ UINT64_C(0x0fffffffffffffff)
+
+#if SIZE_MAX < UINT64_C(0x0fffffffffffffff)
+#define NNI_MAX_RECVMAXSZ SIZE_MAX
+#else
+#define NNI_MAX_RECVMAXSZ ((size_t) NNI_MAX_STREAM_MSGSZ)
+#endif
+
+static inline bool
+nni_msg_size_valid(uint64_t size)
+{
+	return ((size <= NNI_MAX_STREAM_MSGSZ) &&
+	    (size <= (uint64_t) SIZE_MAX));
+}
+
 // Structure allocation conveniences.
 #define NNI_ALLOC_STRUCT(s) nni_zalloc(sizeof(*s))
 #define NNI_FREE_STRUCT(s) nni_free((s), sizeof(*s))

--- a/src/core/message.c
+++ b/src/core/message.c
@@ -98,6 +98,7 @@ static int
 nni_chunk_grow(nni_chunk *ch, size_t newsz, size_t headwanted)
 {
 	uint8_t *newbuf;
+	size_t   allocsz;
 
 	// We assume that if the pointer is a valid pointer, and inside
 	// the backing store, then the entire data length fits.  In this
@@ -111,6 +112,9 @@ nni_chunk_grow(nni_chunk *ch, size_t newsz, size_t headwanted)
 	// No shrinking (violets)
 	if (newsz < ch->ch_len) {
 		newsz = ch->ch_len;
+	}
+	if (headwanted > (SIZE_MAX - newsz)) {
+		return (NNG_ENOMEM);
 	}
 
 	if ((ch->ch_ptr >= ch->ch_buf) && (ch->ch_ptr != NULL) &&
@@ -131,7 +135,11 @@ nni_chunk_grow(nni_chunk *ch, size_t newsz, size_t headwanted)
 			newsz = ch->ch_cap - headroom;
 		}
 
-		if ((newbuf = nni_zalloc(newsz + headwanted)) == NULL) {
+		if (headwanted > (SIZE_MAX - newsz)) {
+			return (NNG_ENOMEM);
+		}
+		allocsz = newsz + headwanted;
+		if ((newbuf = nni_zalloc(allocsz)) == NULL) {
 			return (NNG_ENOMEM);
 		}
 		// Copy all the data, but not header or trailer.
@@ -141,19 +149,20 @@ nni_chunk_grow(nni_chunk *ch, size_t newsz, size_t headwanted)
 		nni_free(ch->ch_buf, ch->ch_cap);
 		ch->ch_buf = newbuf;
 		ch->ch_ptr = newbuf + headwanted;
-		ch->ch_cap = newsz + headwanted;
+		ch->ch_cap = allocsz;
 		return (0);
 	}
 
 	// We either don't have a data pointer yet, or it doesn't reference
 	// the backing store.  In this case, we just check against the
 	// allocated capacity and grow, or don't grow.
-	if ((newsz + headwanted) >= ch->ch_cap) {
-		if ((newbuf = nni_zalloc(newsz + headwanted)) == NULL) {
+	allocsz = newsz + headwanted;
+	if (allocsz >= ch->ch_cap) {
+		if ((newbuf = nni_zalloc(allocsz)) == NULL) {
 			return (NNG_ENOMEM);
 		}
 		nni_free(ch->ch_buf, ch->ch_cap);
-		ch->ch_cap = newsz + headwanted;
+		ch->ch_cap = allocsz;
 		ch->ch_buf = newbuf;
 	}
 
@@ -235,6 +244,9 @@ nni_chunk_append(nni_chunk *ch, const void *data, size_t len)
 	if (len == 0) {
 		return (0);
 	}
+	if (len > (SIZE_MAX - ch->ch_len)) {
+		return (NNG_ENOMEM);
+	}
 	if ((rv = nni_chunk_grow(ch, len + ch->ch_len, 0)) != 0) {
 		return (rv);
 	}
@@ -263,12 +275,17 @@ nni_chunk_room(nni_chunk *ch)
 static int
 nni_chunk_insert(nni_chunk *ch, const void *data, size_t len)
 {
-	int  rv;
-	bool grow = false;
+	int    rv;
+	bool   grow = false;
+	size_t needed;
 
 	if (ch->ch_ptr == NULL) {
 		ch->ch_ptr = ch->ch_buf;
 	}
+	if (len > (SIZE_MAX - ch->ch_len)) {
+		return (NNG_ENOMEM);
+	}
+	needed = ch->ch_len + len;
 
 	if ((ch->ch_ptr >= ch->ch_buf) &&
 	    (ch->ch_ptr < (ch->ch_buf + ch->ch_cap))) {
@@ -276,8 +293,8 @@ nni_chunk_insert(nni_chunk *ch, const void *data, size_t len)
 		if (len <= (size_t) (ch->ch_ptr - ch->ch_buf)) {
 			// There is already enough room at the beginning.
 			ch->ch_ptr -= len;
-		} else if ((ch->ch_len + len + sizeof(uint64_t)) <=
-		    ch->ch_cap) {
+		} else if ((needed <= (SIZE_MAX - sizeof(uint64_t))) &&
+		    ((needed + sizeof(uint64_t)) <= ch->ch_cap)) {
 			// We have some room.  Split it between the head and
 			// tail. This is an attempt to reduce the likelihood of
 			// repeated shifts.  We round it up to preserve
@@ -285,7 +302,7 @@ nni_chunk_insert(nni_chunk *ch, const void *data, size_t len)
 			//
 			// We've ensured we have an extra
 			// pad for alignment in the check above.
-			size_t shift = ((ch->ch_cap - (ch->ch_len + len)) / 2);
+			size_t shift = ((ch->ch_cap - needed) / 2);
 			shift        = (shift + (sizeof(uint64_t) - 1)) &
 			    ~(sizeof(uint64_t) - 1);
 			memmove(ch->ch_buf + shift, ch->ch_ptr, ch->ch_len);

--- a/src/core/sock_test.c
+++ b/src/core/sock_test.c
@@ -9,6 +9,7 @@
 //
 
 #include "../testing/nuts.h"
+#include "defs.h"
 
 void
 test_recv_timeout(void)
@@ -517,19 +518,28 @@ test_size_options(void)
 	for (int i = 0; (opt = cases[i]) != NULL; i++) {
 		TEST_CASE(opt);
 
+		NUTS_PASS(nng_socket_get_size(s1, opt, &val));
+		NUTS_TRUE(val == NNI_RECVMAXSZ_DEFAULT);
+
 		// Can set a valid duration
 		NUTS_PASS(nng_socket_set_size(s1, opt, 1234));
 		NUTS_PASS(nng_socket_get_size(s1, opt, &val));
 		NUTS_TRUE(val == 1234);
 
-		// We limit the limit to 4GB. Clear it if you want to
-		// ship more than 4GB at a time.
+		// We allow larger limits on 64-bit platforms, but reserve
+		// the top four bits of the 64-bit size field.
 #if defined(_WIN64) || defined(_LP64)
-		val = 0x10000u;
-		val <<= 30u;
+		val = 1u;
+		val <<= 32u;
+		NUTS_PASS(nng_socket_set_size(s1, opt, val));
+		NUTS_PASS(nng_socket_get_size(s1, opt, &val));
+		NUTS_TRUE(val == ((size_t) 1u << 32u));
+
+		val = 1u;
+		val <<= 60u;
 		NUTS_FAIL(nng_socket_set_size(s1, opt, val), NNG_EINVAL);
 		NUTS_PASS(nng_socket_get_size(s1, opt, &val));
-		NUTS_TRUE(val == 1234);
+		NUTS_TRUE(val == ((size_t) 1u << 32u));
 #endif
 	}
 	NUTS_CLOSE(s1);

--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -205,7 +205,8 @@ static nng_err
 sock_set_recvmaxsz(void *s, const void *buf, size_t sz, nni_type t)
 {
 	return (
-	    nni_copyin_size(&SOCK(s)->s_rcvmaxsz, buf, sz, 0, NNI_MAXSZ, t));
+	    nni_copyin_size(
+	        &SOCK(s)->s_rcvmaxsz, buf, sz, 0, NNI_MAX_RECVMAXSZ, t));
 }
 
 static nng_err
@@ -555,7 +556,7 @@ nni_sock_create(nni_sock **sp, const nni_proto *proto)
 	s->s_rcvtimeo  = -1;
 	s->s_reconn    = NNI_SECOND;
 	s->s_reconnmax = 0;
-	s->s_rcvmaxsz  = 0; // unlimited by default
+	s->s_rcvmaxsz  = NNI_RECVMAXSZ_DEFAULT;
 	s->s_id        = 0;
 	s->s_ref       = 0;
 	s->s_self_id   = proto->proto_self;

--- a/src/sp/transport/dtls/dtls.c
+++ b/src/sp/transport/dtls/dtls.c
@@ -1534,7 +1534,7 @@ dtls_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 	dtls_ep *ep = arg;
 	size_t   val;
 	nng_err  rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, NNG_DTLS_RECVMAX, t)) == 0) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) == 0) {
 		if ((val == 0) || (val > NNG_DTLS_RECVMAX)) {
 			val = NNG_DTLS_RECVMAX;
 		}

--- a/src/sp/transport/dtls/dtls_tran_test.c
+++ b/src/sp/transport/dtls/dtls_tran_test.c
@@ -420,12 +420,12 @@ test_dtls_reqrep_multi(void)
 	NUTS_PASS(nng_dialer_set_tls(d2, c1));
 	NUTS_PASS(nng_dialer_start(d2, 0));
 
-	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_SENDTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, 1000));
 
 	// send a bunch of messages - we're hoping that by serializing we won't
 	// overwhelm the network.

--- a/src/sp/transport/inproc/inproc.c
+++ b/src/sp/transport/inproc/inproc.c
@@ -539,7 +539,8 @@ inproc_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 	inproc_ep *ep = arg;
 	size_t     val;
 	nng_err    rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, t)) == NNG_OK) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) ==
+	    NNG_OK) {
 		nni_mtx_lock(&ep->mtx);
 		ep->rcvmax = val;
 		nni_mtx_unlock(&ep->mtx);

--- a/src/sp/transport/ipc/ipc.c
+++ b/src/sp/transport/ipc/ipc.c
@@ -337,6 +337,11 @@ ipc_pipe_recv_cb(void *arg)
 		// We should have gotten a message header.
 		NNI_GET64(p->rx_head + 1, len);
 
+		if (!nni_msg_size_valid(len)) {
+			rv = NNG_EMSGSIZE;
+			goto error;
+		}
+
 		// Make sure the message payload is not too big.  If it is
 		// the caller will shut down the pipe.
 		if ((len > p->rcv_max) && (p->rcv_max > 0)) {
@@ -890,7 +895,8 @@ ipc_ep_set_recv_max_sz(void *arg, const void *v, size_t sz, nni_type t)
 	ipc_ep *ep = arg;
 	size_t  val;
 	nng_err rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, t)) == NNG_OK) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) ==
+	    NNG_OK) {
 
 		nni_mtx_lock(&ep->mtx);
 		ep->rcv_max = val;

--- a/src/sp/transport/socket/sockfd.c
+++ b/src/sp/transport/socket/sockfd.c
@@ -343,6 +343,11 @@ sfd_tran_pipe_recv_cb(void *arg)
 		// We should have gotten a message header.
 		NNI_GET64(p->rxlen, len);
 
+		if (!nni_msg_size_valid(len)) {
+			rv = NNG_EMSGSIZE;
+			goto recv_error;
+		}
+
 		// Make sure the message payload is not too big.  If it is
 		// the caller will shut down the pipe.
 		if ((len > p->rcvmax) && (p->rcvmax > 0)) {
@@ -772,7 +777,8 @@ sfd_tran_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 	sfd_tran_ep *ep = arg;
 	size_t       val;
 	nng_err      rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, t)) == NNG_OK) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) ==
+	    NNG_OK) {
 		nni_mtx_lock(&ep->mtx);
 		ep->rcvmax = val;
 		nni_mtx_unlock(&ep->mtx);

--- a/src/sp/transport/socket/sockfd_test.c
+++ b/src/sp/transport/socket/sockfd_test.c
@@ -25,6 +25,8 @@
 #ifdef NNG_PLATFORM_WINDOWS
 #include <io.h>
 #define close(fd) _close(fd)
+#define read(fd, buf, len) _read(fd, buf, (unsigned) (len))
+#define write(fd, buf, len) _write(fd, buf, (unsigned) (len))
 #endif
 
 // FDC tests.
@@ -328,6 +330,39 @@ test_sockfd_close_pending(void)
 }
 
 void
+test_sfd_reserved_length_bits(void)
+{
+#ifdef NNG_HAVE_SOCKETPAIR
+	int          fds[2];
+	nng_socket   s0;
+	nng_listener l0;
+	uint8_t      nego[8];
+	uint8_t      peer[8] = { 0, 'S', 'P', 0, 0, NUTS_PROTO(1, 1), 0, 0 };
+	uint8_t      len[8]  = { 0x10, 0, 0, 0, 0, 0, 0, 0 };
+	char         buf[1];
+	size_t       sz = sizeof(buf);
+
+	NUTS_PASS(nng_socket_pair(fds));
+	NUTS_OPEN(s0);
+	NUTS_PASS(nng_socket_set_ms(s0, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_listener_create(&l0, s0, "socket://"));
+	NUTS_PASS(nng_listener_start(l0, 0));
+	NUTS_PASS(nng_listener_set_int(l0, NNG_OPT_SOCKET_FD, fds[0]));
+
+	NUTS_ASSERT(read(fds[1], nego, sizeof(nego)) == (int) sizeof(nego));
+	NUTS_ASSERT(write(fds[1], peer, sizeof(peer)) == (int) sizeof(peer));
+	nng_msleep(100);
+	NUTS_ASSERT(write(fds[1], len, sizeof(len)) == (int) sizeof(len));
+
+	NUTS_FAIL(nng_recv(s0, buf, &sz, 0), NNG_ETIMEDOUT);
+	NUTS_CLOSE(s0);
+	close(fds[1]);
+#else
+	NUTS_SKIP("no socketpair");
+#endif
+}
+
+void
 test_sockfd_close_peer(void)
 {
 #ifdef NNG_HAVE_SOCKETPAIR
@@ -571,6 +606,7 @@ NUTS_TESTS = {
 	{ "socket exchange", test_sfd_exchange },
 	{ "socket exchange late", test_sfd_exchange_late },
 	{ "socket recv max", test_sfd_recv_max },
+	{ "socket reserved length bits", test_sfd_reserved_length_bits },
 	{ "socket exchange large", test_sfd_large },
 	{ "socket close pending", test_sockfd_close_pending },
 	{ "socket close peer", test_sockfd_close_peer },

--- a/src/sp/transport/tcp/tcp.c
+++ b/src/sp/transport/tcp/tcp.c
@@ -334,6 +334,11 @@ tcptran_pipe_recv_cb(void *arg)
 		// We should have gotten a message header.
 		NNI_GET64(p->rxlen, len);
 
+		if (!nni_msg_size_valid(len)) {
+			rv = NNG_EMSGSIZE;
+			goto recv_error;
+		}
+
 		// Make sure the message payload is not too big.  If it is
 		// the caller will shut down the pipe.
 		if ((len > p->rcvmax) && (p->rcvmax > 0)) {
@@ -911,7 +916,8 @@ tcptran_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 	tcptran_ep *ep = arg;
 	size_t      val;
 	nng_err     rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, t)) == NNG_OK) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) ==
+	    NNG_OK) {
 		nni_mtx_lock(&ep->mtx);
 		ep->rcvmax = val;
 		nni_mtx_unlock(&ep->mtx);

--- a/src/sp/transport/tls/tls.c
+++ b/src/sp/transport/tls/tls.c
@@ -341,6 +341,11 @@ tlstran_pipe_recv_cb(void *arg)
 		// We should have gotten a message header.
 		NNI_GET64(p->rxlen, len);
 
+		if (!nni_msg_size_valid(len)) {
+			rv = NNG_EMSGSIZE;
+			goto recv_error;
+		}
+
 		// Make sure the message payload is not too big.  If it is
 		// the caller will shut down the pipe.
 		if ((len > p->rcvmax) && (p->rcvmax > 0)) {
@@ -918,7 +923,8 @@ tlstran_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_type t)
 	tlstran_ep *ep = arg;
 	size_t      val;
 	nng_err     rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAXSZ, t)) == NNG_OK) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) ==
+	    NNG_OK) {
 		nni_mtx_lock(&ep->mtx);
 		ep->rcvmax = val;
 		nni_mtx_unlock(&ep->mtx);

--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -1548,7 +1548,8 @@ udp_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 	udp_ep *ep = arg;
 	size_t  val;
 	nng_err rv;
-	if ((rv = nni_copyin_size(&val, v, sz, 0, 65000, t)) == NNG_OK) {
+	if ((rv = nni_copyin_size(&val, v, sz, 0, NNI_MAX_RECVMAXSZ, t)) ==
+	    NNG_OK) {
 		if ((val == 0) || (val > 65000)) {
 			val = 65000;
 		}


### PR DESCRIPTION
Default `NNG_OPT_RECVMAXSZ` to 1 GiB and add a build-time default override with warnings for values above 4 GiB on 64-bit platforms.

Reject stream message lengths above the 60-bit wire limit or `SIZE_MAX` before allocation, and harden message chunk arithmetic against `size_t` overflow.

Update docs and migration notes to describe the new default, 32-bit compatibility caveat, and DoS guidance.

Validated with `sock_test`, `message_test`, `sockfd_test`, `tcp_test`, `ipc_test`, and OpenSSL `tls_tran_test`.

By submitting this PR, I have read and agreed to the contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default receive maximum message size now **1 GiB** (was unlimited). Set the per-socket option to **0** for unlimited, or configure a higher build-time default for larger limits.
  * Added clearer **32-bit vs 64-bit** compatibility guidance for sizes above **4 GiB**.

* **Bug Fixes**
  * Improved receive-side message-length validation across transports (returns **EMSGSIZE** for invalid sizes earlier).
  * Added overflow-safe checks for message chunk growth/append/insert; updated receive-max clamping to use the correct maximum limit.

* **Documentation**
  * Updated API and migration guides to match the new default and tuning behavior.

* **Tests**
  * Strengthened receive-max default/limit tests and added reserved-length negotiation coverage; adjusted DTLS timeout expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->