### PR TITLE
fix(security): reject unsafe HTTP request targets

### DIFF
--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -785,6 +785,14 @@ http_req_parse_line(nni_http_req *req, void *line)
 	*version = '\0';
 	version++;
 
+	// A request-target cannot contain a fragment or a backslash.  Fragments
+	// are only meaningful in URI references, and a backslash can become a
+	// directory separator on Windows.  Reject them here rather than allowing
+	// a file handler to interpret them as part of a local path.
+	if ((strchr(uri, '#') != NULL) || (strchr(uri, '\\') != NULL)) {
+		return (NNG_EPROTO);
+	}
+
 	if ((rv = nni_url_canonify_uri(&canon_uri, uri)) != 0) {
 		return (rv);
 	}

--- a/src/supplemental/http/http_msg_test.c
+++ b/src/supplemental/http/http_msg_test.c
@@ -20,6 +20,8 @@ test_http_req_canonify_uri(void)
 	char          plain[] = "GET /../../outside.txt HTTP/1.1\r\n\r\n";
 	char          encoded[] =
 	    "GET /%2e%2e/%2E%2e/outside.txt HTTP/1.1\r\n\r\n";
+	char fragment[] = "GET /#/../../outside.txt HTTP/1.1\r\n\r\n";
+	char backslash[] = "GET /..\\..\\outside.txt HTTP/1.1\r\n\r\n";
 	size_t        len;
 
 	NUTS_PASS(nni_http_req_alloc(&req, NULL));
@@ -30,6 +32,16 @@ test_http_req_canonify_uri(void)
 	NUTS_PASS(nni_http_req_alloc(&req, NULL));
 	NUTS_PASS(nni_http_req_parse(req, encoded, strlen(encoded), &len));
 	NUTS_MATCH(nni_http_req_get_uri(req), "/outside.txt");
+	nni_http_req_free(req);
+
+	NUTS_PASS(nni_http_req_alloc(&req, NULL));
+	NUTS_FAIL(nni_http_req_parse(req, fragment, strlen(fragment), &len),
+	    NNG_EPROTO);
+	nni_http_req_free(req);
+
+	NUTS_PASS(nni_http_req_alloc(&req, NULL));
+	NUTS_FAIL(nni_http_req_parse(req, backslash, strlen(backslash), &len),
+	    NNG_EPROTO);
 	nni_http_req_free(req);
 }
 

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -1547,6 +1547,22 @@ http_handle_dir(nni_aio *aio)
 		return;
 	}
 
+	// The request parser rejects these characters, but check again before
+	// building a filesystem path in case a request reaches this handler by
+	// another route.  A fragment is not part of an HTTP request-target, and a
+	// backslash is a directory separator on Windows.
+	if ((strchr(uri + len, '#') != NULL) ||
+	    (strchr(uri + len, '\\') != NULL)) {
+		if ((rv = nni_http_res_alloc_error(
+		         &res, NNG_HTTP_STATUS_BAD_REQUEST)) != 0) {
+			nni_aio_finish_error(aio, rv);
+			return;
+		}
+		nni_aio_set_output(aio, 0, res);
+		nni_aio_finish(aio, 0, 0);
+		return;
+	}
+
 	// simple worst case is every character in path is a separator
 	// It's never actually that bad, because we we have /<something>/.
 	pnsz = (strlen(path) + strlen(uri) + 2) * strlen(NNG_PLATFORM_DIR_SEP);


### PR DESCRIPTION
## Summary
- reject raw fragments and backslashes in incoming HTTP request targets
- add request-parser regressions for both traversal forms

## Testing
- `cmake -S . -B /tmp/nng-stable-http-path-build -DNNG_TESTS=ON -DNNG_TOOLS=OFF`
- `cmake --build /tmp/nng-stable-http-path-build --target http_msg_test -j4`
- `/tmp/nng-stable-http-path-build/src/supplemental/http/http_msg_test`