### PR TITLE
ci: avoid persisting checkout credentials

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install mbedTLS
         run: sudo apt-get install libmbedtls-dev
@@ -45,6 +47,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install mbedTLS
         run: brew install mbedtls
@@ -82,6 +86,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up UCRT64
         uses: msys2/setup-msys2@v2

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install Mbed TLS
         run: brew install mbedtls

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -19,6 +19,8 @@ jobs:
       NNG_UDP_PASS_RATE: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Test NNG in FreeBSD
         id: test
         uses: vmactions/freebsd-vm@v1

--- a/.github/workflows/http-client-interop.yml
+++ b/.github/workflows/http-client-interop.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install ninja
         run: sudo apt-get install ninja-build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install ninja
         run: sudo apt-get install ninja-build

--- a/.github/workflows/omnios.yml
+++ b/.github/workflows/omnios.yml
@@ -19,6 +19,8 @@ jobs:
       NNG_UDP_PASS_RATE: 10
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - name: Test NNG in OmniOS
         id: test
         uses: vmactions/omnios-vm@v1

--- a/.github/workflows/openssl.yml
+++ b/.github/workflows/openssl.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install ninja
         run: sudo apt-get install ninja-build

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
+        with:
+          persist-credentials: false
 
       - name: Install mbedTLS
         run: sudo apt-get install libmbedtls-dev

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: vcpkg build
         id: vcpkg


### PR DESCRIPTION
fixes #<issue number> Disable persisted checkout credentials

Set `persist-credentials: false` for every checkout in CI workflows that only require read access. The documentation publishing workflow remains unchanged because it requires `contents: write`.

You agree that by submitting a PR, you have read and agreed to our contributing guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - CI workflows no longer retain Git credentials after checking out code.
  - Credential handling is more restricted across coverage, platform, interoperability, OpenSSL, and sanitizer checks.

- **Chores**
  - Updated automated build and test workflows to apply consistent credential protection.
  - Modernized the sanitizer workflow’s checkout step for improved consistency and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->