### PR TITLE
fix(websocket/security): harden websocket against sender allocations

### DIFF
--- a/src/supplemental/websocket/websocket.c
+++ b/src/supplemental/websocket/websocket.c
@@ -48,6 +48,10 @@ typedef int (*nni_ws_listen_hook)(void *, nng_http *);
 #define WS_DEF_MAXRXFRAME (1U << 20) // 1MB Frame size (recv)
 #define WS_DEF_MAXTXFRAME (1U << 16) // 64KB Frame size (send)
 
+#ifndef WS_DEF_MAXFRAMES
+#define WS_DEF_MAXFRAMES (1 << 12) // 4K frames in a single message
+#endif
+
 // Alias for checking the prefix of a string.
 #define startswith(s, t) (strncmp(s, t, strlen(t)) == 0)
 
@@ -79,6 +83,8 @@ struct nni_ws {
 	nni_list         recvq;
 	nni_list         txq;
 	nni_list         rxq;
+	int 		 rxq_len;
+	size_t           rxq_size;
 	ws_frame        *txframe;
 	ws_frame        *rxframe;
 	nni_aio          txaio; // physical aios
@@ -971,17 +977,31 @@ ws_read_finish(nni_ws *ws)
 static void
 ws_read_frame_cb(nni_ws *ws, ws_frame *frame)
 {
+	bool message_done = false;
+
 	switch (frame->op) {
 	case WS_CONT:
 		if (!ws->inmsg) {
 			ws_close(ws, WS_CLOSE_PROTOCOL_ERR);
 			return;
 		}
+		if (ws->rxq_len >= WS_DEF_MAXFRAMES) {
+			ws_close(ws, WS_CLOSE_TOO_BIG);
+			return;
+		}
 		if (frame->final) {
 			ws->inmsg = false;
+			message_done = true;
 		}
 		ws->rxframe = NULL;
-		nni_list_append(&ws->rxq, frame);
+		if (frame->len == 0) {
+			// drop empty middle frames
+			ws_frame_fini(frame);
+		} else {
+			nni_list_append(&ws->rxq, frame);
+			ws->rxq_len++;
+			ws->rxq_size += frame->len;
+		}
 		break;
 	case WS_TEXT:
 		if (!ws->recv_text) {
@@ -997,8 +1017,13 @@ ws_read_frame_cb(nni_ws *ws, ws_frame *frame)
 		}
 		if (!frame->final) {
 			ws->inmsg = true;
+		} else {
+			message_done = true;
 		}
 		ws->rxframe = NULL;
+		ws->rxq_size = frame->len;
+		ws->rxq_len++;
+		NNI_ASSERT(ws->rxq_len == 1);
 		nni_list_append(&ws->rxq, frame);
 		break;
 
@@ -1035,6 +1060,10 @@ ws_read_frame_cb(nni_ws *ws, ws_frame *frame)
 		return;
 	}
 
+	if (message_done) {
+		ws->rxq_len  = 0;
+		ws->rxq_size = 0;
+	}
 	ws_read_finish(ws);
 }
 
@@ -1126,12 +1155,7 @@ ws_read_cb(void *arg)
 		// length of the message has not exceeded our recvmax.
 		// (Protect against an infinite stream of small messages!)
 		if ((!ws->isstream) && (ws->recvmax > 0)) {
-			size_t    totlen = frame->len;
-			ws_frame *fr2;
-			NNI_LIST_FOREACH (&ws->rxq, fr2) {
-				totlen += fr2->len;
-			}
-			if (totlen > ws->recvmax) {
+			if (ws->rxq_size + frame->len > ws->recvmax)  {
 				ws_close(ws, WS_CLOSE_TOO_BIG);
 				nni_mtx_unlock(&ws->mtx);
 				return;

--- a/src/supplemental/websocket/websocket_test.c
+++ b/src/supplemental/websocket/websocket_test.c
@@ -12,6 +12,7 @@
 #include <nng/nng.h>
 
 #include "sha1.h"
+#include "websocket.h"
 
 #include "../../testing/nuts.h"
 
@@ -455,6 +456,108 @@ test_websocket_text_rejected(void)
 	nng_stream_dialer_free(d);
 }
 
+void
+test_websocket_frame_limit(void)
+{
+	nng_stream_listener *l = NULL;
+	nng_stream_dialer   *d = NULL;
+	nng_stream          *c = NULL;
+	nng_stream          *s = NULL;
+	nng_aio             *daio = NULL;
+	nng_aio             *laio = NULL;
+	nng_aio             *raio = NULL;
+	nng_aio             *saio = NULL;
+	nng_msg             *msg;
+	char                 url[64];
+	uint16_t             port;
+	const size_t         maxframes = 1U << 12;
+	int                  rv;
+
+	NUTS_PASS(nng_aio_alloc(&daio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&laio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&raio, NULL, NULL));
+	NUTS_PASS(nng_aio_alloc(&saio, NULL, NULL));
+	nng_aio_set_timeout(daio, 5000);
+	nng_aio_set_timeout(laio, 5000);
+	nng_aio_set_timeout(raio, 5000);
+	nng_aio_set_timeout(saio, 5000);
+
+	for (int i = 0; i < 256; i++) {
+		port = nuts_next_port();
+		(void) snprintf(
+		    url, sizeof(url), "ws://127.0.0.1:%d/test", port);
+		NUTS_PASS(nng_stream_listener_alloc(&l, url));
+		NUTS_PASS(nng_stream_dialer_alloc(&d, url));
+		NUTS_PASS(nng_stream_listener_set_bool(
+		    l, NNI_OPT_WS_MSGMODE, true));
+		NUTS_PASS(nng_stream_dialer_set_bool(
+		    d, NNI_OPT_WS_MSGMODE, true));
+		NUTS_PASS(nng_stream_listener_set_size(
+		    l, NNG_OPT_WS_SENDMAXFRAME, 1));
+		rv = nng_stream_listener_listen(l);
+		if (rv != NNG_EADDRINUSE) {
+			break;
+		}
+		nng_stream_listener_free(l);
+		nng_stream_dialer_free(d);
+	}
+	NUTS_PASS(rv);
+
+	nng_stream_listener_accept(l, laio);
+	nng_stream_dialer_dial(d, daio);
+	nng_aio_wait(laio);
+	nng_aio_wait(daio);
+	NUTS_PASS(nng_aio_result(laio));
+	NUTS_PASS(nng_aio_result(daio));
+	s = nng_aio_get_output(laio, 0);
+	c = nng_aio_get_output(daio, 0);
+
+	// Two messages at the limit must be accepted.  Receiving the first
+	// one verifies that the accounting is reset before receiving the next.
+	for (int i = 0; i < 2; i++) {
+		NUTS_PASS(nng_msg_alloc(&msg, maxframes));
+		memset(nng_msg_body(msg), 'A' + i, maxframes);
+		nng_aio_set_msg(saio, msg);
+		nng_stream_recv(c, raio);
+		nng_stream_send(s, saio);
+		nng_aio_wait(saio);
+		nng_aio_wait(raio);
+		NUTS_PASS(nng_aio_result(saio));
+		NUTS_PASS(nng_aio_result(raio));
+		msg = nng_aio_get_msg(raio);
+		NUTS_TRUE(nng_msg_len(msg) == maxframes);
+		nng_aio_set_msg(raio, NULL);
+		nng_msg_free(msg);
+	}
+
+	// One more fragment than the limit must close the receiver.
+	NUTS_PASS(nng_msg_alloc(&msg, maxframes + 1));
+	memset(nng_msg_body(msg), 'X', maxframes + 1);
+	nng_aio_set_msg(saio, msg);
+	nng_stream_recv(c, raio);
+	nng_stream_send(s, saio);
+	nng_aio_wait(raio);
+	NUTS_FAIL(nng_aio_result(raio), NNG_ECLOSED);
+	nng_aio_wait(saio);
+	NUTS_TRUE((nng_aio_result(saio) == 0) ||
+	    (nng_aio_result(saio) == NNG_ECLOSED));
+	if ((msg = nng_aio_get_msg(saio)) != NULL) {
+		nng_aio_set_msg(saio, NULL);
+		nng_msg_free(msg);
+	}
+
+	nng_stream_close(c);
+	nng_stream_free(c);
+	nng_stream_close(s);
+	nng_stream_free(s);
+	nng_aio_free(saio);
+	nng_aio_free(raio);
+	nng_aio_free(laio);
+	nng_aio_free(daio);
+	nng_stream_listener_free(l);
+	nng_stream_dialer_free(d);
+}
+
 typedef struct recv_state {
 	nng_stream  *c;
 	int          total;
@@ -642,5 +745,6 @@ NUTS_TESTS = {
 	{ "websocket fragmentation", test_websocket_fragmentation },
 	{ "websocket text mode", test_websocket_text_mode },
 	{ "websocket text rejected", test_websocket_text_rejected },
+	{ "websocket frame limit", test_websocket_frame_limit },
 	{ NULL, NULL },
 };


### PR DESCRIPTION
This ensures that we have a sensible limit on allocations and maximum frames, and that we avoid a quadratic growth in compute due to a caller controlled behavior (pathological many small or empty frames.)

fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket message frame accounting for more reliable size-limit enforcement.
  * Oversized messages are now rejected consistently, preventing receivers from accepting messages beyond configured limits.
  * Empty continuation frames are safely ignored.
  * WebSocket connections close appropriately when the maximum frame count is exceeded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->