### PR TITLE
fix(url): Fix UTF-8 validator off-by-one

### DIFF
--- a/src/core/url.c
+++ b/src/core/url.c
@@ -73,9 +73,8 @@ url_utf8_validate(void *arg)
 			if ((s[0] & 0xc0u) != 0x80) {
 				return (NNG_EINVAL); // not continuation
 			}
+			v = (v << 6u) | (s[0] & 0x3fu);
 			s++;
-			v <<= 6u;
-			v += s[0] & 0x3fu;
 		}
 		if (v < minv) {
 			return (NNG_EINVAL);

--- a/src/core/url_test.c
+++ b/src/core/url_test.c
@@ -367,6 +367,12 @@ test_url_bad_utf8(void)
 	NUTS_NULL(url);
 	NUTS_FAIL(nng_url_parse(&url, "http://x.com/x%c0%81"), NNG_EINVAL);
 	NUTS_NULL(url);
+	NUTS_FAIL(nng_url_parse(&url, "http://x.com/x%e0%80%a0"), NNG_EINVAL);
+	NUTS_NULL(url);
+	NUTS_FAIL(nng_url_parse(&url, "http://x.com/x%f0%80%90%80"), NNG_EINVAL);
+	NUTS_NULL(url);
+	NUTS_FAIL(nng_url_parse(&url, "http://x.com/x%ed%a0%80"), NNG_EINVAL);
+	NUTS_NULL(url);
 }
 
 void
@@ -379,6 +385,11 @@ test_url_good_utf8(void)
 	NUTS_MATCH(nng_url_hostname(url), "www.x.com");
 	NUTS_TRUE(nng_url_port(url) == 80);
 	NUTS_MATCH(nng_url_path(url), "/\xc2\xa2_cents");
+	nng_url_free(url);
+
+	NUTS_PASS(nng_url_parse(&url, "http://www.x.com/%ed%9f%bf%f0%90%80%80"));
+	NUTS_ASSERT(url != NULL);
+	NUTS_MATCH(nng_url_path(url), "/\xed\x9f\xbf\xf0\x90\x80\x80");
 	nng_url_free(url);
 }
 


### PR DESCRIPTION
Fixes UTF-8 validator off-by-one behavior.

Correctly consume continuation bytes while constructing the code point and add regression coverage for valid, surrogate, and overlong UTF-8 URL paths.

Tests: `ctest --test-dir /tmp/nng-url-test-build -R '^nng\\.core\\.url_test$' --output-on-failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected UTF-8 URL decoding to use the proper continuation bytes.
  * Improved handling of valid and invalid Unicode sequences, including supplementary-plane characters.
  * Invalid overlong encodings and UTF-16 surrogate values are now rejected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->