### PR TITLE
feat(windows/ipc): Add AF_UNIX unix:// support on Windows

### DIFF
--- a/docs/ref/tran/ipc.md
+++ b/docs/ref/tran/ipc.md
@@ -5,7 +5,9 @@
 The {{i:*ipc* transport}}{{hi:*ipc*}} provides communication support between
 sockets within different processes on the same host.
 For POSIX platforms, this is implemented using {{i:UNIX domain sockets}}.
-For Windows, this is implemented using Windows {{i:named pipes}}.
+For Windows, this is implemented using Windows {{i:named pipes}}.  Windows
+also supports the related {{i:`unix://`}} scheme, which uses Windows
+{{i:AF_UNIX}} sockets.
 Other platforms may have different implementation strategies.
 
 ### URI Formats
@@ -39,11 +41,20 @@ name in the file system where the socket or named pipe should be created.
 
 #### UNIX Aliases
 
-The {{i:`unix://`}} scheme is an alias for `ipc://` and can be used inter-changeably, but only on POSIX systems.[^ipc_unix]
+On POSIX systems, the {{i:`unix://`}} scheme is an alias for `ipc://` and can
+be used interchangeably.  On Windows, it instead selects the AF_UNIX transport;
+`ipc://` continues to select named pipes.[^ipc_unix]
+
+On Windows, the `unix://` path is a UTF-8 Win32 pathname (for example,
+`unix://C:\Temp\nng.sock`) and is limited to 107 bytes plus its final `NUL`.
+Windows AF_UNIX streams support [`NNG_OPT_PEER_PID`], but do not provide
+POSIX user or group credentials.
+AF_UNIX requires Windows build 17063 or later; on older builds, `unix://`
+operations fail because `WSASocket(AF_UNIX, ...)` returns `WSAEAFNOSUPPORT`.
 
 [^ipc_unix]:
-    The purpose of this scheme is to support a future transport making use of `AF_UNIX`
-    on Windows systems, at which time it will be necessary to discriminate between the Named Pipes and the `AF_UNIX` based transports.
+    This scheme distinguishes the existing named-pipe transport from the
+    AF_UNIX transport on Windows.
 
 #### Abstract Names
 

--- a/src/core/platform.h
+++ b/src/core/platform.h
@@ -342,6 +342,9 @@ typedef struct nni_ipc_listener nni_ipc_listener;
 // be stubs that just return NNG_ENOTSUP.
 extern nng_err nni_ipc_dialer_alloc(nng_stream_dialer **, const nng_url *);
 extern nng_err nni_ipc_listener_alloc(nng_stream_listener **, const nng_url *);
+extern nng_err nni_unix_dialer_alloc(nng_stream_dialer **, const nng_url *);
+extern nng_err nni_unix_listener_alloc(
+    nng_stream_listener **, const nng_url *);
 
 //
 // UDP support. UDP is not connection oriented, and only has the notion

--- a/src/core/stream.c
+++ b/src/core/stream.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -38,6 +38,12 @@ static struct {
 	    .scheme         = "unix",
 	    .dialer_alloc   = nni_ipc_dialer_alloc,
 	    .listener_alloc = nni_ipc_listener_alloc,
+	},
+#elif defined(NNG_HAVE_UNIX_SOCKETS)
+	{
+	    .scheme         = "unix",
+	    .dialer_alloc   = nni_unix_dialer_alloc,
+	    .listener_alloc = nni_unix_listener_alloc,
 	},
 #endif
 #ifdef NNG_HAVE_ABSTRACT_SOCKETS

--- a/src/platform/windows/CMakeLists.txt
+++ b/src/platform/windows/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Staysail Systems, Inc. <info@staystail.tech>
+# Copyright 2026 Staysail Systems, Inc. <info@staystail.tech>
 #
 # This software is supplied under the terms of the MIT License, a
 # copy of which should be located in the distribution where this
@@ -15,6 +15,7 @@ if (NNG_PLATFORM_WINDOWS)
     nng_check_sym(InitializeConditionVariable windows.h NNG_HAVE_CONDVAR)
     nng_check_sym(timespec_get time.h NNG_HAVE_TIMESPEC_GET)
     nng_check_sym(snprintf stdio.h NNG_HAVE_SNPRINTF)
+    nng_check_sym(AF_UNIX "winsock2.h;afunix.h" NNG_HAVE_UNIX_SOCKETS)
     if (NOT NNG_HAVE_CONDVAR OR NOT NNG_HAVE_SNPRINTF OR NOT NNG_HAVE_TIMESPEC_GET)
         message(FATAL_ERROR
                 "Modern Windows API support is missing. "
@@ -48,6 +49,8 @@ if (NNG_PLATFORM_WINDOWS)
             win_tcplisten.c
             win_thread.c
             win_udp.c
+            win_unix.c
+            win_unix.h
     )
 
     nng_test(win_ipc_sec_test)

--- a/src/platform/windows/win_tcp.h
+++ b/src/platform/windows/win_tcp.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -36,11 +36,12 @@ struct nni_tcp_conn {
 	char            buf[512]; // to hold acceptex results
 	bool            sending;
 	bool            recving;
+	bool            peer_pid_supported;
 	nni_mtx         mtx;
 	nni_cv          cv;
 };
 
-extern int nni_win_tcp_init(nni_tcp_conn **, SOCKET);
+extern int nni_win_tcp_init(nni_tcp_conn **, SOCKET, bool);
 
 // Following functions are wrappers around Windows functions that have to be
 // looked up by pointer/GUID.

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -12,6 +12,10 @@
 #include "../../core/nng_impl.h"
 
 #include "win_tcp.h"
+
+#ifdef NNG_HAVE_UNIX_SOCKETS
+#include <afunix.h>
+#endif
 
 #include <stdio.h>
 
@@ -301,6 +305,32 @@ tcp_get_keepalive(void *arg, void *buf, size_t *szp, nni_type t)
 	return (nni_copyout_bool(b, buf, szp, t));
 }
 
+static nng_err
+tcp_get_peer_pid(void *arg, void *buf, size_t *szp, nni_type t)
+{
+	nni_tcp_conn *c = arg;
+
+#ifdef NNG_HAVE_UNIX_SOCKETS
+	ULONG id;
+	DWORD nbytes;
+
+	if (!c->peer_pid_supported) {
+		return (NNG_ENOTSUP);
+	}
+	if (WSAIoctl(c->s, SIO_AF_UNIX_GETPEERPID, NULL, 0, &id,
+	        sizeof(id), &nbytes, NULL, NULL) == SOCKET_ERROR) {
+		return (nni_win_error(WSAGetLastError()));
+	}
+	return (nni_copyout_int((int) id, buf, szp, t));
+#else
+	NNI_ARG_UNUSED(c);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(szp);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
+#endif
+}
+
 static const nng_sockaddr *
 tcp_self_addr(void *arg)
 {
@@ -323,6 +353,10 @@ static const nni_option tcp_options[] = {
 	{
 	    .o_name = NNG_OPT_TCP_KEEPALIVE,
 	    .o_get  = tcp_get_keepalive,
+	},
+	{
+	    .o_name = NNG_OPT_PEER_PID,
+	    .o_get  = tcp_get_peer_pid,
 	},
 	{
 	    .o_name = NULL,
@@ -372,7 +406,7 @@ tcp_free(void *arg)
 }
 
 int
-nni_win_tcp_init(nni_tcp_conn **connp, SOCKET s)
+nni_win_tcp_init(nni_tcp_conn **connp, SOCKET s, bool peer_pid_supported)
 {
 	nni_tcp_conn *c;
 	int           rv;
@@ -390,7 +424,8 @@ nni_win_tcp_init(nni_tcp_conn **connp, SOCKET s)
 	nni_cv_init(&c->cv, &c->mtx);
 	nni_aio_list_init(&c->recv_aios);
 	nni_aio_list_init(&c->send_aios);
-	c->conn_aio        = NULL;
+	c->conn_aio          = NULL;
+	c->peer_pid_supported = peer_pid_supported;
 	c->ops.s_close     = tcp_close;
 	c->ops.s_stop      = tcp_stop;
 	c->ops.s_free      = tcp_free;

--- a/src/platform/windows/win_tcpdial.c
+++ b/src/platform/windows/win_tcpdial.c
@@ -193,7 +193,7 @@ nni_tcp_dial(nni_tcp_dialer *d, const nni_sockaddr *sa, nni_aio *aio)
 		return;
 	}
 
-	if ((rv = nni_win_tcp_init(&c, s)) != 0) {
+	if ((rv = nni_win_tcp_init(&c, s, false)) != 0) {
 		nng_stream_free(&c->ops);
 		nni_aio_finish_error(aio, rv);
 		return;

--- a/src/platform/windows/win_tcplisten.c
+++ b/src/platform/windows/win_tcplisten.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2018 Devolutions <info@devolutions.net>
 //
@@ -274,7 +274,7 @@ tcp_listener_doaccept(tcp_listener *l)
 			continue;
 		}
 
-		if ((rv = nni_win_tcp_init(&c, s)) != 0) {
+		if ((rv = nni_win_tcp_init(&c, s, false)) != 0) {
 			nni_aio_list_remove(aio);
 			closesocket(s);
 			nni_aio_finish_error(aio, rv);

--- a/src/platform/windows/win_unix.c
+++ b/src/platform/windows/win_unix.c
@@ -1,0 +1,699 @@
+//
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#include "core/nng_impl.h"
+
+#include "win_tcp.h"
+#include "win_unix.h"
+
+#include <string.h>
+
+#ifdef NNG_HAVE_UNIX_SOCKETS
+
+typedef struct unix_dialer unix_dialer;
+typedef struct unix_listener unix_listener;
+
+struct unix_dialer {
+	nng_stream_dialer sd;
+	SOCKADDR_UN        sa;
+	nng_sockaddr       nsa;
+	nni_list           aios;
+	nni_aio           *active;
+	SOCKET             active_s;
+	nni_mtx            mtx;
+	nni_cv             cv;
+	nni_thr            thr;
+	bool               thread_started;
+	bool               closed;
+};
+
+struct unix_listener {
+	nng_stream_listener sl;
+	SOCKADDR_UN          sa;
+	nng_sockaddr         nsa;
+	SOCKET               s;
+	WSAEVENT             event;
+	nni_list             aios;
+	nni_aio             *active;
+	nni_mtx              mtx;
+	nni_cv               cv;
+	nni_thr              thr;
+	bool                 thread_started;
+	bool                 started;
+	bool                 closed;
+};
+
+static nng_err
+unix_make_addr(SOCKADDR_UN *sa, nng_sockaddr *nsa, const nng_url *url)
+{
+	size_t len;
+
+	if ((url->u_path == NULL) || ((len = strlen(url->u_path)) == 0) ||
+	    (len >= sizeof(sa->sun_path))) {
+		return (NNG_EADDRINVAL);
+	}
+	memset(sa, 0, sizeof(*sa));
+	sa->sun_family = AF_UNIX;
+	memcpy(sa->sun_path, url->u_path, len + 1);
+	memset(nsa, 0, sizeof(*nsa));
+	nsa->s_ipc.sa_family = NNG_AF_IPC;
+	nni_strlcpy(nsa->s_ipc.sa_path, url->u_path, NNG_MAXADDRLEN);
+	return (NNG_OK);
+}
+
+static SOCKET
+unix_socket(void)
+{
+	return (WSASocket(AF_UNIX, SOCK_STREAM, 0, NULL, 0, WSA_FLAG_OVERLAPPED));
+}
+
+static nng_err
+unix_remove_stale(const SOCKADDR_UN *sa)
+{
+	SOCKET  s;
+	u_long  nonblock = 1;
+	int     err;
+	nng_err rv;
+
+	if ((s = unix_socket()) == INVALID_SOCKET) {
+		return (NNG_EADDRINUSE);
+	}
+	if (ioctlsocket(s, FIONBIO, &nonblock) == SOCKET_ERROR) {
+		closesocket(s);
+		return (NNG_EADDRINUSE);
+	}
+	if (connect(s, (SOCKADDR *) sa, sizeof(*sa)) == 0) {
+		rv = NNG_EADDRINUSE;
+	} else if ((err = WSAGetLastError()) == WSAECONNREFUSED) {
+		if (DeleteFileA(sa->sun_path) ||
+		    (GetLastError() == ERROR_FILE_NOT_FOUND)) {
+			rv = NNG_OK;
+		} else {
+			rv = nni_win_error(GetLastError());
+		}
+	} else {
+		rv = NNG_EADDRINUSE;
+	}
+	closesocket(s);
+	return (rv);
+}
+
+static void
+unix_conn_addr(nni_tcp_conn *c, const nng_sockaddr *sa)
+{
+	c->sockname = *sa;
+	c->peername = *sa;
+}
+
+static void
+unix_dial_finish(unix_dialer *d, nni_aio *aio, SOCKET s, nng_err rv)
+{
+	nni_tcp_conn *c = NULL;
+
+	if (rv == NNG_OK) {
+		WSAEventSelect(s, NULL, 0);
+		if ((rv = nni_win_tcp_init(&c, s, true)) == NNG_OK) {
+			unix_conn_addr(c, &d->nsa);
+		}
+	}
+
+	nni_mtx_lock(&d->mtx);
+	if ((d->active == aio) && !d->closed) {
+		d->active   = NULL;
+		d->active_s = INVALID_SOCKET;
+		nni_aio_list_remove(aio);
+		nni_mtx_unlock(&d->mtx);
+		if (rv == NNG_OK) {
+			nni_aio_set_output(aio, 0, c);
+			nni_aio_finish(aio, 0, 0);
+		} else {
+			if (s != INVALID_SOCKET) {
+				closesocket(s);
+			}
+			nni_aio_finish_error(aio, rv);
+		}
+		return;
+	}
+	nni_mtx_unlock(&d->mtx);
+	if (c != NULL) {
+		nng_stream_close(&c->ops);
+		nng_stream_stop(&c->ops);
+		nng_stream_free(&c->ops);
+	} else if (s != INVALID_SOCKET) {
+		closesocket(s);
+	}
+}
+
+static void
+unix_dial_thr(void *arg)
+{
+	unix_dialer *d = arg;
+
+	nni_mtx_lock(&d->mtx);
+	for (;;) {
+		nni_aio *aio;
+		SOCKET   s;
+		WSAEVENT event;
+		int      rv;
+
+		while (!d->closed && ((aio = nni_list_first(&d->aios)) == NULL)) {
+			nni_cv_wait(&d->cv);
+		}
+		if (d->closed) {
+			break;
+		}
+		d->active   = aio;
+		d->active_s = INVALID_SOCKET;
+		nni_mtx_unlock(&d->mtx);
+
+		if ((s = unix_socket()) == INVALID_SOCKET) {
+			unix_dial_finish(d, aio, s, nni_win_error(WSAGetLastError()));
+			nni_mtx_lock(&d->mtx);
+			continue;
+		}
+		if ((event = WSACreateEvent()) == WSA_INVALID_EVENT) {
+			rv = nni_win_error(WSAGetLastError());
+			closesocket(s);
+			unix_dial_finish(d, aio, INVALID_SOCKET, rv);
+			nni_mtx_lock(&d->mtx);
+			continue;
+		}
+		if (WSAEventSelect(s, event, FD_CONNECT) == SOCKET_ERROR) {
+			rv = nni_win_error(WSAGetLastError());
+			WSACloseEvent(event);
+			unix_dial_finish(d, aio, s, rv);
+			nni_mtx_lock(&d->mtx);
+			continue;
+		}
+
+		nni_mtx_lock(&d->mtx);
+		if ((d->active != aio) || d->closed) {
+			nni_mtx_unlock(&d->mtx);
+			WSACloseEvent(event);
+			closesocket(s);
+			nni_mtx_lock(&d->mtx);
+			continue;
+		}
+		d->active_s = s;
+		nni_mtx_unlock(&d->mtx);
+
+		if (connect(s, (SOCKADDR *) &d->sa, sizeof(d->sa)) == 0) {
+			rv = NNG_OK;
+		} else {
+			int err = WSAGetLastError();
+			if ((err != WSAEWOULDBLOCK) && (err != WSAEINPROGRESS)) {
+				rv = nni_win_error(err);
+			} else {
+				rv = NNG_EAGAIN;
+				while (rv == NNG_EAGAIN) {
+					WSANETWORKEVENTS ne;
+
+					(void) WSAWaitForMultipleEvents(
+					    1, &event, FALSE, 10, FALSE);
+					nni_mtx_lock(&d->mtx);
+					if ((d->active != aio) || d->closed) {
+						nni_mtx_unlock(&d->mtx);
+						rv = NNG_ECANCELED;
+						break;
+					}
+					nni_mtx_unlock(&d->mtx);
+					if (WSAEnumNetworkEvents(s, event, &ne) == SOCKET_ERROR) {
+						rv = nni_win_error(WSAGetLastError());
+					} else if (ne.lNetworkEvents & FD_CONNECT) {
+						rv = ne.iErrorCode[FD_CONNECT_BIT] == 0 ? NNG_OK :
+						    nni_win_error(ne.iErrorCode[FD_CONNECT_BIT]);
+					}
+				}
+			}
+		}
+		WSACloseEvent(event);
+		unix_dial_finish(d, aio, s, rv);
+		nni_mtx_lock(&d->mtx);
+	}
+	nni_mtx_unlock(&d->mtx);
+}
+
+static void
+unix_dial_cancel(nni_aio *aio, void *arg, nng_err rv)
+{
+	unix_dialer *d = arg;
+
+	nni_mtx_lock(&d->mtx);
+	if (nni_aio_list_active(aio)) {
+		if (d->active == aio) {
+			d->active_s = INVALID_SOCKET;
+			d->active   = NULL;
+		}
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, rv);
+	}
+	nni_mtx_unlock(&d->mtx);
+}
+
+static void
+unix_dialer_dial(void *arg, nng_aio *aio)
+{
+	unix_dialer *d = arg;
+
+	nni_aio_reset(aio);
+	nni_mtx_lock(&d->mtx);
+	if (d->closed) {
+		nni_mtx_unlock(&d->mtx);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+		return;
+	}
+	if (!nni_aio_start(aio, unix_dial_cancel, d)) {
+		nni_mtx_unlock(&d->mtx);
+		return;
+	}
+	nni_list_append(&d->aios, aio);
+	nni_cv_wake(&d->cv);
+	nni_mtx_unlock(&d->mtx);
+}
+
+static void
+unix_dialer_close(void *arg)
+{
+	unix_dialer *d = arg;
+	nni_aio     *aio;
+
+	nni_mtx_lock(&d->mtx);
+	if (d->closed) {
+		nni_mtx_unlock(&d->mtx);
+		return;
+	}
+	d->closed   = true;
+	d->active   = NULL;
+	d->active_s = INVALID_SOCKET;
+	while ((aio = nni_list_first(&d->aios)) != NULL) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+	}
+	nni_cv_wake(&d->cv);
+	nni_mtx_unlock(&d->mtx);
+}
+
+static void
+unix_dialer_stop(void *arg)
+{
+	unix_dialer *d = arg;
+
+	unix_dialer_close(d);
+	if (d->thread_started) {
+		nni_thr_fini(&d->thr);
+		d->thread_started = false;
+	}
+}
+
+static void
+unix_dialer_free(void *arg)
+{
+	unix_dialer *d = arg;
+
+	unix_dialer_stop(d);
+	nni_cv_fini(&d->cv);
+	nni_mtx_fini(&d->mtx);
+	NNI_FREE_STRUCT(d);
+}
+
+static nng_err
+unix_dialer_get(void *arg, const char *name, void *buf, size_t *szp, nni_type t)
+{
+	NNI_ARG_UNUSED(arg);
+	NNI_ARG_UNUSED(name);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(szp);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
+}
+
+static nng_err
+unix_dialer_set(
+    void *arg, const char *name, const void *buf, size_t sz, nni_type t)
+{
+	NNI_ARG_UNUSED(arg);
+	NNI_ARG_UNUSED(name);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
+}
+
+nng_err
+nni_unix_dialer_alloc(nng_stream_dialer **dp, const nng_url *url)
+{
+	unix_dialer *d;
+	nng_err      rv;
+
+	if ((d = NNI_ALLOC_STRUCT(d)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	if ((rv = unix_make_addr(&d->sa, &d->nsa, url)) != NNG_OK) {
+		NNI_FREE_STRUCT(d);
+		return (rv);
+	}
+	d->active_s = INVALID_SOCKET;
+	nni_mtx_init(&d->mtx);
+	nni_cv_init(&d->cv, &d->mtx);
+	nni_aio_list_init(&d->aios);
+	if ((rv = nni_thr_init(&d->thr, unix_dial_thr, d)) != NNG_OK) {
+		nni_cv_fini(&d->cv);
+		nni_mtx_fini(&d->mtx);
+		NNI_FREE_STRUCT(d);
+		return (rv);
+	}
+	nni_thr_set_name(&d->thr, "nng:unix:dial");
+	nni_thr_run(&d->thr);
+	d->thread_started = true;
+	d->sd.sd_free  = unix_dialer_free;
+	d->sd.sd_close = unix_dialer_close;
+	d->sd.sd_stop  = unix_dialer_stop;
+	d->sd.sd_dial  = unix_dialer_dial;
+	d->sd.sd_get   = unix_dialer_get;
+	d->sd.sd_set   = unix_dialer_set;
+	*dp            = &d->sd;
+	return (NNG_OK);
+}
+
+static void
+unix_listener_finish(unix_listener *l, nni_aio *aio, SOCKET s, nng_err rv)
+{
+	nni_tcp_conn *c = NULL;
+
+	if (rv == NNG_OK) {
+		WSAEventSelect(s, NULL, 0);
+		if ((rv = nni_win_tcp_init(&c, s, true)) == NNG_OK) {
+			unix_conn_addr(c, &l->nsa);
+		}
+	}
+
+	nni_mtx_lock(&l->mtx);
+	if (!l->closed && (l->active == aio) && nni_aio_list_active(aio)) {
+		l->active = NULL;
+		nni_aio_list_remove(aio);
+		nni_mtx_unlock(&l->mtx);
+		if (rv == NNG_OK) {
+			nni_aio_set_output(aio, 0, c);
+			nni_aio_finish(aio, 0, 0);
+		} else {
+			if (s != INVALID_SOCKET) {
+				closesocket(s);
+			}
+			nni_aio_finish_error(aio, rv);
+		}
+		return;
+	}
+	nni_mtx_unlock(&l->mtx);
+	if (c != NULL) {
+		nng_stream_close(&c->ops);
+		nng_stream_stop(&c->ops);
+		nng_stream_free(&c->ops);
+	} else if (s != INVALID_SOCKET) {
+		closesocket(s);
+	}
+}
+
+static void
+unix_listener_thr(void *arg)
+{
+	unix_listener *l = arg;
+
+	for (;;) {
+		nni_aio *aio;
+		SOCKET   s;
+		WSANETWORKEVENTS ne;
+		int      rv;
+
+		nni_mtx_lock(&l->mtx);
+		while (!l->closed && ((aio = nni_list_first(&l->aios)) == NULL)) {
+			nni_cv_wait(&l->cv);
+		}
+		if (l->closed) {
+			nni_mtx_unlock(&l->mtx);
+			return;
+		}
+		l->active = aio;
+		nni_mtx_unlock(&l->mtx);
+
+		(void) WSAWaitForMultipleEvents(1, &l->event, FALSE, 10, FALSE);
+		nni_mtx_lock(&l->mtx);
+		if (l->closed) {
+			nni_mtx_unlock(&l->mtx);
+			return;
+		}
+		nni_mtx_unlock(&l->mtx);
+		if (WSAEnumNetworkEvents(l->s, l->event, &ne) == SOCKET_ERROR) {
+			continue;
+		}
+		if ((s = accept(l->s, NULL, NULL)) == INVALID_SOCKET) {
+			int err = WSAGetLastError();
+			if (err == WSAEWOULDBLOCK) {
+				continue;
+			}
+			rv = nni_win_error(err);
+		} else {
+			rv = NNG_OK;
+		}
+		unix_listener_finish(l, aio, s, rv);
+	}
+}
+
+static void
+unix_listener_accept_cancel(nni_aio *aio, void *arg, nng_err rv)
+{
+	unix_listener *l = arg;
+
+	nni_mtx_lock(&l->mtx);
+	if (nni_aio_list_active(aio)) {
+		if (l->active == aio) {
+			l->active = NULL;
+		}
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, rv);
+	}
+	nni_mtx_unlock(&l->mtx);
+}
+
+static void
+unix_listener_accept(void *arg, nng_aio *aio)
+{
+	unix_listener *l = arg;
+
+	nni_aio_reset(aio);
+	nni_mtx_lock(&l->mtx);
+	if (!l->started) {
+		nni_mtx_unlock(&l->mtx);
+		nni_aio_finish_error(aio, NNG_ESTATE);
+		return;
+	}
+	if (l->closed) {
+		nni_mtx_unlock(&l->mtx);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+		return;
+	}
+	if (!nni_aio_start(aio, unix_listener_accept_cancel, l)) {
+		nni_mtx_unlock(&l->mtx);
+		return;
+	}
+	nni_list_append(&l->aios, aio);
+	nni_cv_wake(&l->cv);
+	nni_mtx_unlock(&l->mtx);
+}
+
+static nng_err
+unix_listener_listen(void *arg)
+{
+	unix_listener *l = arg;
+	SOCKET         s;
+	nng_err        rv;
+
+	nni_mtx_lock(&l->mtx);
+	if (l->closed) {
+		nni_mtx_unlock(&l->mtx);
+		return (NNG_ECLOSED);
+	}
+	if (l->started) {
+		nni_mtx_unlock(&l->mtx);
+		return (NNG_EBUSY);
+	}
+	if ((s = unix_socket()) == INVALID_SOCKET) {
+		rv = nni_win_error(WSAGetLastError());
+		nni_mtx_unlock(&l->mtx);
+		return (rv);
+	}
+	if (bind(s, (SOCKADDR *) &l->sa, sizeof(l->sa)) == SOCKET_ERROR) {
+		int err = WSAGetLastError();
+
+		rv = nni_win_error(err);
+		if ((err == WSAEADDRINUSE) &&
+		    ((rv = unix_remove_stale(&l->sa)) == NNG_OK)) {
+			if (bind(s, (SOCKADDR *) &l->sa, sizeof(l->sa)) == 0) {
+				goto bound;
+			}
+			rv = nni_win_error(WSAGetLastError());
+		}
+		closesocket(s);
+		nni_mtx_unlock(&l->mtx);
+		return (rv);
+	}
+bound:
+	if (listen(s, SOMAXCONN) == SOCKET_ERROR) {
+		rv = nni_win_error(WSAGetLastError());
+		closesocket(s);
+		(void) DeleteFileA(l->sa.sun_path);
+		nni_mtx_unlock(&l->mtx);
+		return (rv);
+	}
+	if ((l->event = WSACreateEvent()) == WSA_INVALID_EVENT) {
+		rv = nni_win_error(WSAGetLastError());
+		closesocket(s);
+		(void) DeleteFileA(l->sa.sun_path);
+		nni_mtx_unlock(&l->mtx);
+		return (rv);
+	}
+	if (WSAEventSelect(s, l->event, FD_ACCEPT | FD_CLOSE) == SOCKET_ERROR) {
+		rv = nni_win_error(WSAGetLastError());
+		WSACloseEvent(l->event);
+		l->event = WSA_INVALID_EVENT;
+		closesocket(s);
+		(void) DeleteFileA(l->sa.sun_path);
+		nni_mtx_unlock(&l->mtx);
+		return (rv);
+	}
+	l->s       = s;
+	l->started = true;
+	if ((rv = nni_thr_init(&l->thr, unix_listener_thr, l)) != NNG_OK) {
+		l->started = false;
+		closesocket(l->s);
+		WSACloseEvent(l->event);
+		l->event = WSA_INVALID_EVENT;
+		(void) DeleteFileA(l->sa.sun_path);
+		l->s = INVALID_SOCKET;
+		nni_mtx_unlock(&l->mtx);
+		return (rv);
+	}
+	nni_thr_set_name(&l->thr, "nng:unix:listen");
+	nni_thr_run(&l->thr);
+	l->thread_started = true;
+	nni_mtx_unlock(&l->mtx);
+	return (NNG_OK);
+}
+
+static void
+unix_listener_close(void *arg)
+{
+	unix_listener *l = arg;
+	nni_aio       *aio;
+	WSAEVENT        event;
+
+	nni_mtx_lock(&l->mtx);
+	if (l->closed) {
+		nni_mtx_unlock(&l->mtx);
+		return;
+	}
+	l->closed = true;
+	event     = l->event;
+	while ((aio = nni_list_first(&l->aios)) != NULL) {
+		nni_aio_list_remove(aio);
+		nni_aio_finish_error(aio, NNG_ECLOSED);
+	}
+	nni_cv_wake(&l->cv);
+	nni_mtx_unlock(&l->mtx);
+	if (event != WSA_INVALID_EVENT) {
+		WSASetEvent(event);
+	}
+}
+
+static void
+unix_listener_stop(void *arg)
+{
+	unix_listener *l = arg;
+
+	unix_listener_close(l);
+	if (l->thread_started) {
+		nni_thr_fini(&l->thr);
+		l->thread_started = false;
+	}
+	if (l->s != INVALID_SOCKET) {
+		closesocket(l->s);
+		l->s = INVALID_SOCKET;
+	}
+	if (l->event != WSA_INVALID_EVENT) {
+		WSACloseEvent(l->event);
+		l->event = WSA_INVALID_EVENT;
+	}
+	if (l->started) {
+		(void) DeleteFileA(l->sa.sun_path);
+	}
+}
+
+static void
+unix_listener_free(void *arg)
+{
+	unix_listener *l = arg;
+
+	unix_listener_stop(l);
+	nni_cv_fini(&l->cv);
+	nni_mtx_fini(&l->mtx);
+	NNI_FREE_STRUCT(l);
+}
+
+static nng_err
+unix_listener_get(void *arg, const char *name, void *buf, size_t *szp, nni_type t)
+{
+	NNI_ARG_UNUSED(arg);
+	NNI_ARG_UNUSED(name);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(szp);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
+}
+
+static nng_err
+unix_listener_set(
+    void *arg, const char *name, const void *buf, size_t sz, nni_type t)
+{
+	NNI_ARG_UNUSED(arg);
+	NNI_ARG_UNUSED(name);
+	NNI_ARG_UNUSED(buf);
+	NNI_ARG_UNUSED(sz);
+	NNI_ARG_UNUSED(t);
+	return (NNG_ENOTSUP);
+}
+
+nng_err
+nni_unix_listener_alloc(nng_stream_listener **lp, const nng_url *url)
+{
+	unix_listener *l;
+	nng_err        rv;
+
+	if ((l = NNI_ALLOC_STRUCT(l)) == NULL) {
+		return (NNG_ENOMEM);
+	}
+	if ((rv = unix_make_addr(&l->sa, &l->nsa, url)) != NNG_OK) {
+		NNI_FREE_STRUCT(l);
+		return (rv);
+	}
+	l->s     = INVALID_SOCKET;
+	l->event = WSA_INVALID_EVENT;
+	nni_mtx_init(&l->mtx);
+	nni_cv_init(&l->cv, &l->mtx);
+	nni_aio_list_init(&l->aios);
+	l->sl.sl_free   = unix_listener_free;
+	l->sl.sl_close  = unix_listener_close;
+	l->sl.sl_stop   = unix_listener_stop;
+	l->sl.sl_listen = unix_listener_listen;
+	l->sl.sl_accept = unix_listener_accept;
+	l->sl.sl_get    = unix_listener_get;
+	l->sl.sl_set    = unix_listener_set;
+	*lp             = &l->sl;
+	return (NNG_OK);
+}
+
+#endif // NNG_HAVE_UNIX_SOCKETS

--- a/src/platform/windows/win_unix.h
+++ b/src/platform/windows/win_unix.h
@@ -1,0 +1,19 @@
+//
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
+//
+// This software is supplied under the terms of the MIT License, a
+// copy of which should be located in the distribution where this
+// file was obtained (LICENSE.txt).  A copy of the license may also be
+// found online at https://opensource.org/licenses/MIT.
+//
+
+#ifndef PLATFORM_WIN_UNIX_H
+#define PLATFORM_WIN_UNIX_H
+
+#include "core/nng_impl.h"
+
+#ifdef NNG_HAVE_UNIX_SOCKETS
+#include <afunix.h>
+#endif
+
+#endif // PLATFORM_WIN_UNIX_H

--- a/src/sp/transport/ipc/ipc.c
+++ b/src/sp/transport/ipc/ipc.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 // Copyright 2019 Devolutions <info@devolutions.net>
 //
@@ -1104,7 +1104,7 @@ static nni_sp_tran ipc_tran = {
 	.tran_fini     = ipc_tran_fini,
 };
 
-#ifdef NNG_PLATFORM_POSIX
+#if defined(NNG_PLATFORM_POSIX) || defined(NNG_HAVE_UNIX_SOCKETS)
 static nni_sp_tran ipc_tran_unix = {
 	.tran_scheme   = "unix",
 	.tran_dialer   = &ipc_dialer_ops,
@@ -1130,7 +1130,7 @@ void
 nni_sp_ipc_register(void)
 {
 	nni_sp_tran_register(&ipc_tran);
-#ifdef NNG_PLATFORM_POSIX
+#if defined(NNG_PLATFORM_POSIX) || defined(NNG_HAVE_UNIX_SOCKETS)
 	nni_sp_tran_register(&ipc_tran_unix);
 #endif
 #ifdef NNG_HAVE_ABSTRACT_SOCKETS

--- a/src/sp/transport/ipc/ipc_test.c
+++ b/src/sp/transport/ipc/ipc_test.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Cody Piersall <cody.piersall@gmail.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -7,6 +7,10 @@
 // file was obtained (LICENSE.txt).  A copy of the license may also be
 // found online at https://opensource.org/licenses/MIT.
 //
+
+#ifdef _WIN32
+#include <winsock2.h>
+#endif
 
 #include "../../../testing/nuts.h"
 
@@ -17,6 +21,12 @@
 #endif
 #ifdef NNG_PLATFORM_SUNOS
 #include <zone.h>
+#endif
+#ifdef NNG_PLATFORM_WINDOWS
+#include <windows.h>
+#endif
+#if defined(NNG_PLATFORM_WINDOWS) && defined(NNG_HAVE_UNIX_SOCKETS)
+#include <afunix.h>
 #endif
 
 void
@@ -384,8 +394,55 @@ test_ipc_listener_clean_stale(void)
 	NUTS_PASS(nng_listen(s0, addr, NULL, 0));
 	nng_msleep(50);
 	NUTS_CLOSE(s0);
+#elif defined(NNG_PLATFORM_WINDOWS) && defined(NNG_HAVE_UNIX_SOCKETS)
+	nng_socket           s0;
+	nng_stream_listener *l;
+	char                *addr;
+	char                *path;
+	SOCKADDR_UN          sa;
+	SOCKET               stale;
+
+	NUTS_ADDR(addr, "unix");
+	NUTS_OPEN(s0);
+	path = addr + strlen("unix://");
+	NUTS_TRUE(strlen(path) < sizeof(sa.sun_path));
+	memset(&sa, 0, sizeof(sa));
+	sa.sun_family = AF_UNIX;
+	memcpy(sa.sun_path, path, strlen(path) + 1);
+	(void) DeleteFileA(path);
+	NUTS_TRUE((stale = WSASocket(
+	               AF_UNIX, SOCK_STREAM, 0, NULL, 0, WSA_FLAG_OVERLAPPED)) !=
+	    INVALID_SOCKET);
+	NUTS_TRUE(bind(stale, (SOCKADDR *) &sa, sizeof(sa)) == 0);
+	closesocket(stale);
+
+	NUTS_PASS(nng_stream_listener_alloc(&l, addr));
+	NUTS_PASS(nng_stream_listener_listen(l));
+	nng_stream_listener_close(l);
+	nng_stream_listener_free(l);
+	NUTS_CLOSE(s0);
 #else
-	NUTS_SKIP("Not POSIX.");
+	NUTS_SKIP("No UNIX socket support.");
+#endif
+}
+
+void
+test_unix_listener_duplicate(void)
+{
+#if defined(NNG_PLATFORM_WINDOWS) && defined(NNG_HAVE_UNIX_SOCKETS)
+	nng_socket s0;
+	nng_socket s1;
+	char      *addr;
+
+	NUTS_ADDR(addr, "unix");
+	NUTS_OPEN(s0);
+	NUTS_OPEN(s1);
+	NUTS_PASS(nng_listen(s0, addr, NULL, 0));
+	NUTS_FAIL(nng_listen(s1, addr, NULL, 0), NNG_EADDRINUSE);
+	NUTS_CLOSE(s0);
+	NUTS_CLOSE(s1);
+#else
+	NUTS_SKIP("Not Windows AF_UNIX.");
 #endif
 }
 
@@ -503,25 +560,38 @@ test_abstract_null(void)
 }
 
 void
-test_unix_alias(void)
+test_unix_scheme(void)
 {
-#ifdef NNG_PLATFORM_POSIX
+#if defined(NNG_PLATFORM_POSIX) || defined(NNG_HAVE_UNIX_SOCKETS)
 	nng_socket   s1;
 	nng_socket   s2;
+#ifdef NNG_PLATFORM_POSIX
 	char         addr1[32];
 	char         addr2[32];
 	char         rng[20];
+#endif
+	char        *a1;
+	char        *a2;
 	nng_sockaddr sa1;
 	nng_sockaddr sa2;
 	nng_msg     *msg;
 	nng_pipe     p;
+#ifdef NNG_PLATFORM_WINDOWS
+	int           id;
+#endif
 
+#ifdef NNG_PLATFORM_POSIX
 	// Presumes /tmp.
-
 	(void) snprintf(
 	    rng, sizeof(rng), "%08x%08x", nng_random(), nng_random());
 	snprintf(addr1, sizeof(addr1), "ipc:///tmp/%s", rng);
 	snprintf(addr2, sizeof(addr2), "unix:///tmp/%s", rng);
+	a1 = addr1;
+	a2 = addr2;
+#else
+	NUTS_ADDR(a1, "unix");
+	a2 = a1;
+#endif
 
 	NUTS_OPEN(s1);
 	NUTS_OPEN(s2);
@@ -529,8 +599,8 @@ test_unix_alias(void)
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_SENDTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s1, NNG_OPT_RECVTIMEO, 1000));
 	NUTS_PASS(nng_socket_set_ms(s2, NNG_OPT_RECVTIMEO, 1000));
-	NUTS_PASS(nng_listen(s1, addr1, NULL, 0));
-	NUTS_PASS(nng_dial(s2, addr2, NULL, 0));
+	NUTS_PASS(nng_listen(s1, a1, NULL, 0));
+	NUTS_PASS(nng_dial(s2, a2, NULL, 0));
 
 	// first send the ping
 	NUTS_SEND(s1, "ping");
@@ -544,12 +614,25 @@ test_unix_alias(void)
 	NUTS_TRUE(sa1.s_family == sa2.s_family);
 	NUTS_TRUE(sa1.s_family == NNG_AF_IPC);
 	NUTS_MATCH(sa1.s_ipc.sa_path, sa2.s_ipc.sa_path);
+#ifdef NNG_PLATFORM_WINDOWS
+	NUTS_PASS(nng_pipe_get_int(p, NNG_OPT_PEER_PID, &id));
+	NUTS_TRUE(id == (int) GetCurrentProcessId());
+#endif
 	nng_msg_free(msg);
+
+#ifdef NNG_PLATFORM_WINDOWS
+	NUTS_SEND(s2, "pong");
+	NUTS_PASS(nng_recvmsg(s1, &msg, 0));
+	p = nng_msg_get_pipe(msg);
+	NUTS_PASS(nng_pipe_get_int(p, NNG_OPT_PEER_PID, &id));
+	NUTS_TRUE(id == (int) GetCurrentProcessId());
+	nng_msg_free(msg);
+#endif
 
 	NUTS_CLOSE(s1);
 	NUTS_CLOSE(s2);
 #else
-	NUTS_SKIP("Not POSIX.");
+	NUTS_SKIP("No UNIX socket support.");
 #endif
 }
 
@@ -642,12 +725,13 @@ TEST_LIST = {
 	{ "ipc connect blocking accept", test_ipc_connect_blocking_accept },
 	{ "ipc listen cleanup stale", test_ipc_listener_clean_stale },
 	{ "ipc listen duplicate", test_ipc_listen_duplicate },
+	{ "unix listen duplicate", test_unix_listener_duplicate },
 	{ "ipc listen accept cancel", test_ipc_listen_accept_cancel },
 	{ "ipc abstract sockets", test_abstract_sockets },
 	{ "ipc abstract auto-bind", test_abstract_autobind },
 	{ "ipc abstract name too long", test_abstract_too_long },
 	{ "ipc abstract embedded null", test_abstract_null },
-	{ "ipc unix alias", test_unix_alias },
+	{ "ipc unix scheme", test_unix_scheme },
 	{ "ipc peer id", test_ipc_pipe_peer },
 	{ "ipc security descriptor", test_ipc_security_descriptor },
 	{ NULL, NULL },

--- a/src/testing/marry.c
+++ b/src/testing/marry.c
@@ -1,5 +1,5 @@
 //
-// Copyright 2024 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 // Copyright 2018 Capitar IT Group BV <info@capitar.com>
 //
 // This software is supplied under the terms of the MIT License, a
@@ -65,12 +65,38 @@ nuts_scratch_addr(const char *scheme, size_t sz, char *addr)
 		return;
 	}
 
-	if ((strncmp(scheme, "ipc", 3) == 0) ||
-	    (strncmp(scheme, "unix", 4) == 0)) {
+	if (strncmp(scheme, "ipc", 3) == 0) {
 #ifdef _WIN32
 		// Windows doesn't place IPC names in the filesystem.
 		(void) snprintf(addr, sz, "%s://nuts%04x%04x%04x%04x", scheme,
 		    nng_random(), nng_random(), nng_random(), nng_random());
+		return;
+#else
+		char *tmpdir;
+
+		if (((tmpdir = getenv("TMPDIR")) == NULL) &&
+		    ((tmpdir = getenv("TEMP")) == NULL) &&
+		    ((tmpdir = getenv("TMP")) == NULL)) {
+			tmpdir = "/tmp";
+		}
+
+		(void) snprintf(addr, sz, "%s://%s/nuts%04x%04x%04x%04x",
+		    scheme, tmpdir, nng_random(), nng_random(), nng_random(),
+		    nng_random());
+		return;
+#endif
+	}
+	if (strncmp(scheme, "unix", 4) == 0) {
+#ifdef _WIN32
+		char  tmpdir[NNG_MAXADDRLEN];
+		DWORD n;
+
+		if (((n = GetTempPathA(sizeof(tmpdir), tmpdir)) == 0) ||
+		    (n >= sizeof(tmpdir))) {
+			tmpdir[0] = 0;
+		}
+		(void) snprintf(addr, sz, "%s://%snuts%08x", scheme, tmpdir,
+		    nng_random());
 		return;
 #else
 		char *tmpdir;
@@ -122,12 +148,38 @@ nuts_scratch_addr_zero(const char *scheme, size_t sz, char *addr)
 		return;
 	}
 
-	if ((strncmp(scheme, "ipc", 3) == 0) ||
-	    (strncmp(scheme, "unix", 4) == 0)) {
+	if (strncmp(scheme, "ipc", 3) == 0) {
 #ifdef _WIN32
 		// Windows doesn't place IPC names in the filesystem.
 		(void) snprintf(addr, sz, "%s://nuts%04x%04x%04x%04x", scheme,
 		    nng_random(), nng_random(), nng_random(), nng_random());
+		return;
+#else
+		char *tmpdir;
+
+		if (((tmpdir = getenv("TMPDIR")) == NULL) &&
+		    ((tmpdir = getenv("TEMP")) == NULL) &&
+		    ((tmpdir = getenv("TMP")) == NULL)) {
+			tmpdir = "/tmp";
+		}
+
+		(void) snprintf(addr, sz, "%s://%s/nuts%04x%04x%04x%04x",
+		    scheme, tmpdir, nng_random(), nng_random(), nng_random(),
+		    nng_random());
+		return;
+#endif
+	}
+	if (strncmp(scheme, "unix", 4) == 0) {
+#ifdef _WIN32
+		char  tmpdir[NNG_MAXADDRLEN];
+		DWORD n;
+
+		if (((n = GetTempPathA(sizeof(tmpdir), tmpdir)) == 0) ||
+		    (n >= sizeof(tmpdir))) {
+			tmpdir[0] = 0;
+		}
+		(void) snprintf(addr, sz, "%s://%snuts%08x", scheme, tmpdir,
+		    nng_random());
 		return;
 #else
 		char *tmpdir;

--- a/src/testing/nuts.h
+++ b/src/testing/nuts.h
@@ -1,5 +1,5 @@
 //
-// Copyright 2025 Staysail Systems, Inc. <info@staysail.tech>
+// Copyright 2026 Staysail Systems, Inc. <info@staysail.tech>
 //
 // This software is supplied under the terms of the MIT License, a
 // copy of which should be located in the distribution where this
@@ -255,14 +255,14 @@ extern const char *nuts_ecdsa_client_crt;
 
 #define NUTS_ADDR(var, scheme)                                             \
 	do {                                                               \
-		static char nuts_addr_[64];                                \
+		static char nuts_addr_[NNG_MAXADDRLEN];                    \
 		nuts_scratch_addr(scheme, sizeof(nuts_addr_), nuts_addr_); \
 		(var) = nuts_addr_;                                        \
 	} while (0)
 
 #define NUTS_ADDR_ZERO(var, scheme)                          \
 	do {                                                 \
-		static char nuts_addr_[64];                  \
+		static char nuts_addr_[NNG_MAXADDRLEN];      \
 		nuts_scratch_addr_zero(                      \
 		    scheme, sizeof(nuts_addr_), nuts_addr_); \
 		(var) = nuts_addr_;                          \


### PR DESCRIPTION
fixes #1320 Add AF_UNIX unix:// support on Windows

Adds a Windows AF_UNIX stream backend behind `unix://`, while preserving `ipc://` for named pipes.
It supports peer PID lookup, stale-path cleanup, cancellation-safe socket ownership, Windows-specific tests, and transport documentation.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows AF_UNIX stream support through the `unix://` scheme.
  * Windows AF_UNIX connections can report peer process IDs via `NNG_OPT_PEER_PID`.
  * Continued support for named-pipe IPC through the `ipc://` scheme.
* **Bug Fixes**
  * Improved temporary endpoint handling, stale-socket cleanup, and duplicate-listener detection on Windows.
* **Documentation**
  * Documented Windows version requirements, path limits, supported credentials, and differences between `unix://` and `ipc://`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->