### PR TITLE
Fix async connect completion failure when dial_aio is set to NULL

### DIFF
--- a/src/platform/posix/posix_ipcdial.c
+++ b/src/platform/posix/posix_ipcdial.c
@@ -226,7 +226,7 @@ ipc_dialer_dial(void *arg, nni_aio *aio)
 		if ((rv = nni_posix_pfd_arm(&c->pfd, NNI_POLL_OUT)) != 0) {
 			goto error;
 		}
-		c->dial_aio = NULL;
+		// c->dial_aio = NULL;
 		nni_aio_set_prov_data(aio, c);
 		nni_list_append(&d->connq, aio);
 		nni_mtx_unlock(&d->mtx);


### PR DESCRIPTION
Setting c->dial_aio to NULL prevents the asynchronous connect completion handler from finding the associated aio, thus the dial cannot be completed or cancelled.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of asynchronous connection handling by preserving connection state during dial operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->