### PR TITLE
ci(coverage): collect Windows coverage with MinGW gcovr

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,6 +6,12 @@ ignore:
  - "src/testing"
  - "perf"
  - "**/*_test.c"
+
+# MinGW gcov records the GitHub Actions checkout as an absolute Windows path.
+# Strip that prefix so Codecov can match the report to repository sources.
+fixes:
+ - "D:/a/nng/nng/::"
+
 coverage:
   range: 50..95
   status:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,11 +7,6 @@ ignore:
  - "perf"
  - "**/*_test.c"
 
-# MinGW gcov records the GitHub Actions checkout as an absolute Windows path.
-# Strip that prefix so Codecov can match the report to repository sources.
-fixes:
- - "D:/a/nng/nng/::"
-
 coverage:
   range: 50..95
   status:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,7 +81,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up UCRT64
-        id: msys2
         uses: msys2/setup-msys2@v2
         with:
           msystem: UCRT64
@@ -91,17 +90,6 @@ jobs:
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-wolfssl
-
-      - name: Install grcov
-        shell: pwsh
-        run: |
-          $version = '0.10.7'
-          $archive = "grcov-x86_64-pc-windows-msvc.zip"
-          $url = "https://github.com/mozilla/grcov/releases/download/v$version/$archive"
-          $destination = "${{ steps.msys2.outputs.msys2-location }}\ucrt64\bin"
-          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\$archive"
-          Expand-Archive -Path "$env:RUNNER_TEMP\$archive" -DestinationPath $destination -Force
-          & "$destination\grcov.exe" --version
 
       - name: Configure CMake
         run: >-
@@ -115,15 +103,8 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
-      - name: Collect coverage
-        run: >-
-          grcov build -s . --branch --ignore-not-existing
-          --keep-only 'src/*' --keep-only 'include/*'
-          --output-types lcov --output-path lcov.info
-
       - name: Upload report
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./lcov.info
           flags: windows

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -81,6 +81,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up UCRT64
+        id: msys2
         uses: msys2/setup-msys2@v2
         with:
           msystem: UCRT64
@@ -97,10 +98,10 @@ jobs:
           $version = '0.10.7'
           $archive = "grcov-x86_64-pc-windows-msvc.zip"
           $url = "https://github.com/mozilla/grcov/releases/download/v$version/$archive"
-          $destination = "$env:RUNNER_TEMP\grcov"
+          $destination = "${{ steps.msys2.outputs.msys2-location }}\ucrt64\bin"
           Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\$archive"
-          Expand-Archive -Path "$env:RUNNER_TEMP\$archive" -DestinationPath $destination
-          $destination | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Expand-Archive -Path "$env:RUNNER_TEMP\$archive" -DestinationPath $destination -Force
+          & "$destination\grcov.exe" --version
 
       - name: Configure CMake
         run: >-

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -73,61 +73,56 @@ jobs:
   windows-coverage:
     name: windows
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: msys2 {0}
     steps:
-      # Fix history bug by ensuring deep parent graphing context
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      # Install OpenCppCoverage and expose it to subsequent PowerShell steps.
-      - name: Install OpenCppCoverage
+      - name: Set up UCRT64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-wolfssl
+
+      - name: Install grcov
         shell: pwsh
         run: |
-          choco install opencppcoverage --version=0.9.9.0 --yes --no-progress
-          "${env:ProgramFiles}\OpenCppCoverage" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-
-      # Setup vcpkg for clean cross-platform dependency resolution
-      - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11
-        with:
-          vcpkgDirectory: ${{ github.workspace }}/vcpkg
-          vcpkgGitCommitId: 'abb6dda5cc32914d2e64d7d72b974dc301d1fc8a'
-
-      # WolfSSL's DTLS feature exercises NNG's alternate TLS engine.
-      - name: Install dependencies via vcpkg
-        run: vcpkg install "wolfssl[dtls]:x64-windows"
+          $version = '0.10.7'
+          $archive = "grcov-x86_64-pc-windows-msvc.zip"
+          $url = "https://github.com/mozilla/grcov/releases/download/v$version/$archive"
+          $destination = "$env:RUNNER_TEMP\grcov"
+          Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\$archive"
+          Expand-Archive -Path "$env:RUNNER_TEMP\$archive" -DestinationPath $destination
+          $destination | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Configure CMake
-        run: |
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DNNG_ENABLE_TLS=ON -DNNG_TLS_ENGINE=wolf -DCMAKE_TOOLCHAIN_FILE="${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake" ..
+        run: >-
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug
+          -DNNG_ENABLE_COVERAGE=ON -DNNG_ENABLE_TLS=ON -DNNG_TLS_ENGINE=wolf
+          -DWOLFSSL_ROOT_DIR=/ucrt64
 
       - name: Build
-        run: cmake --build build --config Debug
+        run: cmake --build build
 
       - name: Test
-        run: ctest --test-dir build -C Debug --output-on-failure
+        run: ctest --test-dir build --output-on-failure
 
       - name: Collect coverage
-        run: |
-          # OpenCppCoverage presents as a debugger.  Preserve acutest's
-          # normal per-test child-process isolation; --cover_children
-          # collects those workers too.
-          $env:ACUTEST_EXEC = "always"
-          OpenCppCoverage.exe `
-            --cover_children `
-            --modules "${{ github.workspace }}\build" `
-            --sources "${{ github.workspace }}\src" `
-            --sources "${{ github.workspace }}\include" `
-            --excluded_sources "${{ github.workspace }}\build" `
-            --export_type=cobertura:coverage.xml `
-            -- "C:\Program Files\CMake\bin\ctest.exe" --test-dir build -C Debug --output-on-failure
+        run: >-
+          grcov build -s . --branch --ignore-not-existing
+          --keep-only 'src/*' --keep-only 'include/*'
+          --output-types lcov --output-path lcov.info
 
       - name: Upload report
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
+          files: ./lcov.info
           flags: windows

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -88,6 +88,7 @@ jobs:
           install: >-
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-gcc
+            mingw-w64-ucrt-x86_64-gcovr
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-wolfssl
 
@@ -103,8 +104,16 @@ jobs:
       - name: Test
         run: ctest --test-dir build --output-on-failure
 
+      - name: Collect coverage
+        run: >-
+          gcovr --root . --object-directory build
+          --filter 'src/' --filter 'include/'
+          --lcov --output lcov.info
+
       - name: Upload report
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.info
+          disable_search: true
           flags: windows

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,6 +108,7 @@ jobs:
         run: >-
           gcovr --root . --object-directory build
           --filter 'src/' --filter 'include/'
+          --gcov-ignore-parse-errors negative_hits.warn_once_per_file
           --lcov --output lcov.info
 
       - name: Upload report

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -108,7 +108,6 @@ jobs:
         run: >-
           gcovr --root . --object-directory build
           --filter 'src/' --filter 'include/'
-          --gcov-ignore-parse-errors negative_hits.warn_once_per_file
           --lcov --output lcov.info
 
       - name: Upload report

--- a/.grcov.yml
+++ b/.grcov.yml
@@ -1,5 +1,0 @@
-branch: true
-ignore-not-existing: true
-filter: covered
-output-type: lcov
-output-file: lcov.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ if (NNG_ENABLE_COVERAGE)
     # is older than that, you will need to find something newer.  For
     # correct reporting, we always turn off all optimizations.
     if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
-        set(NNG_COVERAGE_C_FLAGS "-g -O0 --coverage")
+        set(NNG_COVERAGE_C_FLAGS "-g -O0 --coverage -fprofile-update=atomic")
         set(CMAKE_SHARED_LINKER_FLAGS --coverage)
     elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
         set(NNG_COVERAGE_C_FLAGS "-g -O0 --coverage")

--- a/src/platform/tcp_stream_test.c
+++ b/src/platform/tcp_stream_test.c
@@ -263,7 +263,6 @@ test_tcp_listen_activation(void)
 	// on the incoming FD.
 	nng_stream_listener *l2;
 	SOCKET               s;
-	char                *addr;
 	int                  port;
 	nng_aio             *aio1;
 	nng_aio             *aio2;
@@ -272,7 +271,6 @@ test_tcp_listen_activation(void)
 	char                 url[32];
 	SOCKADDR_IN          sin;
 
-	NUTS_ADDR_ZERO(addr, "tcp4");
 	NUTS_PASS(nng_aio_alloc(&aio1, NULL, NULL));
 	NUTS_PASS(nng_aio_alloc(&aio2, NULL, NULL));
 

--- a/src/platform/windows/win_ipcconn.c
+++ b/src/platform/windows/win_ipcconn.c
@@ -319,7 +319,6 @@ static void
 ipc_close(void *arg)
 {
 	ipc_conn *c = arg;
-	nni_time  now;
 	nni_aio  *aio;
 
 	nni_mtx_lock(&c->mtx);

--- a/src/platform/windows/win_resolv.c
+++ b/src/platform/windows/win_resolv.c
@@ -122,11 +122,8 @@ resolv_worker(void *index)
 	struct addrinfo  hints;
 	struct addrinfo *results;
 	struct addrinfo *probe;
-	int              rv;
 	char             serv[8];
 	char             host[256];
-	nni_aio         *aio;
-	nni_resolv_item *item;
 
 	nni_thr_set_name(NULL, "nng:resolver");
 

--- a/src/platform/windows/win_sockaddr.c
+++ b/src/platform/windows/win_sockaddr.c
@@ -49,11 +49,9 @@ nni_win_nn2sockaddr(SOCKADDR_STORAGE *ss, const nni_sockaddr *sa)
 int
 nni_win_sockaddr2nn(nni_sockaddr *sa, const void *s, size_t sz)
 {
-	SOCKADDR_IN     *sin;
-	nng_sockaddr_in *nsin;
+	SOCKADDR_IN *sin;
 #ifdef NNG_ENABLE_IPV6
-	SOCKADDR_IN6     *sin6;
-	nng_sockaddr_in6 *nsin6;
+	SOCKADDR_IN6 *sin6;
 #endif
 
 	if ((s == NULL) || (sa == NULL)) {

--- a/src/platform/windows/win_tcpconn.c
+++ b/src/platform/windows/win_tcpconn.c
@@ -260,7 +260,6 @@ tcp_close(void *arg)
 {
 	nni_tcp_conn *c = arg;
 	nni_mtx_lock(&c->mtx);
-	nni_time now;
 	if (!c->closed) {
 		SOCKET s = c->s;
 

--- a/src/platform/windows/win_tcpdial.c
+++ b/src/platform/windows/win_tcpdial.c
@@ -30,10 +30,6 @@ int
 nni_tcp_dialer_init(nni_tcp_dialer **dp)
 {
 	nni_tcp_dialer *d;
-	int             rv;
-	SOCKET          s;
-	DWORD           nbytes;
-	GUID            guid = WSAID_CONNECTEX;
 
 	if ((d = NNI_ALLOC_STRUCT(d)) == NULL) {
 		return (NNG_ENOMEM);

--- a/src/platform/windows/win_tcplisten.c
+++ b/src/platform/windows/win_tcplisten.c
@@ -256,7 +256,6 @@ tcp_listener_doaccept(tcp_listener *l)
 	SOCKET        s;
 	nni_tcp_conn *c;
 	int           rv;
-	DWORD         cnt;
 
 	while ((aio = nni_list_first(&l->aios)) != NULL) {
 		// Windows requires us to explicitly create the socket
@@ -546,7 +545,6 @@ static nng_err
 tcp_listener_alloc_addr(nng_stream_listener **lp, const nng_sockaddr *sa)
 {
 	tcp_listener *l;
-	nng_err       rv;
 
 	if ((l = NNI_ALLOC_STRUCT(l)) == NULL) {
 		return (NNG_ENOMEM);

--- a/src/platform/windows/win_thread.c
+++ b/src/platform/windows/win_thread.c
@@ -63,6 +63,7 @@ nni_plat_mtx_init(nni_plat_mtx *mtx)
 void
 nni_plat_mtx_fini(nni_plat_mtx *mtx)
 {
+	NNI_ARG_UNUSED(mtx);
 }
 
 void
@@ -413,8 +414,13 @@ nni_plat_init(nng_init_params *params)
 	// Let's look up the function to set thread descriptions.
 	hKernel32 = LoadLibrary(TEXT("kernel32.dll"));
 	if (hKernel32 != NULL) {
-		set_thread_desc = (pfnSetThreadDescription) GetProcAddress(
-		    hKernel32, "SetThreadDescription");
+		union {
+			FARPROC                 source;
+			pfnSetThreadDescription target;
+		} thread_desc;
+
+		thread_desc.source = GetProcAddress(hKernel32, "SetThreadDescription");
+		set_thread_desc   = thread_desc.target;
 	}
 
 	if (((rv = nni_win_io_sysinit(params)) != 0) ||

--- a/src/sp/transport/dtls/dtls_tran_test.c
+++ b/src/sp/transport/dtls/dtls_tran_test.c
@@ -39,6 +39,7 @@ tls_server_config_ecdsa(void)
 	return (c);
 }
 
+#ifdef NNG_SUPP_TLS_PSK
 static nng_tls_config *
 tls_config_psk(nng_tls_mode mode, const char *name, uint8_t *key, size_t len)
 {
@@ -47,6 +48,7 @@ tls_config_psk(nng_tls_mode mode, const char *name, uint8_t *key, size_t len)
 	NUTS_PASS(nng_tls_config_psk(c, name, key, len));
 	return (c);
 }
+#endif
 
 static nng_tls_config *
 tls_client_config(void)

--- a/src/sp/transport/tls/tls_tran_test.c
+++ b/src/sp/transport/tls/tls_tran_test.c
@@ -113,7 +113,10 @@ test_tls_bad_cert_mutual(void)
 	nng_listener    l;
 	nng_dialer      d;
 	const nng_url  *url;
+
+#ifdef NNG_TLS_ENGINE_MBEDTLS
 	nng_err         rv;
+#endif
 
 	NUTS_ENABLE_LOG(NNG_LOG_DEBUG);
 	c1 = tls_server_config();

--- a/src/sp/transport/ws/wss_test.c
+++ b/src/sp/transport/ws/wss_test.c
@@ -36,6 +36,7 @@ wss_server_config_ecdsa(void)
 	return (c);
 }
 
+#ifdef NNG_SUPP_TLS_PSK
 static nng_tls_config *
 wss_config_psk(nng_tls_mode mode, const char *name, uint8_t *key, size_t len)
 {
@@ -44,6 +45,7 @@ wss_config_psk(nng_tls_mode mode, const char *name, uint8_t *key, size_t len)
 	NUTS_PASS(nng_tls_config_psk(c, name, key, len));
 	return (c);
 }
+#endif
 
 static nng_tls_config *
 wss_client_config(void)

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -140,6 +140,7 @@ httpecho(nng_http *conn, void *arg, nng_aio *aio)
 	nng_aio_finish(aio, 0);
 }
 
+#if defined(NNG_PLATFORM_POSIX) || defined(NNG_HAVE_UNIX_SOCKETS)
 static void
 httpok(nng_http *conn, void *arg, nng_aio *aio)
 {
@@ -210,6 +211,7 @@ http_unix_url(char *url, size_t size)
 	}
 	url[off] = '\0';
 }
+#endif
 
 static void
 httpaddrcheck(nng_http *conn, void *arg, nng_aio *aio)

--- a/src/testing/acutest.h
+++ b/src/testing/acutest.h
@@ -1878,24 +1878,6 @@ main(int argc, char** argv)
     /* Parse options */
     acutest_cmdline_read_(acutest_cmdline_options_, argc, argv, acutest_cmdline_callback_);
 
-    /*
-     * A test runner may need to override the debugger heuristic below without
-     * changing every test command line.  In particular, coverage collectors
-     * can debug a process while still collecting coverage from its children.
-     * Command-line options take precedence over this environment variable.
-     */
-    if(acutest_no_exec_ < 0) {
-        const char* exec = getenv("ACUTEST_EXEC");
-
-        if(exec != NULL) {
-            if(strcmp(exec, "always") == 0) {
-                acutest_no_exec_ = 0;
-            } else if(strcmp(exec, "never") == 0) {
-                acutest_no_exec_ = 1;
-            }
-        }
-    }
-
     /* Initialize the proper timer. */
     acutest_timer_init_();
 


### PR DESCRIPTION
fixes #1064 Windows coverage pipeline

Replace debugger-based OpenCppCoverage collection with native GCC coverage from an MSYS2 UCRT64 build. GCC coverage counters use atomic updates so threaded tests cannot corrupt profile data. Gcovr uses the matching MinGW `gcov` to produce a repository-relative LCOV report, which Codecov uploads without scanning raw coverage artifacts. The coverage job continues to exercise wolfSSL, now supplied by MSYS2, and removes the collector-specific Acutest override and obsolete grcov configuration file. It also removes MinGW warnings exposed by the build.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.