### PR TITLE
fix(demo): nng_http_set_uri is required

### DIFF
--- a/demo/http_client/http_client.c
+++ b/demo/http_client/http_client.c
@@ -84,8 +84,11 @@ main(int argc, char **argv)
 	// Get the connection, at the 0th output.
 	conn = nng_aio_get_output(aio, 0);
 
-	// Request is already set up with URL, and for GET via HTTP/1.1.
-	// The Host: header is already set up too.
+	// Set request URI
+	if ((rv = nng_http_set_uri(
+	         conn, nng_url_path(url), nng_url_query(url))) != 0) {
+		fatal(rv);
+	}
 
 	// Send the request, and wait for that to finish.
 	nng_http_write_request(conn, aio);


### PR DESCRIPTION
This demo seems require `nng_http_set_uri` now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP client demo requests by preserving both URL paths and query parameters.
  * Added error handling when setting the request URI fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->