### PR TITLE
udp: add UDP and DTLS connection tunables

### DIFF
--- a/docs/ref/tran/dtls.md
+++ b/docs/ref/tran/dtls.md
@@ -97,8 +97,8 @@ listener is started.
 | Option                                                | Type     | Description                                                                                                                     |
 | ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | [`NNG_OPT_RECVMAXSZ`]                                 | `size_t` | Maximum size of incoming messages. Values larger than the DTLS transport maximum are clamped to the transport maximum.          |
-| [`NNG_OPT_UDP_CONN_RETRY`]                             | `nng_duration` | Interval between connection requests while dialing. The default is 200 milliseconds.                                            |
-| [`NNG_OPT_UDP_CONN_EXPIRE`]                            | `nng_duration` | Time allowed to establish a connection. The default is 5 seconds.                                                              |
+| [`NNG_OPT_UDP_CONN_RETRY`]                             | `nng_duration` | Interval between connection requests while dialing. The default is 200 milliseconds. Only positive values are accepted; `<= 0` returns `NNG_EINVAL`. |
+| [`NNG_OPT_UDP_CONN_EXPIRE`]                            | `nng_duration` | Time allowed to establish a connection. The default is 5 seconds. Only positive values are accepted; `<= 0` returns `NNG_EINVAL`. |
 | [`NNG_OPT_UDP_MAX_PEERS`]                              | `size_t` | Maximum number of unauthenticated inbound DTLS handshakes. The default is 1024; set to 0 to disable the limit.                   |
 | `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a> | `int`    | The locally bound UDP port number (1-65535), read-only for [listener] objects only.                                             |
 

--- a/docs/ref/tran/dtls.md
+++ b/docs/ref/tran/dtls.md
@@ -97,6 +97,8 @@ listener is started.
 | Option                                                | Type     | Description                                                                                                                     |
 | ----------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | [`NNG_OPT_RECVMAXSZ`]                                 | `size_t` | Maximum size of incoming messages. Values larger than the DTLS transport maximum are clamped to the transport maximum.          |
+| [`NNG_OPT_UDP_CONN_RETRY`]                             | `nng_duration` | Interval between connection requests while dialing. The default is 200 milliseconds.                                            |
+| [`NNG_OPT_UDP_CONN_EXPIRE`]                            | `nng_duration` | Time allowed to establish a connection. The default is 5 seconds.                                                              |
 | [`NNG_OPT_UDP_MAX_PEERS`]                              | `size_t` | Maximum number of unauthenticated inbound DTLS handshakes. The default is 1024; set to 0 to disable the limit.                   |
 | `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a> | `int`    | The locally bound UDP port number (1-65535), read-only for [listener] objects only.                                             |
 

--- a/docs/ref/tran/udp.md
+++ b/docs/ref/tran/udp.md
@@ -115,6 +115,7 @@ UDP dialers retry their connection request every 200 milliseconds by default
 and give up after 5 seconds. Configure [`NNG_OPT_UDP_CONN_RETRY`] and
 [`NNG_OPT_UDP_CONN_EXPIRE`] before starting a dialer to adjust these durations.
 Both options take an [`nng_duration`] and require a positive value.
+Values less than or equal to zero are rejected with `NNG_EINVAL`.
 
 ## Keep Alive
 

--- a/docs/ref/tran/udp.md
+++ b/docs/ref/tran/udp.md
@@ -70,6 +70,8 @@ where supported by the underlying platform.
 | --------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------- |
 | [`NNG_OPT_RECVMAXSZ`]                                     | `size_t` | Maximum size of incoming messages, will be limited to at most 65000.                                                |
 | `NNG_OPT_UDP_COPY_MAX`<a name="NNG_OPT_UDP_COPY_MAX"></a> | `size_t` | Threshold above which received messages are "loaned" up, rather than a new message being allocated and copied into. |
+| [`NNG_OPT_UDP_CONN_RETRY`]                                 | `nng_duration` | Interval between connection requests while dialing. The default is 200 milliseconds.                                 |
+| [`NNG_OPT_UDP_CONN_EXPIRE`]                                | `nng_duration` | Time allowed to establish a connection. The default is 5 seconds.                                                   |
 | `NNG_OPT_UDP_MAX_PEERS`<a name="NNG_OPT_UDP_MAX_PEERS"></a> | `size_t` | Maximum number of remote peers admitted by a listener. The default is 1024; set to 0 to disable the limit. |
 | `NNG_OPT_BOUND_PORT`<a name="NNG_OPT_BOUND_PORT"></a>     | `int`    | The locally bound UDP port number (1-65535), read-only for [listener] objects only.                                 |
 
@@ -107,13 +109,18 @@ requests, listeners admit at most 1024 peers by default. Configure
 [`NNG_OPT_UDP_MAX_PEERS`] before starting the listener to select another
 limit. A value of 0 disables this protection.
 
+## Connection Establishment
+
+UDP dialers retry their connection request every 200 milliseconds by default
+and give up after 5 seconds. Configure [`NNG_OPT_UDP_CONN_RETRY`] and
+[`NNG_OPT_UDP_CONN_EXPIRE`] before starting a dialer to adjust these durations.
+Both options take an [`nng_duration`] and require a positive value.
+
 ## Keep Alive
 
 This transports maintains a logical "connection" with each peer, to provide a rough
 facsimile of a connection based semantic. This requires some resource on each peer.
 In order to ensure that resources are reclaimed when a peer vanishes unexpectedly, a
 keep-alive mechanism is implemented.
-
-TODO: Document the tunables for this.
 
 {{#include ../xref.md}}

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -858,10 +858,11 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 #define NNG_OPT_UDP_COPY_MAX "udp:copy-max"
 
 // Interval between connection requests while a UDP-based dialer is waiting
-// for its peer to accept the connection.
+// for its peer to accept the connection.  The duration must be positive.
 #define NNG_OPT_UDP_CONN_RETRY "udp:conn-retry"
 
-// Time a UDP-based dialer waits for its peer to accept the connection.
+// Time a UDP-based dialer waits for its peer to accept the connection.  The
+// duration must be positive.
 #define NNG_OPT_UDP_CONN_EXPIRE "udp:conn-expire"
 
 // Maximum number of peers admitted by a UDP-based listener.  A value of zero

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -857,6 +857,13 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 // to replace a full message buffer.
 #define NNG_OPT_UDP_COPY_MAX "udp:copy-max"
 
+// Interval between connection requests while a UDP-based dialer is waiting
+// for its peer to accept the connection.
+#define NNG_OPT_UDP_CONN_RETRY "udp:conn-retry"
+
+// Time a UDP-based dialer waits for its peer to accept the connection.
+#define NNG_OPT_UDP_CONN_EXPIRE "udp:conn-expire"
+
 // Maximum number of peers admitted by a UDP-based listener.  A value of zero
 // disables the limit.  This option is also supported by DTLS listeners, where
 // it limits unauthenticated handshakes.

--- a/src/sp/transport/dtls/dtls.c
+++ b/src/sp/transport/dtls/dtls.c
@@ -77,6 +77,10 @@ typedef enum dtls_disc_reason {
 #define NNG_DTLS_CONNRETRY (NNI_SECOND / 5)
 #endif
 
+#ifndef NNG_DTLS_CONNEXPIRE
+#define NNG_DTLS_CONNEXPIRE (5 * NNI_SECOND)
+#endif
+
 #ifndef NNG_DTLS_MAX_PEERS
 #define NNG_DTLS_MAX_PEERS 1024
 #endif
@@ -174,6 +178,8 @@ struct dtls_ep {
 	nni_list        connaios; // aios from accept waiting for a client peer
 	nni_list        connpipes; // pipes waiting to be connected
 	nng_duration    refresh; // refresh interval for connections in milliseconds
+	nng_duration    conn_retry;
+	nng_duration    conn_expire;
 	uint16_t        rcvmax;  // max payload, trimmed to uint16_t
 	size_t          max_peers;
 	size_t          pending_peers;
@@ -643,6 +649,12 @@ dtls_pipe_recv_tls_cb(void *arg)
 		goto bad;
 	}
 
+	if (!p->matched) {
+		// The shorter retry interval is only for establishing the
+		// connection.  Once the peer responds, resume the normal
+		// keep-alive cadence.
+		p->refresh = ep->refresh;
+	}
 	p->expire = nni_clock() + DTLS_PIPE_TIMEOUT(p);
 
 	if (!p->matched) {
@@ -769,8 +781,9 @@ dtls_pipe_alloc(dtls_ep *ep, dtls_pipe **pp, const nng_sockaddr *sa)
 	p->peer      = ep->peer;
 	p->peer_addr = *sa;
 	p->id        = nng_sockaddr_hash(sa);
-	p->refresh   = ep->refresh;
-	p->expire    = nni_clock() + DTLS_PIPE_TIMEOUT(p);
+	p->refresh = ep->dialer ? ep->conn_retry : ep->refresh;
+	p->expire = nni_clock() +
+	    (ep->dialer ? ep->conn_expire : DTLS_PIPE_TIMEOUT(p));
 	p->pending   = !ep->dialer;
 	p->send_max  = NNG_DTLS_RECVMAX;
 	p->recv_max  = ep->rcvmax;
@@ -1262,6 +1275,8 @@ dtls_ep_init(
 	ep->peer             = nni_sock_peer_id(sock);
 	ep->url              = url;
 	ep->refresh          = NNG_DTLS_REFRESH; // one minute by default
+	ep->conn_retry       = NNG_DTLS_CONNRETRY;
+	ep->conn_expire      = NNG_DTLS_CONNEXPIRE;
 	ep->rcvmax           = NNG_DTLS_RECVMAX;
 	ep->max_peers        = NNG_DTLS_MAX_PEERS;
 
@@ -1594,6 +1609,76 @@ dtls_ep_set_recvmaxsz(void *arg, const void *v, size_t sz, nni_opt_type t)
 }
 
 static nng_err
+dtls_ep_get_conn_retry(void *arg, void *v, size_t *szp, nni_opt_type t)
+{
+	dtls_ep *ep = arg;
+	nng_err  rv;
+
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_ms(ep->conn_retry, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
+}
+
+static nng_err
+dtls_ep_set_conn_retry(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	dtls_ep      *ep = arg;
+	nng_duration  val;
+	nng_err       rv;
+
+	if ((rv = nni_copyin_ms(&val, v, sz, t)) != NNG_OK) {
+		return (rv);
+	}
+	if (val <= 0) {
+		return (NNG_EINVAL);
+	}
+	nni_mtx_lock(&ep->mtx);
+	if (ep->started) {
+		nni_mtx_unlock(&ep->mtx);
+		return (NNG_EBUSY);
+	}
+	ep->conn_retry = val;
+	nni_mtx_unlock(&ep->mtx);
+	return (NNG_OK);
+}
+
+static nng_err
+dtls_ep_get_conn_expire(void *arg, void *v, size_t *szp, nni_opt_type t)
+{
+	dtls_ep *ep = arg;
+	nng_err  rv;
+
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_ms(ep->conn_expire, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
+}
+
+static nng_err
+dtls_ep_set_conn_expire(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	dtls_ep      *ep = arg;
+	nng_duration  val;
+	nng_err       rv;
+
+	if ((rv = nni_copyin_ms(&val, v, sz, t)) != NNG_OK) {
+		return (rv);
+	}
+	if (val <= 0) {
+		return (NNG_EINVAL);
+	}
+	nni_mtx_lock(&ep->mtx);
+	if (ep->started) {
+		nni_mtx_unlock(&ep->mtx);
+		return (NNG_EBUSY);
+	}
+	ep->conn_expire = val;
+	nni_mtx_unlock(&ep->mtx);
+	return (NNG_OK);
+}
+
+static nng_err
 dtls_ep_get_max_peers(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	dtls_ep *ep = arg;
@@ -1747,6 +1832,16 @@ static const nni_option dtls_ep_opts[] = {
 	    .o_name = NNG_OPT_RECVMAXSZ,
 	    .o_get  = dtls_ep_get_recvmaxsz,
 	    .o_set  = dtls_ep_set_recvmaxsz,
+	},
+	{
+	    .o_name = NNG_OPT_UDP_CONN_RETRY,
+	    .o_get  = dtls_ep_get_conn_retry,
+	    .o_set  = dtls_ep_set_conn_retry,
+	},
+	{
+	    .o_name = NNG_OPT_UDP_CONN_EXPIRE,
+	    .o_get  = dtls_ep_get_conn_expire,
+	    .o_set  = dtls_ep_set_conn_expire,
 	},
 	{
 	    .o_name = NNG_OPT_UDP_MAX_PEERS,

--- a/src/sp/transport/dtls/dtls_tran_test.c
+++ b/src/sp/transport/dtls/dtls_tran_test.c
@@ -245,6 +245,35 @@ test_dtls_max_peers_option(void)
 }
 
 void
+test_dtls_conn_tunables(void)
+{
+	nng_socket   s;
+	nng_dialer   d;
+	nng_duration retry;
+	nng_duration expire;
+	char        *addr;
+
+	NUTS_ADDR(addr, "dtls4");
+	NUTS_OPEN(s);
+	NUTS_PASS(nng_dialer_create(&d, s, addr));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_RETRY, &retry));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_EXPIRE, &expire));
+	NUTS_TRUE(retry == 200);
+	NUTS_TRUE(expire == 5000);
+	NUTS_PASS(nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_RETRY, 50));
+	NUTS_PASS(nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_EXPIRE, 250));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_RETRY, &retry));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_EXPIRE, &expire));
+	NUTS_TRUE(retry == 50);
+	NUTS_TRUE(expire == 250);
+	NUTS_FAIL(nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_RETRY, 0), NNG_EINVAL);
+	NUTS_FAIL(
+	    nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_EXPIRE, 0), NNG_EINVAL);
+	NUTS_PASS(nng_dialer_close(d));
+	NUTS_CLOSE(s);
+}
+
+void
 test_dtls_recv_max(void)
 {
 	char            msg[256];
@@ -667,6 +696,7 @@ NUTS_TESTS = {
 	{ "dtls malformed address", test_dtls_malformed_address },
 	{ "dtls no delay option", test_dtls_no_delay_option },
 	{ "dtls max peers option", test_dtls_max_peers_option },
+	{ "dtls connection tunables", test_dtls_conn_tunables },
 	{ "dtls recv max", test_dtls_recv_max },
 	{ "dtls recv large", test_dtls_recv_large },
 	{ "dtls exchange many", test_dtls_exchange_many },

--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -62,6 +62,10 @@ typedef enum udp_disc_reason {
 #define NNG_UDP_CONNRETRY (NNI_SECOND / 5)
 #endif
 
+#ifndef NNG_UDP_CONNEXPIRE
+#define NNG_UDP_CONNEXPIRE (5 * NNI_SECOND)
+#endif
+
 #define UDP_EP_ROLE(ep) ((ep)->dialer ? "dialer  " : "listener")
 
 // NB: Each of the following messages is exactly 20 bytes in size
@@ -164,6 +168,8 @@ struct udp_ep {
 	nni_list      connaios;   // aios from accept waiting for a client peer
 	nni_list      connpipes;  // pipes waiting to be connected
 	nng_duration  refresh; // refresh interval for connections in seconds
+	nng_duration  conn_retry;
+	nng_duration  conn_expire;
 	udp_sp_msg   *rx_msg;  // contains the received message header
 	uint16_t      rcvmax;  // max payload, trimmed to uint16_t
 	uint16_t      copymax;
@@ -261,10 +267,11 @@ udp_pipe_start(udp_pipe *p, udp_ep *ep, const nng_sockaddr *sa)
 	p->peer      = ep->peer;
 	p->peer_addr = *sa;
 	p->dialer    = ep->dialer;
-	p->refresh   = p->dialer ? NNG_UDP_CONNRETRY : ep->refresh;
+	p->refresh   = p->dialer ? ep->conn_retry : ep->refresh;
 	p->rcvmax    = ep->rcvmax;
 	p->id        = nng_sockaddr_hash(sa);
-	p->expire = now + (p->dialer ? (5 * NNI_SECOND) : UDP_PIPE_TIMEOUT(p));
+	p->expire = now +
+	    (p->dialer ? ep->conn_expire : UDP_PIPE_TIMEOUT(p));
 
 	return (udp_add_pipe(ep, p));
 }
@@ -1237,6 +1244,8 @@ udp_ep_init(
 	ep->peer             = nni_sock_peer_id(sock);
 	ep->url              = url;
 	ep->refresh          = NNG_UDP_REFRESH; // five seconds by default
+	ep->conn_retry       = NNG_UDP_CONNRETRY;
+	ep->conn_expire      = NNG_UDP_CONNEXPIRE;
 	ep->rcvmax           = NNG_UDP_RECVMAX;
 	ep->copymax          = NNG_UDP_COPYMAX;
 	ep->max_peers        = NNG_UDP_MAX_PEERS;
@@ -1633,6 +1642,76 @@ udp_ep_set_copymax(void *arg, const void *v, size_t sz, nni_opt_type t)
 }
 
 static nng_err
+udp_ep_get_conn_retry(void *arg, void *v, size_t *szp, nni_opt_type t)
+{
+	udp_ep *ep = arg;
+	nng_err rv;
+
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_ms(ep->conn_retry, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
+}
+
+static nng_err
+udp_ep_set_conn_retry(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	udp_ep       *ep = arg;
+	nng_duration  val;
+	nng_err       rv;
+
+	if ((rv = nni_copyin_ms(&val, v, sz, t)) != NNG_OK) {
+		return (rv);
+	}
+	if (val <= 0) {
+		return (NNG_EINVAL);
+	}
+	nni_mtx_lock(&ep->mtx);
+	if (ep->started) {
+		nni_mtx_unlock(&ep->mtx);
+		return (NNG_EBUSY);
+	}
+	ep->conn_retry = val;
+	nni_mtx_unlock(&ep->mtx);
+	return (NNG_OK);
+}
+
+static nng_err
+udp_ep_get_conn_expire(void *arg, void *v, size_t *szp, nni_opt_type t)
+{
+	udp_ep *ep = arg;
+	nng_err rv;
+
+	nni_mtx_lock(&ep->mtx);
+	rv = nni_copyout_ms(ep->conn_expire, v, szp, t);
+	nni_mtx_unlock(&ep->mtx);
+	return (rv);
+}
+
+static nng_err
+udp_ep_set_conn_expire(void *arg, const void *v, size_t sz, nni_opt_type t)
+{
+	udp_ep       *ep = arg;
+	nng_duration  val;
+	nng_err       rv;
+
+	if ((rv = nni_copyin_ms(&val, v, sz, t)) != NNG_OK) {
+		return (rv);
+	}
+	if (val <= 0) {
+		return (NNG_EINVAL);
+	}
+	nni_mtx_lock(&ep->mtx);
+	if (ep->started) {
+		nni_mtx_unlock(&ep->mtx);
+		return (NNG_EBUSY);
+	}
+	ep->conn_expire = val;
+	nni_mtx_unlock(&ep->mtx);
+	return (NNG_OK);
+}
+
+static nng_err
 udp_ep_get_max_peers(void *arg, void *v, size_t *szp, nni_opt_type t)
 {
 	udp_ep *ep = arg;
@@ -1768,6 +1847,16 @@ static const nni_option udp_ep_opts[] = {
 	    .o_name = NNG_OPT_UDP_COPY_MAX,
 	    .o_get  = udp_ep_get_copymax,
 	    .o_set  = udp_ep_set_copymax,
+	},
+	{
+	    .o_name = NNG_OPT_UDP_CONN_RETRY,
+	    .o_get  = udp_ep_get_conn_retry,
+	    .o_set  = udp_ep_set_conn_retry,
+	},
+	{
+	    .o_name = NNG_OPT_UDP_CONN_EXPIRE,
+	    .o_get  = udp_ep_get_conn_expire,
+	    .o_set  = udp_ep_set_conn_expire,
 	},
 	{
 	    .o_name = NNG_OPT_UDP_MAX_PEERS,

--- a/src/sp/transport/udp/udp_tran_test.c
+++ b/src/sp/transport/udp/udp_tran_test.c
@@ -545,6 +545,35 @@ test_udp_max_peers(void)
 }
 
 void
+test_udp_conn_tunables(void)
+{
+	nng_socket   s;
+	nng_dialer   d;
+	nng_duration retry;
+	nng_duration expire;
+	char        *addr;
+
+	NUTS_ADDR(addr, "udp4");
+	NUTS_OPEN(s);
+	NUTS_PASS(nng_dialer_create(&d, s, addr));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_RETRY, &retry));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_EXPIRE, &expire));
+	NUTS_TRUE(retry == 200);
+	NUTS_TRUE(expire == 5000);
+	NUTS_PASS(nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_RETRY, 50));
+	NUTS_PASS(nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_EXPIRE, 250));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_RETRY, &retry));
+	NUTS_PASS(nng_dialer_get_ms(d, NNG_OPT_UDP_CONN_EXPIRE, &expire));
+	NUTS_TRUE(retry == 50);
+	NUTS_TRUE(expire == 250);
+	NUTS_FAIL(nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_RETRY, 0), NNG_EINVAL);
+	NUTS_FAIL(
+	    nng_dialer_set_ms(d, NNG_OPT_UDP_CONN_EXPIRE, 0), NNG_EINVAL);
+	NUTS_PASS(nng_dialer_close(d));
+	NUTS_CLOSE(s);
+}
+
+void
 test_udp_reconnect_dialer(void)
 {
 	nng_socket   s0;
@@ -665,6 +694,7 @@ NUTS_TESTS = {
 	{ "udp crush", test_udp_crush },
 	{ "udp pipe", test_udp_pipe },
 	{ "udp max peers", test_udp_max_peers },
+	{ "udp connection tunables", test_udp_conn_tunables },
 	{ "udp reconnect dialer", test_udp_reconnect_dialer },
 	{ "udp stats", test_udp_stats },
 	{ NULL, NULL },


### PR DESCRIPTION
fixes #2178 udp: Make ep->refresh and ep->expire tunable via options

Adds configurable retry and expiry durations for UDP and DTLS dialers while preserving the existing defaults. The transports now use these values during connection establishment and the suite covers their defaults, updates, and validation. Documentation describes the options and their required pre-start configuration. You agree that by submitting a PR, you have read and agreed to our contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added UDP transport tunables for dialer connection retry interval and connection establishment timeout.
  - Added matching DTLS dialer behavior so pipes use the configured retry/expire timing during connection establishment, then return to normal keep-alive cadence.
  - Enforced that timing values must be positive and can’t be changed after endpoint start.
- **Documentation**
  - Updated the UDP and DTLS transport reference docs to include the new connection timing options and reorganized related sections.
- **Bug Fixes**
  - Dialers now apply the configured retry/expiration settings only during connection establishment, then resume standard keep-alive timing.
- **Tests**
  - Added tests covering defaults, updates, and invalid (zero) values for the new tunables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->