### PR TITLE
docs: drop references to asciidoc

### DIFF
--- a/docs/README.txt
+++ b/docs/README.txt
@@ -1,10 +1,7 @@
-This contains the nng documentation for API users.
+This contains the documentation for API users.
 
-Historically, the documentation was written in asciidoc in the form of man pages.
-It is automatically formatted for display on the website.
+The main reference material is made available in mdbook format and online.
+The source of that is in the ref/ subdirectory.
 
-The man pages are in the "man" directory.  The reason those are separate
-is that they get special treatment.  Other documentation is located here.
-
-HOWEVER, we are converting the documentation to mdbook -- see ref/ as the top-level
-of the new tree for that.
+You can run mdbook in this directory (the book.toml is here) to serve it
+locally.


### PR DESCRIPTION
Updates docs/README.txt to describe the current mdbook-based documentation layout instead of the old asciidoc/man-page structure.

This is a docs-only cleanup; no runtime behavior changes.

Validation: reviewed git diff origin/main...HEAD; no build run for documentation text-only change.

You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the user-facing documentation to be shorter and clearer.
  * Added a direct note pointing readers to the main documentation site and its source location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->