### PR TITLE
fix(http/security): Fix path escape when URI is missing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -117,6 +117,7 @@ jobs:
         run: >-
           gcovr --root . --object-directory build
           --filter 'src/' --filter 'include/'
+          --gcov-ignore-parse-errors=negative_hits.warn_once_per_file
           --lcov --output lcov.info
 
       - name: Upload report

--- a/src/supplemental/http/http_conn.c
+++ b/src/supplemental/http/http_conn.c
@@ -1175,6 +1175,12 @@ nni_http_set_uri(nng_http *conn, const char *uri, const char *query)
 	size_t      needed;
 	const char *fmt;
 
+	// HTTP clients must use '/' for an empty origin-form path.  Normalize it
+	// here so that adding a query produces "/?query", never "?query".
+	if (uri[0] == '\0') {
+		uri = "/";
+	}
+
 	if (query != NULL) {
 		fmt    = strchr(uri, '?') != NULL ? "%s&%s" : "%s?%s";
 		needed = strlen(uri) + strlen(query) + 1;

--- a/src/supplemental/http/http_msg.c
+++ b/src/supplemental/http/http_msg.c
@@ -226,11 +226,14 @@ http_req_parse_line(nng_http *conn, void *line)
 	*version = '\0';
 	version++;
 
-	// A request-target cannot contain a fragment or a backslash.  Fragments
-	// are only meaningful in URI references, and a backslash can become a
-	// directory separator on Windows.  Reject them here rather than allowing
-	// a file handler to interpret them as part of a local path.
-	if ((strchr(uri, '#') != NULL) || (strchr(uri, '\\') != NULL)) {
+	// This server supports origin-form request targets only.  Reject targets
+	// that do not start with '/' before canonicalization: in particular, a
+	// leading '?' must not be treated as a root path by routing and then be
+	// mistaken for its separator by a directory handler.  Fragments are only
+	// meaningful in URI references, and a backslash can become a directory
+	// separator on Windows.
+	if ((uri[0] != '/') || (strchr(uri, '#') != NULL) ||
+	    (strchr(uri, '\\') != NULL)) {
 		nni_http_set_status(conn, NNG_HTTP_STATUS_BAD_REQUEST, NULL);
 		return (NNG_OK);
 	}

--- a/src/supplemental/http/http_server.c
+++ b/src/supplemental/http/http_server.c
@@ -464,6 +464,7 @@ http_sconn_rxdone(void *arg)
 	bool              needhost = false;
 	const char       *host;
 	const char       *cls;
+	const char       *path_end;
 
 	if ((rv = nni_aio_result(aio)) != NNG_OK) {
 		http_sconn_close(sc);
@@ -515,6 +516,10 @@ http_sconn_rxdone(void *arg)
 		http_sconn_error(sc, NNG_HTTP_STATUS_BAD_REQUEST);
 		return;
 	}
+	path_end = strchr(uri, '?');
+	if (path_end == NULL) {
+		path_end = uri + strlen(uri);
+	}
 
 	// If the connection was 1.0, or a connection: close was
 	// requested, then mark this close on our end.
@@ -561,21 +566,16 @@ http_sconn_rxdone(void *arg)
 		}
 
 		len = strlen(h->uri);
-		if (strncmp(uri, h->uri, len) != 0) {
+		if (((size_t) (path_end - uri) < len) ||
+		    (strncmp(uri, h->uri, len) != 0)) {
 			continue;
 		}
-		switch (uri[len]) {
-		case '\0':
-		case '?':
-			break;
-		case '/':
-			if ((uri[len + 1] != '\0') && (!h->tree)) {
-				// Trailing component and not a directory.
-				continue;
-			}
-			break;
-		default:
-			continue; // Some other substring, not matched.
+		if (((uri + len) != path_end) &&
+		    ((uri[len] != '/') ||
+		        (((uri + len + 1) != path_end) && (!h->tree)))) {
+			// The URI has a nonmatching suffix or an extra path component
+			// beneath a non-tree handler.
+			continue;
 		}
 
 		if (h->method[0] == '\0') {

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -366,6 +366,33 @@ test_server_basic(void)
 }
 
 static void
+test_server_empty_uri_query(void)
+{
+	void              *data;
+	size_t             size;
+	uint16_t           stat;
+	char              *ctype;
+	struct server_test st;
+	nng_http_handler  *h;
+
+	NUTS_PASS(nng_http_handler_alloc_static(
+	    &h, "/", doc1, strlen(doc1), "text/html"));
+	server_setup(&st, h);
+
+	// An empty path with a query is serialized as the valid target "/?query".
+	NUTS_PASS(nng_http_set_uri(st.conn, "", "param=1234"));
+	NUTS_PASS(httpget(&st, &data, &size, &stat, &ctype));
+	NUTS_TRUE(stat == NNG_HTTP_STATUS_OK);
+	NUTS_TRUE(size == strlen(doc1));
+	NUTS_TRUE(memcmp(data, doc1, size) == 0);
+	NUTS_MATCH(ctype, "text/html");
+	nng_strfree(ctype);
+	nng_free(data, size);
+
+	server_free(&st);
+}
+
+static void
 test_server_unix(void)
 {
 #if !defined(NNG_PLATFORM_POSIX) && !defined(NNG_HAVE_UNIX_SOCKETS)
@@ -1608,6 +1635,7 @@ test_serve_subdir_index(void)
 
 NUTS_TESTS = {
 	{ "server basic", test_server_basic },
+	{ "server empty uri query", test_server_empty_uri_query },
 	{ "server unix", test_server_unix },
 	{ "server unix invalid URL", test_server_unix_invalid_url },
 	{ "server static binary", test_server_static_bin },

--- a/src/supplemental/http/http_server_test.c
+++ b/src/supplemental/http/http_server_test.c
@@ -727,6 +727,20 @@ test_server_bad_request_target(void)
 
 	server_reset(&st);
 
+	NUTS_PASS(nng_http_set_uri(st.conn, "?/../../secret", NULL));
+	nng_http_write_request(st.conn, st.aio);
+
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	nng_http_read_response(st.conn, st.aio);
+	nng_aio_wait(st.aio);
+	NUTS_PASS(nng_aio_result(st.aio));
+
+	NUTS_HTTP_STATUS(st.conn, NNG_HTTP_STATUS_BAD_REQUEST);
+
+	server_reset(&st);
+
 	NUTS_PASS(nng_http_set_uri(st.conn, "/home\\..\\secret", NULL));
 	nng_http_write_request(st.conn, st.aio);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The server now rejects malformed request targets that do not begin with `/`, including query-only and traversal-style targets.
  * Invalid targets return `400 Bad Request` and reset the connection as expected.
  * Empty-path requests with query parameters are normalized to valid `/?query` targets, enabling correct static-file retrieval.
  * URI handler matching remains consistent for exact paths, query strings, trailing slashes, and path trees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->