### PR TITLE
fix(http): fix a potential overflow in the http chunk size.

### DIFF
--- a/src/supplemental/http/http_chunk.c
+++ b/src/supplemental/http/http_chunk.c
@@ -44,6 +44,7 @@ enum chunk_state {
 struct nng_http_chunks {
 	nni_list         cl_chunks;
 	size_t           cl_maxsz;
+	size_t           cl_total; // total size of all chunks
 	size_t           cl_size; // parsed size (so far)
 	size_t           cl_line; // bytes since last newline
 	enum chunk_state cl_state;
@@ -100,12 +101,7 @@ nni_http_chunks_iter(nni_http_chunks *cl, nni_http_chunk *last)
 size_t
 nni_http_chunks_size(nni_http_chunks *cl)
 {
-	size_t          tot = 0;
-	nni_http_chunk *ch;
-	NNI_LIST_FOREACH (&cl->cl_chunks, ch) {
-		tot += ch->c_size;
-	}
-	return (tot);
+	return (cl->cl_total);
 }
 
 size_t
@@ -123,22 +119,29 @@ nni_http_chunk_data(nni_http_chunk *ch)
 static nng_err
 chunk_ingest_len(nni_http_chunks *cl, char c)
 {
-	if (isdigit(c)) {
-		cl->cl_size *= 16;
-		cl->cl_size += (c - '0');
+	size_t digit;
+
+	if (isdigit((unsigned char) c)) {
+		digit = (size_t) (c - '0');
 	} else if ((c >= 'A') && (c <= 'F')) {
-		cl->cl_size *= 16;
-		cl->cl_size += (c - 'A') + 10;
+		digit = (size_t) ((c - 'A') + 10);
 	} else if ((c >= 'a') && (c <= 'f')) {
-		cl->cl_size *= 16;
-		cl->cl_size += (c - 'a') + 10;
+		digit = (size_t) ((c - 'a') + 10);
 	} else if (c == ';') {
 		cl->cl_state = CS_EXT;
+		return (NNG_OK);
 	} else if (c == '\r') {
 		cl->cl_state = CS_CR;
+		return (NNG_OK);
 	} else {
 		return (NNG_EPROTO);
 	}
+
+	if (cl->cl_size > ((SIZE_MAX - digit) / 16)) {
+		return (NNG_EMSGSIZE);
+	}
+	cl->cl_size *= 16;
+	cl->cl_size += digit;
 	return (NNG_OK);
 }
 
@@ -147,7 +150,7 @@ chunk_ingest_ext(nni_http_chunks *cl, char c)
 {
 	if (c == '\r') {
 		cl->cl_state = CS_CR;
-	} else if (!isprint(c)) {
+	} else if (!isprint((unsigned char) c)) {
 		return (NNG_EPROTO);
 	}
 	return (NNG_OK);
@@ -166,8 +169,11 @@ chunk_ingest_newline(nni_http_chunks *cl, char c)
 		cl->cl_state = CS_TRLR;
 		return (NNG_OK);
 	}
-	if ((cl->cl_maxsz > 0) &&
-	    ((nni_http_chunks_size(cl) + cl->cl_size) > cl->cl_maxsz)) {
+	if ((cl->cl_size > (SIZE_MAX - 2)) ||
+	    (cl->cl_size > (SIZE_MAX - cl->cl_total)) ||
+	    ((cl->cl_maxsz > 0) &&
+	        ((cl->cl_total > cl->cl_maxsz) ||
+	            (cl->cl_size > (cl->cl_maxsz - cl->cl_total))))) {
 		return (NNG_EMSGSIZE);
 	}
 	if ((chunk = NNI_ALLOC_STRUCT(chunk)) == NULL) {
@@ -186,6 +192,7 @@ chunk_ingest_newline(nni_http_chunks *cl, char c)
 	chunk->c_size  = cl->cl_size;
 	chunk->c_alloc = cl->cl_size + 2;
 	chunk->c_resid = chunk->c_alloc;
+	cl->cl_total += cl->cl_size;
 	nni_list_append(&cl->cl_chunks, chunk);
 
 	return (NNG_OK);
@@ -198,7 +205,7 @@ chunk_ingest_trailer(nni_http_chunks *cl, char c)
 		cl->cl_state = CS_TRLRCR;
 		return (NNG_OK);
 	}
-	if (!isprint(c)) {
+	if (!isprint((unsigned char) c)) {
 		return (NNG_EPROTO);
 	}
 	cl->cl_line++;
@@ -226,7 +233,7 @@ chunk_ingest_char(nni_http_chunks *cl, char c)
 	nng_err rv;
 	switch (cl->cl_state) {
 	case CS_INIT:
-		if (!isalnum(c)) {
+		if (!isalnum((unsigned char) c)) {
 			rv = NNG_EPROTO;
 			break;
 		}
@@ -281,6 +288,7 @@ chunk_ingest_data(nni_http_chunks *cl, char *buf, size_t n, size_t *lenp)
 
 		if ((chunk->c_data[chunk->c_size] != '\r') ||
 		    (chunk->c_data[chunk->c_size + 1] != '\n')) {
+			*lenp = n;
 			return (NNG_EPROTO);
 		}
 		chunk->c_resid = 0;
@@ -315,8 +323,10 @@ nni_http_chunks_parse(nni_http_chunks *cl, void *buf, size_t n, size_t *lenp)
 			break;
 
 		case CS_DATA:
+			cnt = 0;
 			if ((rv = chunk_ingest_data(
 			         cl, src + i, n - i, &cnt)) != 0) {
+				*lenp = i + cnt;
 				return (rv);
 			}
 			i += cnt;
@@ -326,6 +336,7 @@ nni_http_chunks_parse(nni_http_chunks *cl, void *buf, size_t n, size_t *lenp)
 			// All others character by character parse through
 			// the state machine grinder.
 			if ((rv = chunk_ingest_char(cl, src[i])) != 0) {
+				*lenp = i;
 				return (rv);
 			}
 			i++;

--- a/src/supplemental/http/http_client_test.c
+++ b/src/supplemental/http/http_client_test.c
@@ -14,6 +14,7 @@
 #include <nng/nng.h>
 
 #include "../../testing/nuts.h"
+#include "http_api.h"
 
 #include <stdbool.h>
 #include <stdio.h>
@@ -486,6 +487,190 @@ test_http_client_chunked_alloc_overflow(void)
 	NUTS_TRUE(srv.requests == 1);
 }
 
+static void
+test_http_chunk_parser_extensions(void)
+{
+	nni_http_chunks *chunks = NULL;
+	nni_http_chunk  *chunk  = NULL;
+	char             body[] =
+	    "1;foo=bar\r\n"
+	    "x\r\n"
+	    "0\r\n"
+	    "Some-Trailer: ok\r\n"
+	    "\r\n";
+	size_t n = 0;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 8));
+	NUTS_PASS(nni_http_chunks_parse(chunks, body, strlen(body), &n));
+	NUTS_TRUE(n == strlen(body));
+	NUTS_TRUE(nni_http_chunks_size(chunks) == 1);
+	chunk = nni_http_chunks_iter(chunks, NULL);
+	NUTS_TRUE(chunk != NULL);
+	NUTS_TRUE(nni_http_chunk_size(chunk) == 1);
+	NUTS_TRUE(memcmp(nni_http_chunk_data(chunk), "x", 1) == 0);
+	NUTS_TRUE(nni_http_chunks_iter(chunks, chunk) == NULL);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_max_size(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] =
+	    "1\r\n"
+	    "a\r\n"
+	    "1\r\n"
+	    "b\r\n"
+	    "0\r\n"
+	    "\r\n";
+	size_t n = 0;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 1));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EMSGSIZE);
+	NUTS_TRUE(n == 8);
+	NUTS_TRUE(nni_http_chunks_size(chunks) == 1);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_data_crlf(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] =
+	    "1\r\n"
+	    "aXX";
+	size_t n = 0;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == strlen(body));
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_extension(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] = "1;\001\r\nx\r\n0\r\n\r\n";
+	size_t           n      = 99;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == 2);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_trailer(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] = "0\r\nBad:\001\r\n\r\n";
+	size_t           n      = 99;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == 7);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_uppercase_hex(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] =
+	    "A\r\n"
+	    "1234567890\r\n"
+	    "0\r\n"
+	    "\r\n";
+	size_t n = 0;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 16));
+	NUTS_PASS(nni_http_chunks_parse(chunks, body, strlen(body), &n));
+	NUTS_TRUE(n == strlen(body));
+	NUTS_TRUE(nni_http_chunks_size(chunks) == 10);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_partial_data(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             part1[] =
+	    "3\r\n"
+	    "ab";
+	char   part2[] = "c\r\n0\r\n\r\n";
+	size_t n       = 0;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, part1, strlen(part1), &n),
+	    NNG_EAGAIN);
+	NUTS_TRUE(n == strlen(part1));
+	NUTS_PASS(nni_http_chunks_parse(chunks, part2, strlen(part2), &n));
+	NUTS_TRUE(n == strlen(part2));
+	NUTS_TRUE(nni_http_chunks_size(chunks) == 3);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_length(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] = "g\r\n";
+	size_t           n      = 99;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == 0);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_newline(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] = "1\rx";
+	size_t           n      = 99;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == 2);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_initial(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] = "\r\n";
+	size_t           n      = 99;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == 0);
+	nni_http_chunks_free(chunks);
+}
+
+static void
+test_http_chunk_parser_bad_trailer_cr(void)
+{
+	nni_http_chunks *chunks = NULL;
+	char             body[] = "0\r\nX\rx";
+	size_t           n      = 99;
+
+	NUTS_PASS(nni_http_chunks_init(&chunks, 0));
+	NUTS_FAIL(nni_http_chunks_parse(chunks, body, strlen(body), &n),
+	    NNG_EPROTO);
+	NUTS_TRUE(n == 5);
+	nni_http_chunks_free(chunks);
+}
+
 NUTS_TESTS = {
 	{ "http client request response", test_http_client_request_response },
 	{ "http client transact", test_http_client_transact },
@@ -496,5 +681,21 @@ NUTS_TESTS = {
 	    test_http_client_chunked_size_overflow },
 	{ "http client chunked alloc overflow",
 	    test_http_client_chunked_alloc_overflow },
+	{ "http chunk parser extensions", test_http_chunk_parser_extensions },
+	{ "http chunk parser max size", test_http_chunk_parser_max_size },
+	{ "http chunk parser bad data crlf",
+	    test_http_chunk_parser_bad_data_crlf },
+	{ "http chunk parser bad extension",
+	    test_http_chunk_parser_bad_extension },
+	{ "http chunk parser bad trailer", test_http_chunk_parser_bad_trailer },
+	{ "http chunk parser uppercase hex",
+	    test_http_chunk_parser_uppercase_hex },
+	{ "http chunk parser partial data",
+	    test_http_chunk_parser_partial_data },
+	{ "http chunk parser bad length", test_http_chunk_parser_bad_length },
+	{ "http chunk parser bad newline", test_http_chunk_parser_bad_newline },
+	{ "http chunk parser bad initial", test_http_chunk_parser_bad_initial },
+	{ "http chunk parser bad trailer cr",
+	    test_http_chunk_parser_bad_trailer_cr },
 	{ NULL, NULL },
 };

--- a/src/supplemental/http/http_client_test.c
+++ b/src/supplemental/http/http_client_test.c
@@ -426,11 +426,75 @@ test_http_client_chunked(void)
 	NUTS_TRUE(srv.requests == 1);
 }
 
+static void
+test_http_client_chunked_size_overflow(void)
+{
+	static const char *response =
+	    "HTTP/1.1 200 OK\r\n"
+	    "Transfer-Encoding: chunked\r\n"
+	    "\r\n"
+	    "10000000000000000\r\n"
+	    "\r\n";
+	struct scripted_server srv;
+	nng_aio               *aio = NULL;
+	nng_http_client       *cli = NULL;
+	nng_http              *conn = NULL;
+	nng_url               *url = NULL;
+
+	scripted_server_start(&srv, &response, NULL, 1);
+	srv.ignore_send_errors = true;
+	client_connect(srv.url, &url, &aio, &cli, &conn);
+
+	NUTS_PASS(nng_http_set_uri(conn, "/chunked-overflow", NULL));
+	nng_http_transact(conn, aio);
+	nng_aio_wait(aio);
+	NUTS_FAIL(nng_aio_result(aio), NNG_EMSGSIZE);
+
+	client_free(url, aio, cli, conn);
+	scripted_server_stop(&srv);
+	NUTS_PASS(srv.rv);
+	NUTS_TRUE(srv.requests == 1);
+}
+
+static void
+test_http_client_chunked_alloc_overflow(void)
+{
+	static const char *response =
+	    "HTTP/1.1 200 OK\r\n"
+	    "Transfer-Encoding: chunked\r\n"
+	    "\r\n"
+	    "ffffffffffffffff\r\n"
+	    "\r\n";
+	struct scripted_server srv;
+	nng_aio               *aio = NULL;
+	nng_http_client       *cli = NULL;
+	nng_http              *conn = NULL;
+	nng_url               *url = NULL;
+
+	scripted_server_start(&srv, &response, NULL, 1);
+	srv.ignore_send_errors = true;
+	client_connect(srv.url, &url, &aio, &cli, &conn);
+
+	NUTS_PASS(nng_http_set_uri(conn, "/chunked-alloc-overflow", NULL));
+	nng_http_transact(conn, aio);
+	nng_aio_wait(aio);
+	NUTS_FAIL(nng_aio_result(aio), NNG_EMSGSIZE);
+
+	client_free(url, aio, cli, conn);
+	scripted_server_stop(&srv);
+	NUTS_PASS(srv.rv);
+	NUTS_TRUE(srv.requests == 1);
+}
+
 NUTS_TESTS = {
 	{ "http client request response", test_http_client_request_response },
 	{ "http client transact", test_http_client_transact },
 	{ "http client reuse", test_http_client_reuse },
 	{ "http client timeout", test_http_client_timeout },
 	{ "http client chunked", test_http_client_chunked },
+	{ "http client chunked size overflow",
+	    test_http_client_chunked_size_overflow },
+	{ "http client chunked alloc overflow",
+	    test_http_client_chunked_alloc_overflow },
 	{ NULL, NULL },
 };


### PR DESCRIPTION
This would have allowed a malicious HTTP server to cause a client crash.

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunked HTTP parsing with stricter validation of chunk length and printable extension/trailer characters.
  * Added safer size/overflow protections for declared chunk sizes and allocation behavior.
  * Parsing now reports consumed progress more consistently on early failures.

* **Tests**
  * Added new client and parser test cases for malformed chunked responses, including oversized and allocation-overflow scenarios.
  * Expanded unit coverage for extensions/trailers, max-size handling, and multiple protocol/format error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->