### PR TITLE
Initialize next_wake in UDP transport endpoint

### DIFF
--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -1220,6 +1220,7 @@ udp_ep_init(
 	nni_aio_init(&ep->timeaio, udp_timer_cb, ep);
 	nni_aio_init(&ep->resaio, udp_resolv_cb, ep);
 	nni_aio_completions_init(&ep->complq);
+	ep->next_wake = NNI_TIME_NEVER;
 
 	ep->tx_ring.descs =
 	    NNI_ALLOC_STRUCTS(ep->tx_ring.descs, NNG_UDP_TXQUEUE_LEN);


### PR DESCRIPTION
"Without ep->next_wake = NNI_TIME_NEVER, the listener will never invoke udp_timer_cb when using the UDP transport."



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause unpredictable endpoint wake-up behavior during UDP transport initialization.
  * UDP endpoints now remain inactive until a valid wake-up time is scheduled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->