### PR TITLE
Initialize next_wake in UDP endpoint structure

### DIFF
--- a/src/sp/transport/udp/udp.c
+++ b/src/sp/transport/udp/udp.c
@@ -1250,6 +1250,7 @@ udp_ep_init(
 	ep->rcvmax           = NNG_UDP_RECVMAX;
 	ep->copymax          = NNG_UDP_COPYMAX;
 	ep->max_peers        = NNG_UDP_MAX_PEERS;
+	ep->next_wake        = NNI_TIME_NEVER;
 	if ((rv = nni_msg_alloc(&ep->rx_payload, ep->rcvmax) != 0)) {
 		NNI_FREE_STRUCTS(ep->tx_ring.descs, NNG_UDP_TXQUEUE_LEN);
 		return (rv);


### PR DESCRIPTION
Fix: initialize ep->next_wake to NNI_TIME_NEVER; otherwise the listener never fires udp_timer_cb.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UDP endpoint initialization to ensure its wake-up scheduling starts in a clean, predictable state.
  * Enhanced startup reliability without changing configuration options or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->