### PR TITLE
Assorted minor security concerns

### DIFF
--- a/src/core/message.c
+++ b/src/core/message.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -615,6 +615,7 @@ nni_msg_header_trim_u32(nni_msg *m)
 {
 	uint32_t val;
 	uint8_t *dst;
+	NNI_ASSERT(m->m_header_len >= sizeof(val));
 	dst = (void *) m->m_header_buf;
 	NNI_GET32(dst, val);
 	m->m_header_len -= sizeof(val);

--- a/src/platform/posix/posix_ipclisten.c
+++ b/src/platform/posix/posix_ipclisten.c
@@ -424,7 +424,9 @@ ipc_listener_listen(void *arg)
 #ifdef NNG_HAVE_ABSTRACT_SOCKETS
 	// If the original address was for a system assigned value,
 	// then figure out what we got.  This is analogous to TCP
-	// binding to port 0.
+	// binding to port 0.  Note for reviewers - the kernel's names for
+	// such sockets are always very well formed, the leading NULL byte,
+	// followed by 5 ascii characters.
 	if ((l->sa.s_family == NNG_AF_ABSTRACT) &&
 	    (l->sa.s_abstract.sa_len == 0)) {
 		struct sockaddr_un *su = (void *) &ss;
@@ -438,6 +440,7 @@ ipc_listener_listen(void *arg)
 			l->sa.s_abstract.sa_len = len;
 			memcpy(
 			    l->sa.s_abstract.sa_name, &su->sun_path[1], len);
+			l->sa.s_abstract.sa_name[len] = 0; // null terminate
 		}
 	}
 #endif

--- a/src/sp/transport/dtls/dtls.c
+++ b/src/sp/transport/dtls/dtls.c
@@ -106,7 +106,7 @@ struct dtls_pipe {
 	bool          pending; // true until TLS validates this inbound peer
 	bool          closed;  // true if we are closed (no more send or recv!)
 	bool          dialer;  // true if we are dialer
-	nng_duration  refresh; // seconds, for the protocol
+	nng_duration  refresh; // milliseconds, for the protocol
 	nng_time      next_wake;
 	nng_time      expire; // inactivity expiration time
 	nng_time      next_refresh;
@@ -173,7 +173,7 @@ struct dtls_ep {
 	nni_sockaddr    peer_sa;    // peer address, only for dialer;
 	nni_list        connaios; // aios from accept waiting for a client peer
 	nni_list        connpipes; // pipes waiting to be connected
-	nng_duration    refresh; // refresh interval for connections in seconds
+	nng_duration    refresh; // refresh interval for connections in milliseconds
 	uint16_t        rcvmax;  // max payload, trimmed to uint16_t
 	size_t          max_peers;
 	size_t          pending_peers;
@@ -442,7 +442,8 @@ dtls_pipe_send_tls(dtls_pipe *p)
 	case OPCODE_CREQ:
 	case OPCODE_CACK:
 		NNI_PUT16LE(&hdr->us_params[0], p->recv_max);
-		NNI_PUT16LE(&hdr->us_params[1], p->refresh);
+		NNI_PUT16LE(&hdr->us_params[1],
+		    (p->refresh + NNI_SECOND - 1) / NNI_SECOND);
 		break;
 
 	case OPCODE_DISC:

--- a/src/sp/transport/dtls/dtls.c
+++ b/src/sp/transport/dtls/dtls.c
@@ -673,7 +673,7 @@ dtls_pipe_recv_tls_cb(void *arg)
 			goto bad;
 		}
 		NNI_GET16LE(&hdr->us_params[0], rcvmax);
-		NNI_GET16LE(&hdr->us_params[0], refresh);
+		NNI_GET16LE(&hdr->us_params[1], refresh);
 
 		if ((refresh > 0) && ((refresh * NNI_SECOND) < p->refresh)) {
 			p->refresh = refresh * NNI_SECOND;

--- a/src/sp/transport/ipc/ipc_test.c
+++ b/src/sp/transport/ipc/ipc_test.c
@@ -422,6 +422,22 @@ test_abstract_sockets(void)
 }
 
 void
+test_abstract_autobind(void)
+{
+#ifdef NNG_HAVE_ABSTRACT_SOCKETS
+	nng_stream_listener *l;
+
+	// An empty abstract name asks the kernel to assign one.
+	NUTS_PASS(nng_stream_listener_alloc(&l, "abstract://"));
+	NUTS_PASS(nng_stream_listener_listen(l));
+	nng_stream_listener_close(l);
+	nng_stream_listener_free(l);
+#else
+	NUTS_SKIP("No abstract sockets.");
+#endif
+}
+
+void
 test_abstract_too_long(void)
 {
 #ifdef NNG_HAVE_ABSTRACT_SOCKETS
@@ -629,6 +645,7 @@ TEST_LIST = {
 	{ "ipc listen duplicate", test_ipc_listen_duplicate },
 	{ "ipc listen accept cancel", test_ipc_listen_accept_cancel },
 	{ "ipc abstract sockets", test_abstract_sockets },
+	{ "ipc abstract auto-bind", test_abstract_autobind },
 	{ "ipc abstract name too long", test_abstract_too_long },
 	{ "ipc abstract embedded null", test_abstract_null },
 	{ "ipc unix alias", test_unix_alias },

--- a/src/sp/transport/tls/tls_tran_test.c
+++ b/src/sp/transport/tls/tls_tran_test.c
@@ -107,6 +107,7 @@ test_tls_bad_cert_mutual(void)
 	nng_listener    l;
 	nng_dialer      d;
 	const nng_url  *url;
+	nng_err         rv;
 
 	NUTS_ENABLE_LOG(NNG_LOG_DEBUG);
 	c1 = tls_server_config();
@@ -125,7 +126,11 @@ test_tls_bad_cert_mutual(void)
 	NUTS_PASS(nng_dialer_create_url(&d, s2, url));
 	NUTS_PASS(nng_dialer_set_tls(d, c2));
 #ifdef NNG_TLS_ENGINE_MBEDTLS
-	NUTS_FAIL(nng_dialer_start(d, 0), NNG_ECRYPTO);
+	// The server rejects the client's certificate.  Depending on when
+	// the peer closes its TLS connection, the client observes either the
+	// TLS failure or the resulting connection shutdown.
+	rv = nng_dialer_start(d, 0);
+	NUTS_TRUE((rv == NNG_ECRYPTO) || (rv == NNG_ECONNSHUT));
 #else
 	// WolfSSL doesn't validate this here.
 	nng_dialer_start(d, 0);

--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -627,11 +627,15 @@ udp_recv_data(udp_ep *ep, udp_sp_msg *dreq, size_t len, const nng_sockaddr *sa)
 	p->expire    = now + UDP_PIPE_TIMEOUT(p);
 	p->next_wake = now + UDP_PIPE_REFRESH(p);
 
+	// We verified this above. By setting it here we ensure that we
+	// do not wind up copying or accessing past the header, which is
+	// both faster and prevents certain kinds of data smuggling.
+	len = dreq->us_length;
+
 	udp_pipe_schedule(p);
 
-	// trim the message down to its
-	nni_msg_chop(
-	    ep->rx_payload, nni_msg_len(ep->rx_payload) - dreq->us_length);
+	// trim the message down to its length.
+	nni_msg_chop(ep->rx_payload, nni_msg_len(ep->rx_payload) - len);
 
 	// We have a choice to make.  Drop this message (easiest), or
 	// drop the oldest.  We drop the oldest because generally we

--- a/src/sp/transport/ws/websocket.c
+++ b/src/sp/transport/ws/websocket.c
@@ -510,6 +510,11 @@ wstran_accept_cb(void *arg)
 	if ((rv = nni_aio_result(aaio)) != 0) {
 		goto error;
 	}
+	if (l->closed) {
+		nng_stream_free(ws);
+		nni_mtx_unlock(&l->mtx);
+		return;
+	}
 
 	rv = nni_pipe_alloc_listener((void **) &p, l->nlistener);
 	if (rv != 0) {

--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -921,6 +921,7 @@ ws_read_frame_cb(nni_ws *ws, ws_frame *frame)
 		if (!ws->recv_text) {
 			// No support for text mode at present.
 			ws_close(ws, WS_CLOSE_UNSUPP_FORMAT);
+			return;
 		}
 		// FALLTHROUGH
 	case WS_BINARY:

--- a/src/supplemental/websocket/websocket_test.c
+++ b/src/supplemental/websocket/websocket_test.c
@@ -373,6 +373,88 @@ test_websocket_text_mode(void)
 	nng_stream_dialer_free(d);
 }
 
+void
+test_websocket_text_rejected(void)
+{
+	nng_stream_dialer   *d    = NULL;
+	nng_stream_listener *l    = NULL;
+	nng_aio             *daio = NULL;
+	nng_aio             *laio = NULL;
+	nng_aio             *raio = NULL;
+	nng_aio             *saio = NULL;
+	nng_stream          *c1   = NULL;
+	nng_stream          *c2   = NULL;
+	char                 uri[64];
+	char                 buf[5];
+	char                 text[] = "TEXT";
+	nng_iov              iov;
+	uint16_t             port;
+	int                  rv;
+
+	NUTS_PASS(nng_aio_alloc(&daio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&laio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&raio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&saio, NULL, NULL));
+	nng_aio_set_timeout(daio, 5000);
+	nng_aio_set_timeout(laio, 5000);
+	nng_aio_set_timeout(raio, 5000);
+	nng_aio_set_timeout(saio, 5000);
+
+	for (int i = 0; i < 256; i++) {
+		port = nuts_next_port();
+		(void) snprintf(
+		    uri, sizeof(uri), "ws://127.0.0.1:%d/test", port);
+		NUTS_PASS(nng_stream_listener_alloc(&l, uri));
+		NUTS_PASS(nng_stream_dialer_alloc(&d, uri));
+		NUTS_PASS(nng_stream_dialer_set_bool(
+		    d, NNG_OPT_WS_SEND_TEXT, true));
+		rv = nng_stream_listener_listen(l);
+		if (rv != NNG_EADDRINUSE) {
+			break;
+		}
+		nng_stream_listener_free(l);
+		nng_stream_dialer_free(d);
+	}
+	NUTS_PASS(rv);
+
+	nng_stream_dialer_dial(d, daio);
+	nng_stream_listener_accept(l, laio);
+	nng_aio_wait(laio);
+	nng_aio_wait(daio);
+	NUTS_PASS(nng_aio_result(laio));
+	NUTS_PASS(nng_aio_result(daio));
+	c1 = nng_aio_get_output(laio, 0);
+	c2 = nng_aio_get_output(daio, 0);
+	NUTS_TRUE(c1 != NULL);
+	NUTS_TRUE(c2 != NULL);
+
+	// Text receive mode is disabled on the listener, so its pending read
+	// must be aborted after the peer sends a text frame.
+	iov.iov_buf = buf;
+	iov.iov_len = sizeof(buf);
+	NUTS_PASS(nng_aio_set_iov(raio, 1, &iov));
+	nng_stream_recv(c1, raio);
+	iov.iov_buf = text;
+	iov.iov_len = sizeof(text);
+	NUTS_PASS(nng_aio_set_iov(saio, 1, &iov));
+	nng_stream_send(c2, saio);
+	nng_aio_wait(raio);
+	nng_aio_wait(saio);
+	NUTS_FAIL(nng_aio_result(raio), NNG_ECLOSED);
+	NUTS_PASS(nng_aio_result(saio));
+
+	nng_stream_close(c1);
+	nng_stream_free(c1);
+	nng_stream_close(c2);
+	nng_stream_free(c2);
+	nng_aio_free(saio);
+	nng_aio_free(raio);
+	nng_aio_free(laio);
+	nng_aio_free(daio);
+	nng_stream_listener_free(l);
+	nng_stream_dialer_free(d);
+}
+
 typedef struct recv_state {
 	nng_stream  *c;
 	int          total;
@@ -559,5 +641,6 @@ NUTS_TESTS = {
 	{ "websocket conn properties", test_websocket_conn_props },
 	{ "websocket fragmentation", test_websocket_fragmentation },
 	{ "websocket text mode", test_websocket_text_mode },
+	{ "websocket text rejected", test_websocket_text_rejected },
 	{ NULL, NULL },
 };


### PR DESCRIPTION
This fixes a few different minor (unlikely to be remotely exploitable) security concerns that were found during a comprehensive security audit of our code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected DTLS refresh parameter encoding/decoding in connection acknowledgements.
  * Improved UDP receive processing to consistently use the validated payload length.
  * Fixed WebSocket behavior to immediately close on unsupported text frames.
  * Prevented WebSocket accept-side work when the listener is already closed.
  * Improved decoding/termination of abstract socket names and added header-length validation for 32-bit trimming.
* **New Tests**
  * Added an IPC abstract-socket auto-bind test.
  * Added a WebSocket test verifying rejected text handling.
* **Tests**
  * Broadened mutual bad-certificate TLS test to accept multiple failure outcomes.
* **Chores**
  * Refreshed copyright years in affected components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->