### PR TITLE
doc: document endpoint creation errors

### DIFF
--- a/docs/ref/api/endpoint.md
+++ b/docs/ref/api/endpoint.md
@@ -93,8 +93,9 @@ The create-and-start functions can return:
 - [`NNG_ECLOSED`]: The socket is closed.
 - [`NNG_ECONNREFUSED`]: The remote peer refused the initial dial connection.
 - [`NNG_ECONNRESET`]: The remote peer reset the initial dial connection.
-- [`NNG_EINVAL`]: The URL or flags are invalid.
+- [`NNG_EINVAL`]: The string URL is invalid.
 - [`NNG_ENOMEM`]: Insufficient memory is available.
+- [`NNG_ENOTSUP`]: The transport is not supported, or does not support dialing or listening.
 - [`NNG_EPEERAUTH`]: Authentication or authorization failed.
 - [`NNG_EPROTO`]: A protocol error occurred.
 - [`NNG_EUNREACHABLE`]: The remote address is not reachable.
@@ -126,7 +127,9 @@ These functions can return:
 
 - [`NNG_EADDRINVAL`]: The URL is invalid.
 - [`NNG_ECLOSED`]: The socket is closed.
+- [`NNG_EINVAL`]: The string URL is invalid.
 - [`NNG_ENOMEM`]: Insufficient memory is available.
+- [`NNG_ENOTSUP`]: The transport is not supported, or does not support dialing or listening.
 
 ## Starting
 


### PR DESCRIPTION
fixes #2167 doc: nng_dial and nng_dialer_create can return more errors than documented

Document NNG_EINVAL for malformed string URLs and NNG_ENOTSUP for unsupported transports or unsupported dial/listen roles.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified dialer and listener error guidance for invalid URLs, unsupported transports, and unsupported dialing or listening operations.
  * Applied the same distinctions to both immediate-start and deferred-start APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->