### PR TITLE
Improve WebSocket masking throughput

### DIFF
--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -13,6 +13,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__aarch64__)
+#include <arm_neon.h>
+#define NNI_WS_HAVE_NEON 1
+#elif (defined(__clang__) || defined(__GNUC__)) && defined(__SSE2__) && \
+    (defined(__x86_64__) || defined(_M_X64))
+#include <emmintrin.h>
+#define NNI_WS_HAVE_SSE2 1
+#endif
+
 #include "../../core/aio.h"
 #include "../../core/defs.h"
 #include "../../core/message.h"
@@ -318,6 +327,67 @@ ws_frame_fini(ws_frame *frame)
 }
 
 static void
+ws_apply_mask(uint8_t *buf, size_t len, const uint8_t mask[4])
+{
+	uint32_t mask32;
+
+	// Loading the mask through memcpy makes its byte order match the buffer on
+	// both little- and big-endian hosts, without requiring aligned accesses.
+	memcpy(&mask32, mask, sizeof(mask32));
+
+#if defined(NNI_WS_HAVE_NEON)
+	// NEON is mandatory in AArch64.
+	{
+		const uint32x4_t mask128 = vdupq_n_u32(mask32);
+		while (len >= sizeof(uint8x16_t)) {
+			uint8x16_t word = vld1q_u8(buf);
+			vst1q_u8(buf, veorq_u8(word, vreinterpretq_u8_u32(mask128)));
+			buf += sizeof(uint8x16_t);
+			len -= sizeof(uint8x16_t);
+		}
+	}
+#elif defined(NNI_WS_HAVE_SSE2)
+	// SSE2 is mandatory in the x86-64 architecture.
+	{
+		const __m128i mask128 = _mm_set1_epi32((int) mask32);
+		while (len >= sizeof(__m128i)) {
+			__m128i word = _mm_loadu_si128((const __m128i *) buf);
+			_mm_storeu_si128((__m128i *) buf, _mm_xor_si128(word, mask128));
+			buf += sizeof(__m128i);
+			len -= sizeof(__m128i);
+		}
+	}
+#endif
+
+#if SIZE_MAX > UINT32_MAX
+	{
+		const uint64_t mask64 = ((uint64_t) mask32 << 32u) | mask32;
+		while (len >= sizeof(mask64)) {
+			uint64_t word;
+			memcpy(&word, buf, sizeof(word));
+			word ^= mask64;
+			memcpy(buf, &word, sizeof(word));
+			buf += sizeof(word);
+			len -= sizeof(word);
+		}
+	}
+#endif
+
+	while (len >= sizeof(mask32)) {
+		uint32_t word;
+		memcpy(&word, buf, sizeof(word));
+		word ^= mask32;
+		memcpy(buf, &word, sizeof(word));
+		buf += sizeof(word);
+		len -= sizeof(word);
+	}
+
+	for (size_t i = 0; i < len; i++) {
+		buf[i] ^= mask[i];
+	}
+}
+
+static void
 ws_mask_frame(ws_frame *frame)
 {
 	uint32_t r;
@@ -327,9 +397,7 @@ ws_mask_frame(ws_frame *frame)
 	}
 	r = nni_random();
 	NNI_PUT32(frame->mask, r);
-	for (size_t i = 0; i < frame->len; i++) {
-		frame->buf[i] ^= frame->mask[i % 4];
-	}
+	ws_apply_mask(frame->buf, frame->len, frame->mask);
 	memcpy(frame->head + frame->hlen, frame->mask, 4);
 	frame->hlen += 4;
 	frame->head[1] |= 0x80; // set masked bit
@@ -343,9 +411,7 @@ ws_unmask_frame(ws_frame *frame)
 	if (!frame->masked) {
 		return;
 	}
-	for (size_t i = 0; i < frame->len; i++) {
-		frame->buf[i] ^= frame->mask[i % 4];
-	}
+	ws_apply_mask(frame->buf, frame->len, frame->mask);
 	frame->hlen -= 4;
 	frame->head[1] &= 0x7f; // clear masked bit
 	frame->masked = false;

--- a/src/supplemental/websocket/websocket_test.c
+++ b/src/supplemental/websocket/websocket_test.c
@@ -240,8 +240,8 @@ test_websocket_text_mode(void)
 	nng_stream          *c1   = NULL;
 	nng_stream          *c2   = NULL;
 	char                 uri[64];
-	char                 txb[5];
-	char                 rxb[5];
+	char                 txb[25];
+	char                 rxb[25];
 	bool                 on;
 	uint16_t             port;
 	nng_iov              iov;
@@ -327,13 +327,13 @@ test_websocket_text_mode(void)
 	NUTS_PASS(nng_stream_get_bool(c2, NNG_OPT_WS_RECV_TEXT, &on));
 	NUTS_TRUE(on == false);
 
-	memcpy(txb, "PING", 5);
+	memcpy(txb, "123456789012345678901234", sizeof(txb));
 	iov.iov_buf = txb;
-	iov.iov_len = 5;
+	iov.iov_len = sizeof(txb);
 	nng_aio_set_iov(aio1, 1, &iov);
 	nng_stream_send(c1, aio1);
 	iov.iov_buf = rxb;
-	iov.iov_len = 5;
+	iov.iov_len = sizeof(rxb);
 	nng_aio_set_iov(aio2, 1, &iov);
 	nng_stream_recv(c2, aio2);
 
@@ -341,17 +341,17 @@ test_websocket_text_mode(void)
 	nng_aio_wait(aio2);
 	NUTS_PASS(nng_aio_result(aio1));
 	NUTS_PASS(nng_aio_result(aio2));
-	NUTS_TRUE(memcmp(rxb, txb, 5) == 0);
+	NUTS_TRUE(memcmp(rxb, txb, sizeof(txb)) == 0);
 
-	memset(rxb, 0, 5);
-	memcpy(txb, "PONG", 5);
+	memset(rxb, 0, sizeof(rxb));
+	memcpy(txb, "987654321098765432109876", sizeof(txb));
 
 	iov.iov_buf = txb;
-	iov.iov_len = 5;
+	iov.iov_len = sizeof(txb);
 	nng_aio_set_iov(aio2, 1, &iov);
 	nng_stream_send(c2, aio2);
 	iov.iov_buf = rxb;
-	iov.iov_len = 5;
+	iov.iov_len = sizeof(rxb);
 	nng_aio_set_iov(aio1, 1, &iov);
 	nng_stream_recv(c1, aio1);
 
@@ -359,7 +359,7 @@ test_websocket_text_mode(void)
 	nng_aio_wait(aio2);
 	NUTS_PASS(nng_aio_result(aio1));
 	NUTS_PASS(nng_aio_result(aio2));
-	NUTS_TRUE(memcmp(rxb, txb, 5) == 0);
+	NUTS_TRUE(memcmp(rxb, txb, sizeof(txb)) == 0);
 
 	nng_stream_close(c1);
 	nng_stream_free(c1);

--- a/src/testing/util.c
+++ b/src/testing/util.c
@@ -540,8 +540,10 @@ nuts_tran_perf(const char *scheme)
 	NUTS_ADDR_ZERO(addr, scheme);
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_SENDTIMEO, 100));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 100));
-	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, 100));
+	// Allow for TLS, WebSocket masking, and occasionally overloaded or
+	// emulated CI runners without making the throughput test flaky.
+	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
+	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_MARRY_EX(s1, s2, addr, NULL, NULL);
 	NUTS_PASS(nng_msg_alloc(&msg, 64));
 	nng_log_notice(scheme, "Exchanging 64 byte messages for 10 seconds");


### PR DESCRIPTION
fixes #1801 WebSocket masking performance

Process WebSocket masks with baseline NEON/SSE2 where guaranteed and alignment-safe scalar 64/32-bit paths elsewhere.
This preserves runtime compatibility while eliminating the per-byte modulo work.
Expanded the client-to-server text test to exercise vector, scalar, and tail paths.

Validation: `ctest --test-dir build -R 'websocket_test$' --output-on-failure` in normal and Release configurations.

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved WebSocket masking and unmasking speed by using hardware-accelerated SIMD where available, with safe scalar fallbacks for all other cases.

* **Tests**
  * Expanded WebSocket text-message tests to cover larger payloads.
  * Increased socket receive timeouts in performance-related tests to reduce flakiness in slower or overloaded environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->