### PR TITLE
fix(udp+dtls): cap unauthenticated peer allocation

### DIFF
--- a/docs/ref/tran/dtls.md
+++ b/docs/ref/tran/dtls.md
@@ -97,10 +97,19 @@ listener is started.
 | Option                                                | Type     | Description                                                                                                                     |
 | ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | [`NNG_OPT_RECVMAXSZ`]                                 | `size_t` | Maximum size of incoming messages. Values larger than the DTLS transport maximum are clamped to the transport maximum.          |
+| [`NNG_OPT_UDP_MAX_PEERS`]                              | `size_t` | Maximum number of unauthenticated inbound DTLS handshakes. The default is 1024; set to 0 to disable the limit.                   |
 | `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a> | `int`    | The locally bound UDP port number (1-65535), read-only for [listener] objects only.                                             |
 
 The DTLS transport does not support TCP-specific options such as
 `NNG_OPT_TCP_NODELAY` or `NNG_OPT_TCP_KEEPALIVE`.
+
+## Peer Admission
+
+DTLS only adds a pipe to the socket after TLS has validated an inbound peer.
+Before that point, each source address consumes handshake state. Listeners
+therefore admit at most 1024 unauthenticated peers by default. Configure
+[`NNG_OPT_UDP_MAX_PEERS`] before starting the listener to select another limit.
+A value of 0 disables this protection.
 
 ### Maximum Message Size
 

--- a/docs/ref/tran/udp.md
+++ b/docs/ref/tran/udp.md
@@ -70,6 +70,7 @@ where supported by the underlying platform.
 | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
 | [`NNG_OPT_RECVMAXSZ`]                                     | `size_t` | Maximum size of incoming messages, will be limited to at most 65000.                                                |
 | `NNG_OPT_UDP_COPY_MAX`<a name="NNG_OPT_UDP_COPY_MAX"></a> | `size_t` | Threshold above which received messages are "loaned" up, rather than a new message being allocated and copied into. |
+| `NNG_OPT_UDP_MAX_PEERS`<a name="NNG_OPT_UDP_MAX_PEERS"></a> | `size_t` | Maximum number of remote peers admitted by a listener. The default is 1024; set to 0 to disable the limit. |
 | `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a>     | `int`    | The locally bound UDP port number (1-65535), read-only for [listener] objects only.                                 |
 
 ## Maximum Message Size
@@ -97,6 +98,14 @@ The maximum message size is negotiated as part of establishing a peering relatio
 and oversize messages will be dropped by the sender before going to the network.
 
 The maximum message size to receive can be configured with the [`NNG_OPT_RECVMAXSZ`] option.
+
+## Peer Admission
+
+Each new source address causes the listener to allocate a logical UDP peer.
+To bound the resources consumed by spoofed or otherwise untrusted connection
+requests, listeners admit at most 1024 peers by default. Configure
+[`NNG_OPT_UDP_MAX_PEERS`] before starting the listener to select another
+limit. A value of 0 disables this protection.
 
 ## Keep Alive
 

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -857,6 +857,11 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 // to replace a full message buffer.
 #define NNG_OPT_UDP_COPY_MAX "udp:copy-max"
 
+// Maximum number of peers admitted by a UDP-based listener.  A value of zero
+// disables the limit.  This option is also supported by DTLS listeners, where
+// it limits unauthenticated handshakes.
+#define NNG_OPT_UDP_MAX_PEERS "udp:max-peers"
+
 // IPC options.  These will largely vary depending on the platform,
 // as POSIX systems have very different options than Windows.
 

--- a/src/sp/transport/dtls/dtls.c
+++ b/src/sp/transport/dtls/dtls.c
@@ -77,6 +77,10 @@ typedef enum dtls_disc_reason {
 #define NNG_DTLS_CONNRETRY (NNI_SECOND / 5)
 #endif
 
+#ifndef NNG_DTLS_MAX_PEERS
+#define NNG_DTLS_MAX_PEERS 1024
+#endif
+
 // 64-bit protocol header
 typedef struct dtls_sp_hdr {
 	uint8_t  us_ver;
@@ -99,6 +103,7 @@ struct dtls_pipe {
 	uint16_t      peer;
 	uint16_t      proto;
 	bool          matched; // true if have matched and given this to SP
+	bool          pending; // true until TLS validates this inbound peer
 	bool          closed;  // true if we are closed (no more send or recv!)
 	bool          dialer;  // true if we are dialer
 	nng_duration  refresh; // seconds, for the protocol
@@ -170,6 +175,8 @@ struct dtls_ep {
 	nni_list        connpipes; // pipes waiting to be connected
 	nng_duration    refresh; // refresh interval for connections in seconds
 	uint16_t        rcvmax;  // max payload, trimmed to uint16_t
+	size_t          max_peers;
+	size_t          pending_peers;
 	nni_resolv_item resolv;
 
 	nng_tls_config *tlscfg;
@@ -188,6 +195,8 @@ struct dtls_ep {
 	nni_stat_item st_snd_nobuf;
 	nni_stat_item st_peer_inactive;
 	nni_stat_item st_copy_max;
+	nni_stat_item st_peer_max;
+	nni_stat_item st_peer_reject;
 };
 
 static void dtls_ep_start(dtls_ep *);
@@ -600,6 +609,11 @@ dtls_pipe_recv_tls_cb(void *arg)
 	}
 
 	// We had a "good" receive (TLS passed at least) from the peer.
+	if (p->pending) {
+		NNI_ASSERT(ep->pending_peers != 0);
+		p->pending = false;
+		ep->pending_peers--;
+	}
 
 	if (nni_aio_count(aio) < sizeof(*hdr)) {
 		// Runt frame.
@@ -755,6 +769,8 @@ dtls_pipe_alloc(dtls_ep *ep, dtls_pipe **pp, const nng_sockaddr *sa)
 	p->peer_addr = *sa;
 	p->id        = nng_sockaddr_hash(sa);
 	p->refresh   = ep->refresh;
+	p->expire    = nni_clock() + DTLS_PIPE_TIMEOUT(p);
+	p->pending   = !ep->dialer;
 	p->send_max  = NNG_DTLS_RECVMAX;
 	p->recv_max  = ep->rcvmax;
 	*pp          = p;
@@ -896,6 +912,10 @@ dtls_remove_pipe(dtls_pipe *p)
 			id = 1;
 		}
 	}
+	if (p->pending) {
+		NNI_ASSERT(ep->pending_peers != 0);
+		ep->pending_peers--;
+	}
 	if (!matched) {
 		nni_pipe_rele(p->npipe);
 	}
@@ -913,7 +933,11 @@ dtls_add_pipe(dtls_ep *ep, dtls_pipe *p)
 		}
 	}
 	p->id = id;
-	return (nni_id_set(&ep->pipes, id, p));
+	nng_err rv;
+	if ((rv = nni_id_set(&ep->pipes, id, p)) == NNG_OK && p->pending) {
+		ep->pending_peers++;
+	}
+	return (rv);
 }
 
 static void
@@ -964,6 +988,11 @@ dtls_rx_cb(void *arg)
 	}
 
 	if ((p = dtls_find_pipe(ep, &ep->rx_sa)) == NULL) {
+		if ((ep->max_peers != 0) &&
+		    (ep->pending_peers >= ep->max_peers)) {
+			nni_stat_inc(&ep->st_peer_reject, 1);
+			goto fail;
+		}
 		if (dtls_pipe_alloc(ep, &p, &ep->rx_sa) != NNG_OK) {
 			goto fail;
 		}
@@ -1233,6 +1262,7 @@ dtls_ep_init(
 	ep->url              = url;
 	ep->refresh          = NNG_DTLS_REFRESH; // one minute by default
 	ep->rcvmax           = NNG_DTLS_RECVMAX;
+	ep->max_peers        = NNG_DTLS_MAX_PEERS;
 
 	// receive buffer plus some extra for UDP and TLS headers
 	if ((ep->rx_buf = nni_alloc(DTLS_MAX_RECORD)) == NULL) {
@@ -1260,6 +1290,11 @@ dtls_ep_init(
 	NNI_STAT_LOCK(peer_inactive_info, "peer_inactive",
 	    "connections closed due to inactive peer", NNG_STAT_COUNTER,
 	    NNG_UNIT_EVENTS);
+	NNI_STAT_LOCK(peer_max_info, "peer_max",
+	    "maximum unauthenticated peers", NNG_STAT_LEVEL, NNG_UNIT_MESSAGES);
+	NNI_STAT_LOCK(peer_reject_info, "peer_reject",
+	    "handshakes rejected at the peer limit", NNG_STAT_COUNTER,
+	    NNG_UNIT_MESSAGES);
 
 	nni_stat_init_lock(&ep->st_rcv_max, &rcv_max_info, &ep->mtx);
 	nni_stat_init_lock(&ep->st_rcv_toobig, &rcv_toobig_info, &ep->mtx);
@@ -1269,6 +1304,9 @@ dtls_ep_init(
 	nni_stat_init_lock(&ep->st_snd_nobuf, &snd_nobuf_info, &ep->mtx);
 	nni_stat_init_lock(
 	    &ep->st_peer_inactive, &peer_inactive_info, &ep->mtx);
+	nni_stat_init_lock(&ep->st_peer_max, &peer_max_info, &ep->mtx);
+	nni_stat_init_lock(&ep->st_peer_reject, &peer_reject_info, &ep->mtx);
+	nni_stat_set_value(&ep->st_peer_max, ep->max_peers);
 
 	if (l) {
 		NNI_ASSERT(d == NULL);
@@ -1279,6 +1317,8 @@ dtls_ep_init(
 		nni_listener_add_stat(l, &ep->st_rcv_nobuf);
 		nni_listener_add_stat(l, &ep->st_snd_toobig);
 		nni_listener_add_stat(l, &ep->st_snd_nobuf);
+		nni_listener_add_stat(l, &ep->st_peer_max);
+		nni_listener_add_stat(l, &ep->st_peer_reject);
 	}
 	if (d) {
 		NNI_ASSERT(l == NULL);
@@ -1288,6 +1328,8 @@ dtls_ep_init(
 		nni_dialer_add_stat(d, &ep->st_rcv_nobuf);
 		nni_dialer_add_stat(d, &ep->st_snd_toobig);
 		nni_dialer_add_stat(d, &ep->st_snd_nobuf);
+		nni_dialer_add_stat(d, &ep->st_peer_max);
+		nni_dialer_add_stat(d, &ep->st_peer_reject);
 	}
 
 	// schedule our timer callback - forever for now
@@ -1551,6 +1593,39 @@ dtls_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 }
 
 static nng_err
+dtls_ep_get_max_peers(void *arg, void *v, size_t *szp, nni_opt_type t)
+{
+	dtls_ep *ep = arg;
+	nng_err  rv;
+
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_size(ep->max_peers, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
+}
+
+static nng_err
+dtls_ep_set_max_peers(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	dtls_ep *ep = arg;
+	size_t   val;
+	nng_err  rv;
+
+	if ((rv = nni_copyin_size(&val, v, sz, 0, UINT32_MAX, t)) != NNG_OK) {
+		return (rv);
+	}
+	nni_mtx_lock(&ep->mtx);
+	if (ep->started) {
+		nni_mtx_unlock(&ep->mtx);
+		return (NNG_EBUSY);
+	}
+	ep->max_peers = val;
+	nni_mtx_unlock(&ep->mtx);
+	nni_stat_set_value(&ep->st_peer_max, val);
+	return (NNG_OK);
+}
+
+static nng_err
 dtls_ep_set_tls(void *arg, nng_tls_config *cfg)
 {
 	dtls_ep *ep = arg;
@@ -1671,6 +1746,11 @@ static const nni_option dtls_ep_opts[] = {
 	    .o_name = NNG_OPT_RECVMAXSZ,
 	    .o_get  = dtls_ep_get_recvmaxsz,
 	    .o_set  = dtls_ep_set_recvmaxsz,
+	},
+	{
+	    .o_name = NNG_OPT_UDP_MAX_PEERS,
+	    .o_get  = dtls_ep_get_max_peers,
+	    .o_set  = dtls_ep_set_max_peers,
 	},
 	{
 	    .o_name = NNG_OPT_BOUND_PORT,

--- a/src/sp/transport/dtls/dtls_tran_test.c
+++ b/src/sp/transport/dtls/dtls_tran_test.c
@@ -225,6 +225,26 @@ test_dtls_no_delay_option(void)
 }
 
 void
+test_dtls_max_peers_option(void)
+{
+	nng_socket   s;
+	nng_listener l;
+	size_t       max_peers;
+	char        *addr;
+
+	NUTS_ADDR(addr, "dtls");
+	NUTS_OPEN(s);
+	NUTS_PASS(nng_listener_create(&l, s, addr));
+	NUTS_PASS(nng_listener_get_size(l, NNG_OPT_UDP_MAX_PEERS, &max_peers));
+	NUTS_TRUE(max_peers == 1024);
+	NUTS_PASS(nng_listener_set_size(l, NNG_OPT_UDP_MAX_PEERS, 1));
+	NUTS_PASS(nng_listener_get_size(l, NNG_OPT_UDP_MAX_PEERS, &max_peers));
+	NUTS_TRUE(max_peers == 1);
+	NUTS_PASS(nng_listener_close(l));
+	NUTS_CLOSE(s);
+}
+
+void
 test_dtls_recv_max(void)
 {
 	char            msg[256];
@@ -646,6 +666,7 @@ NUTS_TESTS = {
 	{ "dtls port zero bind", test_dtls_port_zero_bind },
 	{ "dtls malformed address", test_dtls_malformed_address },
 	{ "dtls no delay option", test_dtls_no_delay_option },
+	{ "dtls max peers option", test_dtls_max_peers_option },
 	{ "dtls recv max", test_dtls_recv_max },
 	{ "dtls recv large", test_dtls_recv_large },
 	{ "dtls exchange many", test_dtls_exchange_many },

--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -50,6 +50,10 @@ typedef enum udp_disc_reason {
 #define NNG_UDP_COPYMAX 1024
 #endif
 
+#ifndef NNG_UDP_MAX_PEERS
+#define NNG_UDP_MAX_PEERS 1024
+#endif
+
 #ifndef NNG_UDP_REFRESH
 #define NNG_UDP_REFRESH (5 * NNI_SECOND)
 #endif
@@ -163,6 +167,8 @@ struct udp_ep {
 	udp_sp_msg   *rx_msg;  // contains the received message header
 	uint16_t      rcvmax;  // max payload, trimmed to uint16_t
 	uint16_t      copymax;
+	size_t        max_peers;
+	size_t        peer_count;
 	udp_txring    tx_ring;
 	nni_time      next_wake;
 	nni_aio_completions complq;
@@ -178,6 +184,8 @@ struct udp_ep {
 	nni_stat_item st_snd_nobuf;
 	nni_stat_item st_peer_inactive;
 	nni_stat_item st_copy_max;
+	nni_stat_item st_peer_max;
+	nni_stat_item st_peer_reject;
 };
 
 static void udp_ep_start(udp_ep *);
@@ -323,6 +331,8 @@ udp_remove_pipe(udp_pipe *p)
 		return;
 	}
 	p->id = 0;
+	NNI_ASSERT(ep->peer_count != 0);
+	ep->peer_count--;
 	for (;;) {
 		udp_pipe *srch;
 		if ((srch = nni_id_get(&ep->pipes, id)) == NULL) {
@@ -354,7 +364,11 @@ udp_add_pipe(udp_ep *ep, udp_pipe *p)
 			id = 1;
 		}
 	}
-	return (nni_id_set(&ep->pipes, id, p));
+	nng_err rv;
+	if ((rv = nni_id_set(&ep->pipes, id, p)) == NNG_OK) {
+		ep->peer_count++;
+	}
+	return (rv);
 }
 
 static void
@@ -710,6 +724,11 @@ udp_recv_creq(udp_ep *ep, udp_sp_msg *creq, nng_sockaddr *sa)
 
 		udp_pipe_schedule(p);
 		udp_send_cack(ep, p);
+		return;
+	}
+	if ((ep->max_peers != 0) && (ep->peer_count >= ep->max_peers)) {
+		nni_stat_inc(&ep->st_peer_reject, 1);
+		udp_send_disc_full(ep, sa, DISC_NOBUF);
 		return;
 	}
 
@@ -1216,6 +1235,7 @@ udp_ep_init(
 	ep->refresh          = NNG_UDP_REFRESH; // five seconds by default
 	ep->rcvmax           = NNG_UDP_RECVMAX;
 	ep->copymax          = NNG_UDP_COPYMAX;
+	ep->max_peers        = NNG_UDP_MAX_PEERS;
 	if ((rv = nni_msg_alloc(&ep->rx_payload, ep->rcvmax) != 0)) {
 		NNI_FREE_STRUCTS(ep->tx_ring.descs, NNG_UDP_TXQUEUE_LEN);
 		return (rv);
@@ -1249,6 +1269,11 @@ udp_ep_init(
 	NNI_STAT_LOCK(peer_inactive_info, "peer_inactive",
 	    "connections closed due to inactive peer", NNG_STAT_COUNTER,
 	    NNG_UNIT_EVENTS);
+	NNI_STAT_LOCK(peer_max_info, "peer_max", "maximum admitted peers",
+	    NNG_STAT_LEVEL, NNG_UNIT_MESSAGES);
+	NNI_STAT_LOCK(peer_reject_info, "peer_reject",
+	    "connection requests rejected at the peer limit", NNG_STAT_COUNTER,
+	    NNG_UNIT_MESSAGES);
 
 	nni_stat_init_lock(&ep->st_rcv_max, &rcv_max_info, &ep->mtx);
 	nni_stat_init_lock(&ep->st_copy_max, &copy_max_info, &ep->mtx);
@@ -1261,6 +1286,9 @@ udp_ep_init(
 	nni_stat_init_lock(&ep->st_snd_nobuf, &snd_nobuf_info, &ep->mtx);
 	nni_stat_init_lock(
 	    &ep->st_peer_inactive, &peer_inactive_info, &ep->mtx);
+	nni_stat_init_lock(&ep->st_peer_max, &peer_max_info, &ep->mtx);
+	nni_stat_init_lock(&ep->st_peer_reject, &peer_reject_info, &ep->mtx);
+	nni_stat_set_value(&ep->st_peer_max, ep->max_peers);
 
 	if (l) {
 		NNI_ASSERT(d == NULL);
@@ -1273,6 +1301,8 @@ udp_ep_init(
 		nni_listener_add_stat(l, &ep->st_rcv_nobuf);
 		nni_listener_add_stat(l, &ep->st_snd_toobig);
 		nni_listener_add_stat(l, &ep->st_snd_nobuf);
+		nni_listener_add_stat(l, &ep->st_peer_max);
+		nni_listener_add_stat(l, &ep->st_peer_reject);
 	}
 	if (d) {
 		NNI_ASSERT(l == NULL);
@@ -1285,6 +1315,8 @@ udp_ep_init(
 		nni_dialer_add_stat(d, &ep->st_rcv_nobuf);
 		nni_dialer_add_stat(d, &ep->st_snd_toobig);
 		nni_dialer_add_stat(d, &ep->st_snd_nobuf);
+		nni_dialer_add_stat(d, &ep->st_peer_max);
+		nni_dialer_add_stat(d, &ep->st_peer_reject);
 	}
 
 	// schedule our timer callback - forever for now
@@ -1596,6 +1628,39 @@ udp_ep_set_copymax(void *arg, const void *v, size_t sz, nni_opt_type t)
 	return (rv);
 }
 
+static nng_err
+udp_ep_get_max_peers(void *arg, void *v, size_t *szp, nni_opt_type t)
+{
+	udp_ep *ep = arg;
+	nng_err rv;
+
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_size(ep->max_peers, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
+}
+
+static nng_err
+udp_ep_set_max_peers(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	udp_ep *ep = arg;
+	size_t  val;
+	nng_err rv;
+
+	if ((rv = nni_copyin_size(&val, v, sz, 0, UINT32_MAX, t)) != NNG_OK) {
+		return (rv);
+	}
+	nni_mtx_lock(&ep->mtx);
+	if (ep->started) {
+		nni_mtx_unlock(&ep->mtx);
+		return (NNG_EBUSY);
+	}
+	ep->max_peers = val;
+	nni_mtx_unlock(&ep->mtx);
+	nni_stat_set_value(&ep->st_peer_max, val);
+	return (NNG_OK);
+}
+
 // this just looks for pipes waiting for an aio, and aios waiting for
 // a connection, and matches them together.
 static void
@@ -1699,6 +1764,11 @@ static const nni_option udp_ep_opts[] = {
 	    .o_name = NNG_OPT_UDP_COPY_MAX,
 	    .o_get  = udp_ep_get_copymax,
 	    .o_set  = udp_ep_set_copymax,
+	},
+	{
+	    .o_name = NNG_OPT_UDP_MAX_PEERS,
+	    .o_get  = udp_ep_get_max_peers,
+	    .o_set  = udp_ep_set_max_peers,
 	},
 	{
 	    .o_name = NNG_OPT_LOCADDR,

--- a/src/sp/transport/udp/udp_tran_test.c
+++ b/src/sp/transport/udp/udp_tran_test.c
@@ -493,7 +493,7 @@ test_udp_max_peers(void)
 	nng_socket      client2;
 	nng_listener    listener;
 	nng_dialer      dialer;
-	const nng_stat *stats;
+	nng_stat       *stats;
 	const nng_stat *lstats;
 	const nng_stat *reject;
 	size_t          max_peers;
@@ -518,7 +518,7 @@ test_udp_max_peers(void)
 	NUTS_PASS(nng_sub0_open(&client2));
 	NUTS_PASS(nng_sub0_socket_subscribe(client2, "", 0));
 	NUTS_PASS(nng_dialer_create(&dialer, client2, addr));
-	NUTS_PASS(nng_dialer_start(dialer, 0));
+	NUTS_PASS(nng_dialer_start(dialer, NNG_FLAG_NONBLOCK));
 	nng_msleep(100);
 
 	NUTS_PASS(nng_stats_get(&stats));

--- a/src/sp/transport/udp/udp_tran_test.c
+++ b/src/sp/transport/udp/udp_tran_test.c
@@ -486,6 +486,53 @@ test_udp_pipe(void)
 }
 
 void
+test_udp_max_peers(void)
+{
+	nng_socket      server;
+	nng_socket      client1;
+	nng_socket      client2;
+	nng_listener    listener;
+	nng_dialer      dialer;
+	const nng_stat *stats;
+	const nng_stat *lstats;
+	const nng_stat *reject;
+	size_t          max_peers;
+	char           *addr;
+
+	NUTS_ADDR(addr, "udp4");
+	NUTS_PASS(nng_pub0_open(&server));
+	NUTS_PASS(nng_listener_create(&listener, server, addr));
+	NUTS_PASS(nng_listener_get_size(
+	    listener, NNG_OPT_UDP_MAX_PEERS, &max_peers));
+	NUTS_TRUE(max_peers == 1024);
+	NUTS_PASS(nng_listener_set_size(listener, NNG_OPT_UDP_MAX_PEERS, 1));
+	NUTS_PASS(nng_listener_start(listener, 0));
+	NUTS_FAIL(
+	    nng_listener_set_size(listener, NNG_OPT_UDP_MAX_PEERS, 2), NNG_EBUSY);
+
+	NUTS_PASS(nng_sub0_open(&client1));
+	NUTS_PASS(nng_sub0_socket_subscribe(client1, "", 0));
+	NUTS_PASS(nng_dial(client1, addr, NULL, 0));
+	nng_msleep(100);
+
+	NUTS_PASS(nng_sub0_open(&client2));
+	NUTS_PASS(nng_sub0_socket_subscribe(client2, "", 0));
+	NUTS_PASS(nng_dialer_create(&dialer, client2, addr));
+	NUTS_PASS(nng_dialer_start(dialer, 0));
+	nng_msleep(100);
+
+	NUTS_PASS(nng_stats_get(&stats));
+	NUTS_TRUE((lstats = nng_stat_find_listener(stats, listener)) != NULL);
+	NUTS_TRUE((reject = nng_stat_find(lstats, "peer_reject")) != NULL);
+	NUTS_TRUE(nng_stat_value(reject) > 0);
+	nng_stats_free(stats);
+
+	NUTS_CLOSE(client2);
+	NUTS_CLOSE(client1);
+	NUTS_CLOSE(server);
+}
+
+void
 test_udp_reconnect_dialer(void)
 {
 	nng_socket   s0;
@@ -605,6 +652,7 @@ NUTS_TESTS = {
 	{ "udp multi small burst", test_udp_multi_small_burst },
 	{ "udp crush", test_udp_crush },
 	{ "udp pipe", test_udp_pipe },
+	{ "udp max peers", test_udp_max_peers },
 	{ "udp reconnect dialer", test_udp_reconnect_dialer },
 	{ "udp stats", test_udp_stats },
 	{ NULL, NULL },

--- a/src/sp/transport/udp/udp_tran_test.c
+++ b/src/sp/transport/udp/udp_tran_test.c
@@ -497,6 +497,8 @@ test_udp_max_peers(void)
 	const nng_stat *lstats;
 	const nng_stat *reject;
 	size_t          max_peers;
+	size_t          len;
+	char            buf[16];
 	char           *addr;
 
 	NUTS_ADDR(addr, "udp4");
@@ -526,6 +528,16 @@ test_udp_max_peers(void)
 	NUTS_TRUE((reject = nng_stat_find(lstats, "peer_reject")) != NULL);
 	NUTS_TRUE(nng_stat_value(reject) > 0);
 	nng_stats_free(stats);
+
+	NUTS_PASS(nng_socket_set_ms(client1, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(client2, NNG_OPT_RECVTIMEO, 100));
+	NUTS_PASS(nng_send(server, "ok", 3, 0));
+	len = sizeof(buf);
+	NUTS_PASS(nng_recv(client1, buf, &len, 0));
+	NUTS_TRUE(len == 3);
+	NUTS_MATCH(buf, "ok");
+	len = sizeof(buf);
+	NUTS_FAIL(nng_recv(client2, buf, &len, 0), NNG_ETIMEDOUT);
 
 	NUTS_CLOSE(client2);
 	NUTS_CLOSE(client1);


### PR DESCRIPTION
Fixes unbounded UDP/DTLS peer allocation triggered by forged source addresses.

Adds a tunable `NNG_OPT_UDP_MAX_PEERS` limit with a secure default of 1024; UDP bounds admitted peers, while DTLS bounds only unauthenticated handshakes and expires abandoned handshakes.

Adds transport coverage and documents the peer-admission behavior.

Verified with `udp_tran_test` and `dtls_tran_test`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `NNG_OPT_UDP_MAX_PEERS` option for UDP and DTLS listeners.
  * Listeners now cap admitted peers (default: 1024); set to `0` to disable.
  * DTLS now limits unauthenticated handshakes until TLS validation completes.
  * Added stats to track the configured peer limit and rejected connection attempts.

* **Documentation**
  * Documented “Peer Admission” behavior and the new option semantics.

* **Tests**
  * Added UDP and DTLS coverage for defaults, reconfiguration rules, and rejection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->