### PR TITLE
fix(core): avoid dangling stats node when pipe closes during start

### DIFF
--- a/src/core/socket.c
+++ b/src/core/socket.c
@@ -1395,6 +1395,15 @@ dialer_start_pipe(nni_dialer *d, nni_pipe *p)
 	nni_stat_set_id(&p->st_root, (int) p->p_id);
 	nni_stat_set_id(&p->st_id, (int) p->p_id);
 	nni_stat_register(&p->st_root);
+	if (nni_pipe_is_closed(p)) {
+		// The pipe was closed while we were starting it, and
+		// pipe_reap may have already unregistered the stats
+		// (as a no-op, since they were not registered yet).
+		// Unregister them again here, so that we don't leave
+		// a dangling node in the stats tree when we free the
+		// pipe below.
+		nni_stat_unregister(&p->st_root);
+	}
 #endif
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_POST);
 	if (nng_log_get_level() >= NNG_LOG_DEBUG) {
@@ -1510,6 +1519,15 @@ listener_start_pipe(nni_listener *l, nni_pipe *p)
 	nni_stat_set_id(&p->st_root, (int) p->p_id);
 	nni_stat_set_id(&p->st_id, (int) p->p_id);
 	nni_stat_register(&p->st_root);
+	if (nni_pipe_is_closed(p)) {
+		// The pipe was closed while we were starting it, and
+		// pipe_reap may have already unregistered the stats
+		// (as a no-op, since they were not registered yet).
+		// Unregister them again here, so that we don't leave
+		// a dangling node in the stats tree when we free the
+		// pipe below.
+		nni_stat_unregister(&p->st_root);
+	}
 #endif
 	nni_pipe_run_cb(p, NNG_PIPE_EV_ADD_POST);
 	if (nng_log_get_level() >= NNG_LOG_DEBUG) {


### PR DESCRIPTION
## What this fixes

A race between pipe startup and pipe reap can leave the stat item of an
already freed pipe linked in the global stats tree
(`stats_root.si_children`).

In `dialer_start_pipe()` / `listener_start_pipe()`, if the pipe gets
closed between the `nni_pipe_is_closed()` check and
`nni_stat_register(&p->st_root)` -- which is easy to hit with flaky
connections (transport error, peer restart, concurrent socket close) --
then `pipe_reap()` on the reap thread runs `nni_stat_unregister()`
first, and it is a no-op because the node was never registered
(`si_node` is still `{NULL, NULL}` and `nni_list_node_remove()` guards
on `ln_next != NULL`). The start path then registers the stats of the
already-reaped pipe, and its final `nni_pipe_rele()` drops the last
reference, so `pipe_destroy()` frees the pipe while its `st_root` is
still linked into the stats tree.

From there the allocator eventually recycles the memory while the node
is still reachable from the list. What we saw in a long-running
production process on aarch64 (2.0.0dev, `97b3c9f7`):

- repeated SIGSEGV in the `nng:reap2` thread inside
  `nni_list_node_remove()`, on a node whose `ln_prev` is NULL while
  `ln_next` still points into the list. Deterministic: same PC/LR/SP
  across five crashes.
- glibc aborts (`corrupted size vs. prev_size`, `munmap_chunk():
  invalid pointer`, `double free or corruption`) -- the recycled memory
  of the dangling node ends up with list pointers where glibc expects
  chunk metadata. In one core the "chunk size" field literally held
  `&head | PREV_INUSE`.

Two core dumps taken five hours apart showed the identical corruption:
the tail node of the stats list with `ln_prev == 0` and every other
pointer in the 21-node ring perfectly consistent -- which is what you
get when a node zeroed by allocator reuse gets stitched back in by
later appends/removes through stale neighbour pointers.

In x86 stress runs we also hit the two other flavors of the same
dangling node: `panic: appending node already on a list or not inited`
(when a fresh pipe re-registers the same `st_root` address while stale
links are still on it), and crashes in `stat_update()` when the
application calls `nng_stats_get()` (the snapshot follows the dangling
`si_item`). Neither requires anything unusual from the app -- the
`nng_stats_get()` path just exposes it faster.

## Reproducing

No stats reader is needed; the race is purely between pipe start and
pipe teardown. The window is only a few instructions wide in the
unmodified library, so for deterministic runs we widened it with a
`usleep` between the `is_closed` check and the register, but we also
hit it with the stock library within tens of seconds.

Stress pattern (x86_64, glibc):

- a few threads running: `pub0` listens on an IPC url, `sub0` dials it
  with `NNG_FLAG_NONBLOCK`, sleeps a random 0-5 ms, then closes both
  sockets. The nonblocking dial plus delayed close is what lands the
  close inside the window; a blocking dial followed by a sequential
  close can never hit it.
- plus a couple of threads doing failing TCP dials (refused port,
  immediate `nng_socket_close`) as allocator churn, so freed pipe
  memory gets recycled quickly.

We temporarily instrumented the library with three checks (not part of
this PR): re-test `nni_pipe_is_closed()` after the register, test in
`pipe_destroy()` whether `st_root` is still linked before freeing, and
audit the whole ring under `stats_lock` after every register /
unregister. Results, 4+2 threads, 30 s runs:

- unmodified (`97b3c9f7` and current `main`): race hits, pipe freed
  while linked, ring audits finding in-list nodes with `ln_prev ==
  NULL`, abort within 30 s (3/3 runs on the dev commit, 2/2 on main).
- with this fix: 1400+ race hits, zero freed-while-linked, zero ring
  violations, no crash. The old `nng_stats_get()` reader scenario that
  used to die in `stat_update()` within 10-15 s also survives now (8/8
  runs).

Happy to clean up the harness into a test if that's wanted.

## The fix

Recheck the closed flag right after registering and unregister again
if it got set. This is race-free: `p_closed` is set before the pipe is
queued for reap, and register/unregister are serialized by
`stats_lock`. So `pipe_reap()`'s unregister either ran before our
register -- then the recheck sees the flag and removes the node -- or
it runs after our register and removes it normally. Unregistering
twice is a no-op. The extra check costs nothing on the happy path
(one atomic load).

## Related latent window (not addressed here)

`nni_dialer_init()` / `nni_listener_init()` call
`nni_sock_add_dialer()` / `nni_sock_add_listener()` (making the
endpoint visible to `nni_sock_shutdown()`) *before*
`dialer_register_stats()` / `listener_register_stats()`. A concurrent
socket close could therefore reap the endpoint -- again with the
unregister becoming a no-op -- before its stats are registered, which
has the same shape as the pipe bug. We have not seen this one fire, so
I left it out of this PR, but it may be worth a follow-up.

Possibly related: #1523, #1695, #1837 (different call paths, same list
functions). If any of those crashes involved stat items, this race may
be the shared root cause.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a race condition that could leave stale statistics entries after a pipe was closed during startup.
  - Ensured statistics are properly cleaned up when a pipe is closed before initialization completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->