### PR TITLE
feat(ipc): Implement socket ownership options (fixes #1802)

### DIFF
--- a/docs/ref/tran/ipc.md
+++ b/docs/ref/tran/ipc.md
@@ -94,7 +94,9 @@ where supported by the underlying platform.
 
 | Option                    | Type  | Description                                                                                                        |
 | ------------------------- | ----- | ------------------------------------------------------------------------------------------------------------------ |
-| `NNG_OPT_IPC_PERMISSIONS` | `int` | Settable on listeners before they start, this is the UNIX file mode used when creating the socket.                 |
+| `NNG_OPT_IPC_PERMISSIONS` | `int` | Settable on POSIX listeners before they start, this is the UNIX file mode used when creating the socket.           |
+| `NNG_OPT_IPC_OWNER`       | `int` | Settable on POSIX listeners before they start, this requests the UNIX user ID for the socket. Elevated permission may be required; failure is ignored. |
+| `NNG_OPT_IPC_GROUP`       | `int` | Settable on POSIX listeners before they start, this requests the UNIX group ID for the socket. Elevated permission may be required; failure is ignored. |
 | `NNG_OPT_PEER_GID`        | `int` | Read only option, returns the group ID of the process at the other end of the socket, if platform supports it.     |
 | `NNG_OPT_PEER_PID`        | `int` | Read only option, returns the processed ID of the process at the other end of the socket, if platform supports it. |
 | `NNG_OPT_PEER_UID`        | `int` | Read only option, returns the user ID of the process at the other end of the socket, if platform supports it.      |
@@ -103,8 +105,15 @@ where supported by the underlying platform.
 
 ### Other Configuration Parameters
 
-On Windows systems, the security descriptor for the listener,
-which can be used to control access, can be set using the function
-[`nng_listener_set_security_descriptor`].
+On Windows, an `ipc://` named-pipe listener can use
+[`nng_listener_set_security_descriptor`] to control access.
+
+The POSIX owner and group options are applied with `chown(2)` after binding.
+Because that operation generally requires elevated privilege, failure to apply
+either value does not prevent the listener from starting.  They are ignored for
+abstract sockets, which have no file-system representation.  On Windows, use a
+security descriptor to control access to named pipes.  The Windows AF_UNIX
+(`unix://`) implementation uses its containing directory's ACL; POSIX owner,
+group, and permission options are not supported.
 
 {{#include ../xref.md}}

--- a/docs/ref/xref.md
+++ b/docs/ref/xref.md
@@ -544,6 +544,8 @@
 [`NNG_OPT_PEER_ZONEID`]: ../tran/ipc.md#NNG_OPT_PEER_ZONEID
 [`NNG_OPT_SUB_PREF_NEW`]: ../proto/sub.md#protocol-options
 [`NNG_OPT_IPC_PERMISSIONS`]: ../tran/ipc.md#NNG_OPT_IPC_PERMISSIONS
+[`NNG_OPT_IPC_OWNER`]: ../tran/ipc.md#NNG_OPT_IPC_OWNER
+[`NNG_OPT_IPC_GROUP`]: ../tran/ipc.md#NNG_OPT_IPC_GROUP
 [`NNG_OPT_TCP_KEEPALIVE`]: ../tran/tcp.md#transport-options
 [`NNG_OPT_TCP_NODELAY`]: ../tran/tcp.md#transport-options
 [`NNG_OPT_TLS_VERIFIED`]: ../tran/tls.md#NNG_OPT_TLS_VERIFIED

--- a/include/nng/nng.h
+++ b/include/nng/nng.h
@@ -880,6 +880,13 @@ NNG_DECL nng_listener nng_pipe_listener(nng_pipe);
 // this for security.
 #define NNG_OPT_IPC_PERMISSIONS "ipc:permissions"
 
+// Owner and group IDs.  These options are only valid for listeners on
+// POSIX platforms.  The requested ownership is applied on a best-effort
+// basis when the UNIX domain socket is created; setting either option does
+// not cause listener startup to fail if chown(2) is not permitted.
+#define NNG_OPT_IPC_OWNER "ipc:owner"
+#define NNG_OPT_IPC_GROUP "ipc:group"
+
 // IPC peer options may also be used in some cases with other socket types.
 
 // Peer UID.  This is only available on POSIX style systems.

--- a/src/platform/posix/posix_ipclisten.c
+++ b/src/platform/posix/posix_ipclisten.c
@@ -38,6 +38,8 @@ typedef struct {
 	bool                closed;
 	char               *path;
 	mode_t              perms;
+	uid_t               owner;
+	gid_t               group;
 	nni_mtx             mtx;
 } ipc_listener;
 
@@ -246,6 +248,54 @@ ipc_listener_set_perms(void *arg, const void *buf, size_t sz, nni_type t)
 }
 
 static nng_err
+ipc_listener_set_owner(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	ipc_listener *l = arg;
+	int           owner;
+	nng_err       rv;
+
+	if ((rv = nni_copyin_int(&owner, buf, sz, 0, NNI_MAXINT, t)) != NNG_OK) {
+		return (rv);
+	}
+	if (l->sa.s_family == NNG_AF_ABSTRACT) {
+		// Abstract sockets have no file-system owner.
+		return (0);
+	}
+	nni_mtx_lock(&l->mtx);
+	if (l->started) {
+		nni_mtx_unlock(&l->mtx);
+		return (NNG_EBUSY);
+	}
+	l->owner = (uid_t) owner;
+	nni_mtx_unlock(&l->mtx);
+	return (NNG_OK);
+}
+
+static nng_err
+ipc_listener_set_group(void *arg, const void *buf, size_t sz, nni_type t)
+{
+	ipc_listener *l = arg;
+	int           group;
+	nng_err       rv;
+
+	if ((rv = nni_copyin_int(&group, buf, sz, 0, NNI_MAXINT, t)) != NNG_OK) {
+		return (rv);
+	}
+	if (l->sa.s_family == NNG_AF_ABSTRACT) {
+		// Abstract sockets have no file-system group.
+		return (0);
+	}
+	nni_mtx_lock(&l->mtx);
+	if (l->started) {
+		nni_mtx_unlock(&l->mtx);
+		return (NNG_EBUSY);
+	}
+	l->group = (gid_t) group;
+	nni_mtx_unlock(&l->mtx);
+	return (NNG_OK);
+}
+
+static nng_err
 ipc_listener_set_listen_fd(void *arg, const void *buf, size_t sz, nni_type t)
 {
 	ipc_listener           *l = arg;
@@ -305,6 +355,14 @@ static const nni_option ipc_listener_options[] = {
 	    .o_set  = ipc_listener_set_perms,
 	},
 	{
+	    .o_name = NNG_OPT_IPC_OWNER,
+	    .o_set  = ipc_listener_set_owner,
+	},
+	{
+	    .o_name = NNG_OPT_IPC_GROUP,
+	    .o_set  = ipc_listener_set_group,
+	},
+	{
 	    .o_name = NNG_OPT_LISTEN_FD,
 	    .o_set  = ipc_listener_set_listen_fd,
 #ifdef NNG_TEST_LIB
@@ -333,15 +391,18 @@ ipc_listener_set(
 }
 
 static int
-ipc_listener_chmod(ipc_listener *l, const char *path)
+ipc_listener_set_file_attrs(ipc_listener *l, const char *path)
 {
 	if (path == NULL) {
 		return (0);
 	}
-	if (l->perms == 0) {
-		return (0);
+	if ((l->owner != (uid_t) -1) || (l->group != (gid_t) -1)) {
+		// Changing ownership normally requires elevated privilege.  This is
+		// deliberately best effort so a listener can still be started by an
+		// unprivileged process.
+		(void) chown(path, l->owner, l->group);
 	}
-	if (chmod(path, l->perms & ~S_IFMT) != 0) {
+	if ((l->perms != 0) && (chmod(path, l->perms & ~S_IFMT) != 0)) {
 		return (-1);
 	}
 	return (0);
@@ -405,7 +466,7 @@ ipc_listener_listen(void *arg)
 		}
 	}
 
-	if ((rv != 0) || (ipc_listener_chmod(l, path) != 0) ||
+	if ((rv != 0) || (ipc_listener_set_file_attrs(l, path) != 0) ||
 	    (listen(fd, 128) != 0)) {
 		rv = nni_plat_errno(errno);
 	}
@@ -543,6 +604,8 @@ nni_ipc_listener_alloc(nng_stream_listener **lp, const nng_url *url)
 	l->closed       = false;
 	l->started      = false;
 	l->perms        = 0;
+	l->owner        = (uid_t) -1;
+	l->group        = (gid_t) -1;
 	l->sl.sl_free   = ipc_listener_free;
 	l->sl.sl_close  = ipc_listener_close;
 	l->sl.sl_stop   = ipc_listener_stop;

--- a/src/sp/transport/ipc/ipc_test.c
+++ b/src/sp/transport/ipc/ipc_test.c
@@ -125,6 +125,44 @@ test_ipc_listener_perms(void)
 }
 
 void
+test_ipc_listener_owner_group(void)
+{
+	nng_socket   s;
+	nng_listener l;
+	char        *addr;
+
+#ifndef _WIN32
+	char       *path;
+	struct stat st;
+#endif
+
+	NUTS_ADDR(addr, "ipc");
+	NUTS_OPEN(s);
+	NUTS_PASS(nng_listener_create(&l, s, addr));
+
+#ifdef _WIN32
+	NUTS_FAIL(nng_listener_set_int(l, NNG_OPT_IPC_OWNER, 0), NNG_ENOTSUP);
+	NUTS_FAIL(nng_listener_set_int(l, NNG_OPT_IPC_GROUP, 0), NNG_ENOTSUP);
+#else
+	path = &addr[strlen("ipc://")];
+	NUTS_FAIL(nng_listener_set_int(l, NNG_OPT_IPC_OWNER, -1), NNG_EINVAL);
+	NUTS_FAIL(nng_listener_set_int(l, NNG_OPT_IPC_GROUP, -1), NNG_EINVAL);
+	NUTS_PASS(nng_listener_set_int(l, NNG_OPT_IPC_OWNER, (int) getuid()));
+	NUTS_PASS(nng_listener_set_int(l, NNG_OPT_IPC_GROUP, (int) getgid()));
+	NUTS_PASS(nng_listener_start(l, 0));
+	NUTS_TRUE(stat(path, &st) == 0);
+	NUTS_TRUE(st.st_uid == getuid());
+	NUTS_TRUE(st.st_gid == getgid());
+	NUTS_FAIL(nng_listener_set_int(l, NNG_OPT_IPC_OWNER, (int) getuid()),
+	    NNG_EBUSY);
+	NUTS_FAIL(nng_listener_set_int(l, NNG_OPT_IPC_GROUP, (int) getgid()),
+	    NNG_EBUSY);
+#endif
+
+	NUTS_CLOSE(s);
+}
+
+void
 test_ipc_listener_properties(void)
 {
 	nng_socket   s;
@@ -715,6 +753,7 @@ TEST_LIST = {
 	{ "ipc dialer perms", test_ipc_dialer_perms },
 	{ "ipc dialer props", test_ipc_dialer_properties },
 	{ "ipc listener perms", test_ipc_listener_perms },
+	{ "ipc listener owner group", test_ipc_listener_owner_group },
 	{ "ipc listener props", test_ipc_listener_properties },
 	{ "ipc ping pong", test_ipc_ping_pong },
 	{ "ipc ping pong many", test_ipc_ping_pong_many },


### PR DESCRIPTION
fixes #<issue number> <issue synopsis>

<Comments describing your change. Not all changes need this.>

Note that the above format should be used in your git commit comments.
You agree that by submitting a PR, you have read and agreed to our
contributing guidelines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * POSIX IPC listeners now support configuring the socket owner and group.
  * Ownership and group settings are applied on a best-effort basis before permissions.
  * Abstract sockets and Windows IPC transports do not support these options.

* **Documentation**
  * Updated IPC transport documentation with platform-specific ownership, permissions, and security behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->