### PR TITLE
docs: fix context receive headings and leftover socket wording

### DIFF
--- a/docs/ref/api/ctx.md
+++ b/docs/ref/api/ctx.md
@@ -91,7 +91,7 @@ void nng_ctx_send(nng_ctx ctx, nng_aio *aio);
 ```
 
 These functions ({{i:`nng_ctx_sendmsg`}} and {{i:`nng_ctx_send`}}) send
-messages over the socket _s_. The differences in their behaviors are as follows.
+messages over the context _ctx_. The differences in their behaviors are as follows.
 
 > [!NOTE]
 > The semantics of what sending a message means varies from protocol to
@@ -134,7 +134,7 @@ int nng_ctx_recvmsg(nng_ctx ctx, nng_msg **msgp, int flags);
 void nng_ctx_recv(nng_ctx ctx, nng_aio *aio);
 ```
 
-These functions (, {{i:`nng_ctx_recvmsg`}} and {{i:`nng_ctx_recv`}}) receive
+These functions ({{i:`nng_ctx_recvmsg`}} and {{i:`nng_ctx_recv`}}) receive
 messages over the context _ctx_. The differences in their behaviors are as follows.
 
 > [!NOTE]
@@ -143,16 +143,16 @@ messages over the context _ctx_. The differences in their behaviors are as follo
 > Additionally, some protocols may not support receiving at all or may require other pre-conditions first.
 > (For example, [REQ][req] sockets cannot normally receive data until they have first sent a request.)
 
-### nng_recvmsg
+### nng_ctx_recvmsg
 
 The `nng_ctx_recvmsg` function receives a message and stores a pointer to the [`nng_msg`] for that message in _msgp_.
 
 The _flags_ can contain the value [`NNG_FLAG_NONBLOCK`], indicating that the function should not wait if the socket
 has no messages available to receive. In such a case, it will return [`NNG_EAGAIN`].
 
-### nng_socket_recv
+### nng_ctx_recv
 
-The `nng_ctx_send` function receives a message asynchronously, using the [`nng_aio`] _aio_, over the context _ctx_.
+The `nng_ctx_recv` function receives a message asynchronously, using the [`nng_aio`] _aio_, over the context _ctx_.
 On success, the received message can be retrieved from the _aio_ using the [`nng_aio_get_msg`] function.
 
 > [!NOTE]


### PR DESCRIPTION
The Contexts page heads its two receive subsections `nng_recvmsg` and `nng_socket_recv`, which are socket functions documented on another page, then opens the second one by telling you `nng_ctx_send` is what receives a message.

mdBook builds anchors out of heading text, so the receive links in `xref.md` point at ids the page never emits. Checked the live book on 2026-09-12 and the TIP link at the foot of that section still dead-ends at the top of the page your already on.

| `xref.md` target | anchor `ctx.md` emits |
| --- | --- |
| `#nng_ctx_sendmsg` | `#nng_ctx_sendmsg` |
| `#nng_ctx_send` | `#nng_ctx_send` |
| `#nng_ctx_recvmsg` | `#nng_recvmsg` |
| `#nng_ctx_recv` | `#nng_socket_recv` |

Anyone working out how a context receive is meant to be called gets socket API names sat under the context declarations, then a sentence saying the send function receives. Both spellings are real symbols in `include/nng/nng.h`, so nothing on the page tells you which one is teh mistake. You either call the wrong function, or stop trusting the page and go read the header.

The sending intro gets a word changed too, since it describes a context as socket _s_ one screen above all this. The receive intro loses a stray comma. I've left the `NNG_FLAG_NONBLOCK` sentence alone though - it says "should not wait if the socket" in both halves of this file and over in `sock.md`, so that reads as wording rather than a slip, unlike an _s_ thats not in the signature at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected messaging descriptions to accurately reference context-based sending and receiving.
  - Fixed section headings and terminology for context receive functions.
  - Corrected punctuation and an inaccurate function description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->