### PR TITLE
fix(security): prevent HTTP path escape using special characters

### DIFF
--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -226,6 +226,15 @@ http_req_parse_line(nng_http *conn, void *line)
 	*version = '\0';
 	version++;
 
+	// A request-target cannot contain a fragment or a backslash.  Fragments
+	// are only meaningful in URI references, and a backslash can become a
+	// directory separator on Windows.  Reject them here rather than allowing
+	// a file handler to interpret them as part of a local path.
+	if ((strchr(uri, '#') != NULL) || (strchr(uri, '\\') != NULL)) {
+		nni_http_set_status(conn, NNG_HTTP_STATUS_BAD_REQUEST, NULL);
+		return (NNG_OK);
+	}
+
 	if (nni_url_canonify_uri(uri) != 0) {
 		nni_http_set_status(conn, NNG_HTTP_STATUS_BAD_REQUEST, NULL);
 		return (NNG_OK);

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -502,6 +502,46 @@ test_server_bad_canonify(void)
 }
 
 static void
+test_server_bad_request_target(void)
+{
+	struct server_test st;
+	nng_http_handler  *h;
+
+	NUTS_PASS(nng_http_handler_alloc_static(
+	    &h, "/home.html", doc1, strlen(doc1), "text/html"));
+
+	server_setup(&st, h);
+
+	NUTS_PASS(nng_http_set_uri(st.conn, "/home.html#/../../secret", NULL));
+	nng_http_write_request(st.conn, st.aio);
+
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	nng_http_read_response(st.conn, st.aio);
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	NUTS_HTTP_STATUS(st.conn, NNG_HTTP_STATUS_BAD_REQUEST);
+
+	server_reset(&st);
+
+	NUTS_PASS(nng_http_set_uri(st.conn, "/home\\..\\secret", NULL));
+	nng_http_write_request(st.conn, st.aio);
+
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	nng_http_read_response(st.conn, st.aio);
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	NUTS_HTTP_STATUS(st.conn, NNG_HTTP_STATUS_BAD_REQUEST);
+
+	server_free(&st);
+}
+
+static void
 test_server_bad_version(void)
 {
 	struct server_test st;
@@ -1266,6 +1306,7 @@ NUTS_TESTS = {
 	{ "server 404", test_server_404 },
 	{ "server authoritiative form", test_server_no_authoritative_form },
 	{ "server bad canonify", test_server_bad_canonify },
+	{ "server bad request target", test_server_bad_request_target },
 	{ "server bad version", test_server_bad_version },
 	{ "server missing host", test_server_missing_host },
 	{ "server wrong method", test_server_wrong_method },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP servers now reject malformed request targets containing URL fragments or backslashes.
  * Invalid path-traversal requests receive a `400 Bad Request` response instead of being processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->