### PR TITLE
ci: refresh coverage and status from main

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,8 @@
 name: coverage
 on:
+  push:
+    branches: [main]
+    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -1,5 +1,8 @@
 name: darwin
 on:
+  push:
+    branches: [main]
+    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -1,6 +1,9 @@
 name: freebsd
 
 on:
+  push:
+    branches: [main]
+    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,5 +1,8 @@
 name: linux
 on:
+  push:
+    branches: [main]
+    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -1,6 +1,9 @@
 name: omnios
 
 on:
+  push:
+    branches: [main]
+    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,5 +1,8 @@
 name: windows
 on:
+  push:
+    branches: [main]
+    paths-ignore: ["docs/**", "**.adoc", "**.md"]
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore: ["docs/**", "**.adoc", "**.md"]


### PR DESCRIPTION
Run the coverage workflow and all workflows represented by README status badges when changes land on `main`, in addition to pull requests. This keeps Codecov\x27s default-branch coverage baseline and badge status current while retaining the existing documentation-only path exclusions.\n\nYou agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run on pushes to the main branch across supported platforms.
  * Documentation-only changes are excluded from these checks to reduce unnecessary runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->