### PR TITLE
fix: clear the AIO message slot before consuming the message (pub0)

### DIFF
--- a/src/sp/protocol/pubsub0/pub.c
+++ b/src/sp/protocol/pubsub0/pub.c
@@ -277,6 +277,7 @@ pub0_sock_send(void *arg, nni_aio *aio)
 
 	msg = nni_aio_get_msg(aio);
 	len = nni_msg_len(msg);
+	nni_aio_set_msg(aio, NULL);
 	nni_mtx_lock(&sock->mtx);
 #ifdef NNG_ENABLE_STATS
 	int dropped = 0;


### PR DESCRIPTION
`pub0_sock_send` takes ownership of the caller's message and frees it, but left the pointer in the AIO. Every other protocol clears the slot once it has taken ownership; restore that invariant here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication message handling to ensure messages are released safely after retrieval and distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->