### PR TITLE
fix(http): validate directory handler paths

### DIFF
--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -1306,6 +1306,21 @@ http_handle_dir(nng_http *conn, void *arg, nng_aio *aio)
 		return;
 	}
 
+	// The request parser rejects these characters, but check again before
+	// building a filesystem path in case a request reaches this handler by
+	// another route.  A fragment is not part of an HTTP request-target, and a
+	// backslash is a directory separator on Windows.
+	if ((strchr(uri + len, '#') != NULL) ||
+	    (strchr(uri + len, '\\') != NULL)) {
+		if ((rv = nni_http_set_error(
+		         conn, NNG_HTTP_STATUS_BAD_REQUEST, NULL, NULL)) != 0) {
+			nni_aio_finish_error(aio, rv);
+			return;
+		}
+		nni_aio_finish(aio, NNG_OK, 0);
+		return;
+	}
+
 	// simple worst case is every character in path is a separator
 	// It's never actually that bad, because we we have /<something>/.
 	pnsz = (strlen(path) + strlen(uri) + 2) * strlen(NNG_PLATFORM_DIR_SEP);

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -1105,6 +1105,36 @@ test_serve_directory(void)
 }
 
 void
+test_serve_directory_bad_request_target(void)
+{
+	void                  *data;
+	size_t                 size;
+	uint16_t               stat;
+	char                  *ctype;
+	nng_http_handler      *h;
+	struct server_test     st;
+	struct serve_directory sd;
+
+	setup_directory(&sd);
+	NUTS_PASS(nng_http_handler_alloc_directory(&h, "/", sd.workdir));
+	server_setup(&st, h);
+
+	NUTS_PASS(nng_http_set_uri(st.conn, "/#/../../secret", NULL));
+	NUTS_PASS(httpget(&st, &data, &size, &stat, &ctype));
+	NUTS_TRUE(stat == NNG_HTTP_STATUS_BAD_REQUEST);
+	if (ctype != NULL) {
+		nng_strfree(ctype);
+	}
+	if (data != NULL) {
+		nng_free(data, size);
+	}
+
+	server_free(&st);
+
+	clean_directory(&sd);
+}
+
+void
 test_serve_directory_index(void)
 {
 	void                  *data;
@@ -1324,6 +1354,8 @@ NUTS_TESTS = {
 	{ "server error page", test_server_error_page },
 	{ "server multiple trees", test_server_multiple_trees },
 	{ "server serve directory", test_serve_directory },
+	{ "server directory bad request target",
+	    test_serve_directory_bad_request_target },
 	{ "server serve index", test_serve_directory_index },
 	{ "server plain text", test_serve_plain_text },
 	{ "server file parameters", test_serve_file_parameters },


### PR DESCRIPTION
## Summary
- reject fragments and backslashes again before a directory handler constructs a filesystem path
- retain the request-parser validation merged in #2312 as the first line of defense

## Testing
- `cmake -S . -B /tmp/nng-http-handler-build -DNNG_TESTS=ON -DNNG_TOOLS=OFF`
- `cmake --build /tmp/nng-http-handler-build --target http_server_test -j4`
- `/tmp/nng-http-handler-build/src/supplemental/http/http_server_test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid directory request paths containing fragments or backslashes are now rejected with a Bad Request response.
  * Prevents malformed requests from being used to construct filesystem paths or serve files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->