### PR TITLE
fix(http): reject malformed Content-Length headers

### DIFF
--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -421,6 +421,31 @@ http_handler_host_match(nni_http_handler *h, const char *host)
 	return (true);
 }
 
+static bool
+http_parse_content_length(const char *str, size_t *sizep)
+{
+	size_t size = 0;
+
+	if (*str == '\0') {
+		return (false);
+	}
+	for (; *str != '\0'; str++) {
+		size_t digit;
+
+		if ((*str < '0') || (*str > '9')) {
+			return (false);
+		}
+		digit = (size_t) (*str - '0');
+		if (size > ((SIZE_MAX - digit) / 10)) {
+			return (false);
+		}
+		size = (size * 10) + digit;
+	}
+
+	*sizep = size;
+	return (true);
+}
+
 static void
 http_sconn_rxdone(void *arg)
 {
@@ -511,10 +536,8 @@ http_sconn_rxdone(void *arg)
 
 	sc->unconsumed_body = 0;
 	if ((cls = nni_http_get_header(sc->conn, "Content-Length")) != NULL) {
-		char *end;
-		sc->unconsumed_body = strtoull(cls, &end, 10);
-		if ((end == cls) || (*end != '\0')) {
-			sc->unconsumed_body = 0;
+		if (!http_parse_content_length(cls, &sc->unconsumed_body)) {
+			sc->close = true;
 			http_sconn_error(sc, NNG_HTTP_STATUS_BAD_REQUEST);
 			return;
 		}

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -513,7 +513,7 @@ http_sconn_rxdone(void *arg)
 	if ((cls = nni_http_get_header(sc->conn, "Content-Length")) != NULL) {
 		char *end;
 		sc->unconsumed_body = strtoull(cls, &end, 10);
-		if ((end == NULL) && (*end != '\0')) {
+		if ((end == cls) || (*end != '\0')) {
 			sc->unconsumed_body = 0;
 			http_sconn_error(sc, NNG_HTTP_STATUS_BAD_REQUEST);
 			return;

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -785,7 +785,9 @@ test_server_transfer_encoding(void)
 static void
 test_server_bad_content_length(void)
 {
-	const char         *values[] = { "", "123x" };
+	const char *values[] = {
+		"", "123x", "+1", "-1", "18446744073709551616"
+	};
 	struct server_test  st;
 
 	server_setup(&st, NULL);
@@ -800,11 +802,45 @@ test_server_bad_content_length(void)
 		nng_aio_wait(st.aio);
 		NUTS_PASS(nng_aio_result(st.aio));
 		NUTS_HTTP_STATUS(st.conn, NNG_HTTP_STATUS_BAD_REQUEST);
+		NUTS_MATCH(nng_http_get_header(st.conn, "Connection"), "close");
 
 		if (i + 1 < sizeof(values) / sizeof(values[0])) {
 			server_reset(&st);
 		}
 	}
+
+	server_free(&st);
+}
+
+static void
+test_server_bad_content_length_closes(void)
+{
+	static char request[] =
+	    "GET / HTTP/1.1\r\n"
+	    "Host: 127.0.0.1\r\n"
+	    "\r\n";
+	struct server_test st;
+	nng_http_handler  *h;
+
+	NUTS_PASS(nng_http_handler_alloc_static(
+	    &h, "/", doc1, strlen(doc1), "text/html"));
+	server_setup(&st, h);
+
+	nng_http_set_body(st.conn, request, sizeof(request) - 1);
+	NUTS_PASS(nng_http_set_header(st.conn, "Content-Length", "123x"));
+	nng_http_write_request(st.conn, st.aio);
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	nng_http_read_response(st.conn, st.aio);
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+	NUTS_HTTP_STATUS(st.conn, NNG_HTTP_STATUS_BAD_REQUEST);
+
+	// The appended request must not be parsed after the 400 response.
+	nng_http_read_response(st.conn, st.aio);
+	nng_aio_wait(st.aio);
+	NUTS_TRUE(nng_aio_result(st.aio) != NNG_OK);
 
 	server_free(&st);
 }
@@ -1374,6 +1410,8 @@ NUTS_TESTS = {
 	{ "server post handler", test_server_post_handler },
 	{ "server transfer encoding", test_server_transfer_encoding },
 	{ "server bad content length", test_server_bad_content_length },
+	{ "server bad content length closes",
+	    test_server_bad_content_length_closes },
 	{ "server get redirect", test_server_get_redirect },
 	{ "server tree redirect", test_server_tree_redirect },
 	{ "server post redirect", test_server_post_redirect },

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -783,6 +783,33 @@ test_server_transfer_encoding(void)
 }
 
 static void
+test_server_bad_content_length(void)
+{
+	const char         *values[] = { "", "123x" };
+	struct server_test  st;
+
+	server_setup(&st, NULL);
+
+	for (size_t i = 0; i < sizeof(values) / sizeof(values[0]); i++) {
+		NUTS_PASS(nng_http_set_header(st.conn, "Content-Length", values[i]));
+		nng_http_write_request(st.conn, st.aio);
+		nng_aio_wait(st.aio);
+		NUTS_PASS(nng_aio_result(st.aio));
+
+		nng_http_read_response(st.conn, st.aio);
+		nng_aio_wait(st.aio);
+		NUTS_PASS(nng_aio_result(st.aio));
+		NUTS_HTTP_STATUS(st.conn, NNG_HTTP_STATUS_BAD_REQUEST);
+
+		if (i + 1 < sizeof(values) / sizeof(values[0])) {
+			server_reset(&st);
+		}
+	}
+
+	server_free(&st);
+}
+
+static void
 test_server_addrs_handler(void)
 {
 	struct server_test st;
@@ -1346,6 +1373,7 @@ NUTS_TESTS = {
 	{ "server invalid utf", test_server_invalid_utf8 },
 	{ "server post handler", test_server_post_handler },
 	{ "server transfer encoding", test_server_transfer_encoding },
+	{ "server bad content length", test_server_bad_content_length },
 	{ "server get redirect", test_server_get_redirect },
 	{ "server tree redirect", test_server_tree_redirect },
 	{ "server post redirect", test_server_post_redirect },


### PR DESCRIPTION
Fixes malformed Content-Length header validation.

Reject empty or non-numeric values and add HTTP server regression coverage.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of malformed `Content-Length` headers, including empty, signed, non-numeric, trailing-character, and oversized values.
  * Invalid headers now receive a `400 Bad Request` response with `Connection: close`.
  * Prevented unconsumed request data from being incorrectly parsed as a subsequent request.

* **Tests**
  * Expanded coverage for invalid values and confirmed connections close after rejected requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->