### PR TITLE
AIO API consistency and documentation nits

### DIFF
--- a/demo/http_client/http_client.c
+++ b/demo/http_client/http_client.c
@@ -128,7 +128,7 @@ main(int argc, char **argv)
 	iov.iov_buf = data;
 
 	// Following never fails with fewer than 5 elements.
-	nng_aio_set_iov(aio, 1, &iov);
+	(void) nng_aio_set_iov(aio, 1, &iov);
 
 	// Now attempt to receive the data.
 	nng_http_read_all(conn, aio);

--- a/demo/stream/stream.c
+++ b/demo/stream/stream.c
@@ -76,7 +76,7 @@ client(const char *url)
 	// Allocatate a buffer to recv
 	iov.iov_len = 100;
 	iov.iov_buf = (char *) malloc(sizeof(char) * iov.iov_len);
-	if ((rv = nng_aio_set_iov(aio, 1, &iov)) != 0) {
+	if ((rv = nng_aio_set_iov(aio, 1, &iov)) != NNG_OK) {
 		nng_fatal("call to nng_aio_alloc", rv);
 	}
 	// Connect to the socket via url provided to alloc
@@ -138,7 +138,7 @@ server(const char *url)
 	iov.iov_buf = "This is a message.";
 	iov.iov_len = strlen(iov.iov_buf);
 
-	if ((rv = nng_aio_set_iov(aio, 1, &iov)) != 0) {
+	if ((rv = nng_aio_set_iov(aio, 1, &iov)) != NNG_OK) {
 		nng_fatal("call to nng_aio_alloc", rv);
 	}
 	// Connect to the socket via url provided to alloc

--- a/docs/ref/api/aio.md
+++ b/docs/ref/api/aio.md
@@ -263,7 +263,7 @@ typedef struct nng_iov {
     size_t iov_len;
 };
 
-int nng_aio_set_iov(nng_aio *aio, unsigned int niov, nng_iov *iov);
+nng_err nng_aio_set_iov(nng_aio *aio, unsigned int niov, const nng_iov *iov);
 ```
 
 For some operations, the unit of data transferred is not a [message], but
@@ -290,8 +290,8 @@ A maximum of four (4) `nng_iov` members may be supplied.
 ```c
 void *nng_aio_get_input(nng_aio *aio, unsigned int index);
 void *nng_aio_get_output(nng_aio *aio, unsigned int index);
-void nng_aio_set_input(nng_aio *aio, unsigned int index, void *param);
-void nng_aio_set_output(nng_aio *aio, unsigned int index, void *result);
+nng_err nng_aio_set_input(nng_aio *aio, unsigned int index, void *param);
+nng_err nng_aio_set_output(nng_aio *aio, unsigned int index, void *result);
 ```
 
 Asynchronous operations can take additional input parameters, and
@@ -335,7 +335,7 @@ typedef struct nng_iov {
 	size_t iov_len;
 } nng_iov;
 
-void nng_aio_set_iov(nng_aio *aio, unsigned nio, const nng_iov *iov);
+nng_err nng_aio_set_iov(nng_aio *aio, unsigned int niov, const nng_iov *iov);
 ```
 
 {{hi:`nng_iov`}}

--- a/docs/ref/api/aio.md
+++ b/docs/ref/api/aio.md
@@ -251,7 +251,7 @@ retained and it is the consuming application's responsibility to dispose of the 
 This allows an application the opportunity to reuse the message to try again, if it so desires.
 
 For receive operations, the implementation of the operation will set the message on the _aio_
-on success, and the consuming application hasa responsibility to retrieve and dispose of the
+on success, and the consuming application is responsible for retrieving and disposing of the
 message. Failure to do so will leak the message. If the operation does not complete successfully,
 then no message is stored on the _aio_.
 
@@ -420,10 +420,11 @@ void nng_aio_finish(nng_aio *aio, nng_err err);
 ```
 
 The {{i:`nng_aio_finish`}} function completes the operation associated with _aio_.
-The result of the the status _err_.
+The result of the operation is supplied in _err_.
 
-This function causes the callback associated with the _aio_ to called.
-The _aio_ may not be referenced again by the caller.
+Normally, this function causes the callback associated with the _aio_ to be called.
+(But see the [`nng_aio_skip_callback`] function for specific exceptional cases.)
+The _aio_ must not be referenced again by the caller.
 
 > [!TIP]
 > Set any results using [`nng_aio_set_output`] before calling this function.

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -649,13 +649,13 @@ NNG_DECL void nng_aio_set_msg(nng_aio *, nng_msg *);
 NNG_DECL nng_msg *nng_aio_get_msg(nng_aio *);
 
 // nng_aio_set_input sets an input parameter at the given index.
-NNG_DECL int nng_aio_set_input(nng_aio *, unsigned, void *);
+NNG_DECL nng_err nng_aio_set_input(nng_aio *, unsigned, void *);
 
 // nng_aio_get_input retrieves the input parameter at the given index.
 NNG_DECL void *nng_aio_get_input(nng_aio *, unsigned);
 
 // nng_aio_set_output sets an output result at the given index.
-NNG_DECL int nng_aio_set_output(nng_aio *, unsigned, void *);
+NNG_DECL nng_err nng_aio_set_output(nng_aio *, unsigned, void *);
 
 // nng_aio_get_output retrieves the output result at the given index.
 NNG_DECL void *nng_aio_get_output(nng_aio *, unsigned);
@@ -677,7 +677,7 @@ NNG_DECL void nng_aio_set_expire(nng_aio *, nng_time);
 // itself is copied. Data members (the memory regions referenced) *may* be
 // copied as well, depending on the operation.  This operation is guaranteed
 // to succeed if n <= 4, otherwise it may fail due to NNG_ENOMEM.
-NNG_DECL int nng_aio_set_iov(nng_aio *, unsigned, const nng_iov *);
+NNG_DECL nng_err nng_aio_set_iov(nng_aio *, unsigned, const nng_iov *);
 
 // nng_aio_reset is called by the provider before doing other operations on the
 // aio.  Its purpose is to clear certain output fields, to avoid accidental

--- a/src/nng.c
+++ b/src/nng.c
@@ -2059,29 +2059,30 @@ nng_aio_set_expire(nng_aio *aio, nng_time when)
 	nni_aio_set_expire(aio, when);
 }
 
-int
+nng_err
 nng_aio_set_iov(nng_aio *aio, unsigned niov, const nng_iov *iov)
 {
 	return (nni_aio_set_iov(aio, niov, iov));
 }
 
-int
+nng_err
 nng_aio_set_input(nng_aio *aio, unsigned index, void *arg)
 {
 	if (index > 3) {
 		return (NNG_EINVAL);
 	}
 	nni_aio_set_input(aio, index, arg);
-	return (0);
+	return (NNG_OK);
 }
-int
+
+nng_err
 nng_aio_set_output(nng_aio *aio, unsigned index, void *arg)
 {
 	if (index > 3) {
 		return (NNG_EINVAL);
 	}
 	nni_aio_set_output(aio, index, arg);
-	return (0);
+	return (NNG_OK);
 }
 
 void *


### PR DESCRIPTION
These issues were pointed out by @neachdainn on another PR.  I've further improved his fixes and and addressed other issues that I noticed while reviewing that work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Improvements**
  - AIO configuration functions now return the standard `nng_err` type, providing consistent error reporting.
  - Vector-based I/O configuration accepts read-only buffer descriptions.

- **Documentation**
  - Clarified asynchronous I/O completion behavior, callback handling, and object usage requirements.
  - Updated API declarations and corrected minor wording.

- **Bug Fixes**
  - Improved error checks in stream examples to use standard success codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->